### PR TITLE
cimiimport: preserve leading zeros and quote GUIDs in pkginfo YAML

### DIFF
--- a/cli/cimiimport/Services/ImportService.cs
+++ b/cli/cimiimport/Services/ImportService.cs
@@ -850,9 +850,9 @@ public class ImportService
                 if (!string.IsNullOrEmpty(installer.Hash))
                     sb.AppendLine($"  hash: {installer.Hash}");
                 if (!string.IsNullOrEmpty(installer.ProductCode))
-                    sb.AppendLine($"  product_code: {installer.ProductCode}");
+                    sb.AppendLine($"  product_code: {EscapeYamlString(installer.ProductCode)}");
                 if (!string.IsNullOrEmpty(installer.UpgradeCode))
-                    sb.AppendLine($"  upgrade_code: {installer.UpgradeCode}");
+                    sb.AppendLine($"  upgrade_code: {EscapeYamlString(installer.UpgradeCode)}");
                 if (installer.Arguments != null && installer.Arguments.Count > 0)
                 {
                     sb.AppendLine("  arguments:");

--- a/cli/cimiimport/Services/MetadataExtractor.cs
+++ b/cli/cimiimport/Services/MetadataExtractor.cs
@@ -406,7 +406,11 @@ public partial class MetadataExtractor
 
                     if (numericParts.Count == 4)
                     {
-                        return $"{year}.{month:D2}.{day:D2}.{numericParts[3]}";
+                        // Preserve the original 4th segment string to keep leading zeros
+                        // (e.g. "0838" HHMM timestamps must not become "838"). Month and day
+                        // are still zero-padded from parsed ints so "2026.4.9.0838" normalizes
+                        // to "2026.04.09.0838".
+                        return $"{year}.{month:D2}.{day:D2}.{parts[3]}";
                     }
                     else
                     {

--- a/cli/cimiimport/Services/MetadataExtractor.cs
+++ b/cli/cimiimport/Services/MetadataExtractor.cs
@@ -409,8 +409,9 @@ public partial class MetadataExtractor
                         // Preserve the original 4th segment string to keep leading zeros
                         // (e.g. "0838" HHMM timestamps must not become "838"). Month and day
                         // are still zero-padded from parsed ints so "2026.4.9.0838" normalizes
-                        // to "2026.04.09.0838".
-                        return $"{year}.{month:D2}.{day:D2}.{parts[3]}";
+                        // to "2026.04.09.0838". Trim incidental whitespace (CR/LF, spaces)
+                        // that int.TryParse accepts but shouldn't bleed into the output.
+                        return $"{year}.{month:D2}.{day:D2}.{parts[3].Trim()}";
                     }
                     else
                     {


### PR DESCRIPTION
## Summary

Two MSI-metadata bugs in `cimiimport` surfaced while importing a cimipkg-built
MSI with version `2026.04.09.0838`.

### 1. ParseVersion stripped leading zeros from HHMM

`int.TryParse("0838")` → `838`, then the format string
`{year}.{month:D2}.{day:D2}.{numericParts[3]}` wrote the int back unpadded.
Result: `2026.04.09.0838` → `2026.04.09.838`.

**Fix:** preserve the original `parts[3]` string (it's already been verified
numeric), so HHMM leading zeros survive while month/day still normalize via
`:D2` for unpadded inputs like `2026.4.9.0838`.

### 2. Unquoted GUIDs broke YAML deserialization

`WritePkgInfo` emitted `product_code` and `upgrade_code` as bare GUIDs:

\`\`\`yaml
product_code: {316739e9-1713-48d9-9172-0b2059b63692}
upgrade_code: {eb666390-ff65-55da-aac4-8eebc7b45db0}
\`\`\`

YAML parsed the curly braces as flow-style mappings, throwing
\`Exception during deserialization\` and blocking commits via the
\`makecatalogs\` gate.

**Fix:** route both fields through the existing `EscapeYamlString` helper,
which already detects a leading `{` and wraps the value in single quotes.

## Test plan

- [x] Rebuilt cimiimport and ran it against a 2026.04.09.0838 MSI — prompt and
      generated YAML both show `version: 2026.04.09.0838`.
- [x] Generated YAML parses via YamlDotNet:
      \`product_code: '{316739e9-...}'\` / \`upgrade_code: '{eb666390-...}'\`.
- [x] `makecatalogs` runs successfully without "Exception during deserialization".