### PR TITLE
managedsoftwareupdate: wire SystemFactsCollector into predicate facts

### DIFF
--- a/cli/managedsoftwareupdate/Cimian.CLI.managedsoftwareupdate.csproj
+++ b/cli/managedsoftwareupdate/Cimian.CLI.managedsoftwareupdate.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>net10.0-windows</TargetFramework>
     <AssemblyName>managedsoftwareupdate</AssemblyName>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!--
+      System.Management needs its full surface at runtime for WMI facts collection.
+      Trimming strips ManagementPath static init dependencies in a single-file
+      publish, which silently empties machine_model / gpu_names predicates.
+    -->
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -1,6 +1,5 @@
 using System.Net.Http.Headers;
 using System.Text;
-using Microsoft.Extensions.Logging.Abstractions;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using Cimian.CLI.managedsoftwareupdate.Models;
@@ -348,8 +347,11 @@ public class ManifestService
         }
         catch (Exception ex)
         {
-            ConsoleLogger.Warn($"SystemFactsCollector failed ({ex.Message}) - falling back to minimal facts");
+            ConsoleLogger.Warn($"SystemFactsCollector failed ({ex.GetType().Name}) - falling back to minimal facts. Exception: {ex}");
             var osVersion = Environment.OSVersion.Version;
+            // Preserve the pre-fix stub defaults on the unhappy path so predicates
+            // like `machine_type == "desktop"` keep behaving the way they did before
+            // this change, instead of silently flipping false when collection fails.
             _systemFacts = new SystemFacts
             {
                 Hostname = Environment.MachineName,
@@ -360,6 +362,8 @@ public class ManifestService
                 OSVersMinor = osVersion.Minor,
                 OSBuildNumber = osVersion.Build,
                 Catalogs = _config.Catalogs,
+                MachineType = "desktop",
+                MachineModel = "Unknown",
                 CollectedAt = DateTime.UtcNow
             };
         }

--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -1,10 +1,12 @@
 using System.Net.Http.Headers;
 using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using Cimian.CLI.managedsoftwareupdate.Models;
 using Cimian.Core.Services;
 using Cimian.Engine.Predicates;
+using Cimian.Infrastructure.System;
 using SystemFacts = Cimian.Core.Models.SystemFacts;
 // Use the Predicate expression types from Cimian.Engine
 using ParsedExpression = Cimian.Engine.Predicates.ParsedExpression;
@@ -333,22 +335,34 @@ public class ManifestService
     {
         if (_systemFacts != null) return;
 
-        var osVersion = Environment.OSVersion.Version;
-
-        _systemFacts = new Cimian.Core.Models.SystemFacts
+        // Use the full SystemFactsCollector (WMI-backed) so conditionals referencing
+        // machine_model, gpu_names, cpu_*, ram_*, storage_*, npu_* evaluate against
+        // real hardware values. Falls back to a minimal stub if collection fails so
+        // the run still proceeds (conditionals just evaluate to false, same as before).
+        try
         {
-            Hostname = Environment.MachineName,
-            Architecture = GetSystemArchitecture(),
-            OperatingSystem = "Windows",
-            OperatingSystemVersion = osVersion.ToString(),
-            OSVersMajor = osVersion.Major,
-            OSVersMinor = osVersion.Minor,
-            OSBuildNumber = osVersion.Build,
-            Catalogs = _config.Catalogs,
-            MachineType = GetMachineType(),
-            MachineModel = GetMachineModel(),
-            CollectedAt = DateTime.UtcNow
-        };
+            var collector = new SystemFactsCollector(new ConsoleForwardingLogger<SystemFactsCollector>());
+            collector.SetCatalogs(_config.Catalogs);
+            _systemFacts = collector.CollectAsync().GetAwaiter().GetResult();
+            ConsoleLogger.Info($"    SystemFacts: machine_model='{_systemFacts.MachineModel}' machine_type='{_systemFacts.MachineType}' gpu_names=[{string.Join(", ", _systemFacts.GpuNames)}] arch='{_systemFacts.Architecture}'");
+        }
+        catch (Exception ex)
+        {
+            ConsoleLogger.Warn($"SystemFactsCollector failed ({ex.Message}) - falling back to minimal facts");
+            var osVersion = Environment.OSVersion.Version;
+            _systemFacts = new SystemFacts
+            {
+                Hostname = Environment.MachineName,
+                Architecture = GetSystemArchitecture(),
+                OperatingSystem = "Windows",
+                OperatingSystemVersion = osVersion.ToString(),
+                OSVersMajor = osVersion.Major,
+                OSVersMinor = osVersion.Minor,
+                OSBuildNumber = osVersion.Build,
+                Catalogs = _config.Catalogs,
+                CollectedAt = DateTime.UtcNow
+            };
+        }
 
         // Load admin-provided custom conditions (Munki parity)
         LoadCustomConditions();
@@ -504,62 +518,6 @@ public class ManifestService
         };
     }
     
-    /// <summary>
-    /// Gets the machine model (for ARM64 Surface detection, etc.)
-    /// </summary>
-    private static string GetMachineModel()
-    {
-        // This would ideally use WMI Win32_ComputerSystem.Model
-        // For now, return a placeholder - can be enhanced later
-        return "Unknown";
-    }
-    
-    /// <summary>
-    /// Detects machine type: laptop, desktop, virtual, or server
-    /// Uses battery presence as primary laptop indicator
-    /// </summary>
-    private static string GetMachineType()
-    {
-        try
-        {
-            // Check for virtual machine first
-            var manufacturer = Environment.GetEnvironmentVariable("COMPUTERNAME") ?? "";
-            if (manufacturer.StartsWith("VM", StringComparison.OrdinalIgnoreCase))
-            {
-                return "virtual";
-            }
-            
-            // Check for battery - presence indicates laptop
-            // Use PowerShell to query battery status
-            var batteryCheck = new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = "powershell.exe",
-                Arguments = "-NoProfile -Command \"(Get-WmiObject Win32_Battery).Count\"",
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-            
-            using var process = System.Diagnostics.Process.Start(batteryCheck);
-            if (process != null)
-            {
-                var output = process.StandardOutput.ReadToEnd().Trim();
-                process.WaitForExit(5000);
-                
-                if (int.TryParse(output, out int batteryCount) && batteryCount > 0)
-                {
-                    return "laptop";
-                }
-            }
-        }
-        catch
-        {
-            // Fall through to default
-        }
-        
-        return "desktop";
-    }
-
     private List<ManifestItem> ConvertToManifestItems(ManifestFile manifest, string sourceManifest)
     {
         var items = new List<ManifestItem>();
@@ -751,8 +709,44 @@ public class ManifestService
         {
             return ver1 < ver2;
         }
-        
+
         // Fall back to string comparison
         return string.Compare(v1, v2, StringComparison.OrdinalIgnoreCase) < 0;
+    }
+}
+
+/// <summary>
+/// Forwards Microsoft.Extensions.Logging calls to ConsoleLogger so warnings and errors
+/// from Cimian.Infrastructure services are visible in managedsoftwareupdate output.
+/// </summary>
+internal sealed class ConsoleForwardingLogger<T> : Microsoft.Extensions.Logging.ILogger<T>
+{
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) =>
+        logLevel >= Microsoft.Extensions.Logging.LogLevel.Warning;
+
+    public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId,
+        TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel)) return;
+        var message = formatter(state, exception);
+        if (exception != null) message = $"{message}: {exception.GetType().Name}: {exception.Message}";
+        switch (logLevel)
+        {
+            case Microsoft.Extensions.Logging.LogLevel.Error:
+            case Microsoft.Extensions.Logging.LogLevel.Critical:
+                ConsoleLogger.Error($"    [{typeof(T).Name}] {message}");
+                break;
+            default:
+                ConsoleLogger.Warn($"    [{typeof(T).Name}] {message}");
+                break;
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
     }
 }


### PR DESCRIPTION
## Summary

- `ManifestService.EnsureSystemFacts()` was returning a stub — `MachineModel=\"Unknown\"`, no GPU/CPU/RAM/storage/NPU data. Every manifest conditional referencing `machine_model`, `gpu_names`, `cpu_*`, `ram_*`, `storage_*`, `npu_*` silently evaluated to `false` on every device, making CoreFirmware's Dell/LENOVO/HP branches, CoreDrivers' GPU gates, and Upkeep's Dell gate inert.
- Now delegates to the real `SystemFactsCollector` (WMI-backed, already in `Cimian.Infrastructure`).
- `<PublishTrimmed>false</PublishTrimmed>` on this project only — the trimmer strips `System.Management.ManagementPath` static-init dependencies in a single-file publish, producing `TypeInitializationException` on every WMI call. That was the actual root cause of the silent failure.

## Why the silent failure happened

Two independent bugs compounded:

1. `EnsureSystemFacts()` had a stub `GetMachineModel()` returning the literal string `\"Unknown\"`, and `gpu_names`/`cpu_*`/`ram_*` were never populated at all.
2. Even with a real collector, the trimmed single-file publish killed `System.Management` at runtime — so the \"real\" WMI path would have thrown silently inside the collector's per-call `try { ... } catch (Exception ex) { _logger.LogWarning(...) }` and been swallowed by the `NullLogger` the service was handed.

This PR fixes both: wire the real collector, disable trim on this one project, and route collector warnings through a `ConsoleForwardingLogger<T>` so any future issue is visible in `-v` output instead of disappearing.

## Changes

- `cli/managedsoftwareupdate/Services/ManifestService.cs`
  - `EnsureSystemFacts()` now calls `new SystemFactsCollector(new ConsoleForwardingLogger<SystemFactsCollector>()).CollectAsync()`.
  - Falls back to the previous minimal stub only if collection throws, preserving prior behavior on the unhappy path.
  - Emits one info line per run with the computed predicate values — field telemetry to confirm the fix reached each device.
  - Drops the dead `GetMachineModel()` / `GetMachineType()` helpers.
  - Adds `ConsoleForwardingLogger<T>` at the bottom of the file: forwards `Microsoft.Extensions.Logging` Warning/Error to `ConsoleLogger` so infrastructure services can surface problems.
- `cli/managedsoftwareupdate/Cimian.CLI.managedsoftwareupdate.csproj`
  - `<PublishTrimmed>false</PublishTrimmed>` with a comment explaining why (System.Management + single-file + trim is a known break).

## Impact

- Binary size: **~34 MB → ~58 MB** (x64). Untrimmed is the only safe option right now for tools that use `System.Management`. The `Microsoft.Management.Infrastructure` (CIM IL) path is smaller and trim-safe but is a bigger migration — out of scope for this fix.
- All other Cimian tools remain trimmed.
- Runtime behavior: every `machine_model` / `gpu_names` / `cpu_*` / `ram_*` / `storage_*` / `npu_*` / `machine_type` predicate referenced in any manifest now evaluates against real hardware. `arch` and `os_vers_*` are unchanged.

## Test plan

Verified end-to-end on a Dell Precision 3630 with Quadro RTX 4000 on Staging catalog (REMOTE-01):

\`\`\`
SystemFacts: machine_model='Dell Inc. Precision 3630 Tower' machine_type='desktop' gpu_names=[NVIDIA Quadro RTX 4000, Intel(R) UHD Graphics 630] arch='x64'
Conditional item matched: gpu_names CONTAINS \"Quadro\" OR gpu_names CONTAINS \"RTX A\" OR gpu_names CONTAINS \"RTX PRO\"
Conditional item matched: machine_model CONTAINS \"Dell\"    # CoreFirmware
Conditional item matched: machine_model CONTAINS \"Dell\"    # Upkeep
NvidiaQuadroASeries  | 595.97            | Deferred (04:00-06:00)
DellCommandConfigure | 2005.02.02.292    | Installed
\`\`\`

Zero errors in the run. Negative controls (`machine_model CONTAINS \"LENOVO\"`, `machine_model CONTAINS \"HP\"`, `gpu_names CONTAINS \"Radeon\"`) all correctly did not match.

### Safety

- **False-positive risk: none.** The old stubbed `\"Unknown\"` made predicates false — a silent no-op. This PR changes false → true only when hardware genuinely matches. No device that was previously being skipped will now get something it shouldn't.
- **Predicate-regression risk: low.** `arch`, `os_vers_*`, `catalogs` predicates were already working via the minimal path and continue to work through the full collector.

## Rollout checklist

- [ ] Build: \`.\build.ps1 -Sign -IntuneWin\`
- [ ] Verify binary is signed
- [ ] Push to fleet via Intune (tonight)
- [ ] Once agent propagates, hardware-conditional yaml cleanup (CoreFirmware managed_installs, etc.) can be committed to the deployment repo