### PR TITLE
cimiimport: decode base64 build-info and read CIMIAN_PKG_FULL_VERSION

### DIFF
--- a/cli/cimiimport/Services/MetadataExtractor.cs
+++ b/cli/cimiimport/Services/MetadataExtractor.cs
@@ -115,8 +115,10 @@ public partial class MetadataExtractor
             metadata.ProductCode = ReadProp("ProductCode") ?? "";
             metadata.UpgradeCode = ReadProp("UpgradeCode") ?? "";
 
-            // For cimipkg-built MSI, extract rich metadata from embedded build-info.yaml
-            var buildInfoYaml = ReadProp("CIMIAN_PKG_BUILD_INFO");
+            // For cimipkg-built MSI, extract rich metadata from embedded build-info.yaml.
+            // cimipkg stores the YAML base64-encoded so the property value stays single-line
+            // (multi-line values corrupt the MSI Property dump and PREVIOUSVERSIONSINSTALLED).
+            var buildInfoYaml = DecodeBuildInfoYaml(ReadProp("CIMIAN_PKG_BUILD_INFO"));
             if (!string.IsNullOrEmpty(buildInfoYaml))
             {
                 try
@@ -147,6 +149,14 @@ public partial class MetadataExtractor
                     // build-info.yaml parse failed; standard MSI properties already captured
                 }
             }
+
+            // CIMIAN_PKG_FULL_VERSION is the unencoded full version (e.g. 2026.04.24.1640)
+            // that cimipkg writes alongside the truncated MSI ProductVersion (e.g. 26.4.2416).
+            // Use it as the authoritative version when present so cimiimport doesn't display
+            // the lossy ProductVersion form.
+            var fullVersion = ReadProp("CIMIAN_PKG_FULL_VERSION");
+            if (!string.IsNullOrEmpty(fullVersion))
+                metadata.Version = ParseVersion(fullVersion);
         }
         catch
         {
@@ -631,6 +641,32 @@ public partial class MetadataExtractor
         }
         
         return "";
+    }
+
+    /// <summary>
+    /// CIMIAN_PKG_BUILD_INFO is base64-encoded YAML in cimipkg builds since the
+    /// property-leak fix; older builds stored the raw multi-line YAML inline.
+    /// Try base64 first; if that fails, return the value as-is so legacy MSIs
+    /// still surface their build-info.
+    /// Mirrors cimipkg/Services/MsiPropertyReader.DecodeBuildInfoYaml.
+    /// </summary>
+    private static string? DecodeBuildInfoYaml(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+
+        // A YAML doc always contains a colon and a newline; a base64 string never
+        // does. Base64 is also strictly limited to A-Z, a-z, 0-9, '+', '/', and '='.
+        if (value.Contains('\n') || value.Contains(':')) return value;
+
+        try
+        {
+            var bytes = Convert.FromBase64String(value);
+            return System.Text.Encoding.UTF8.GetString(bytes);
+        }
+        catch (FormatException)
+        {
+            return value;
+        }
     }
 }
 // TODO(pkg-sunset): Remove PkgBuildInfo, PkgProductInfo, PkgInstallerInfo classes

--- a/cli/cimiimport/Services/MetadataExtractor.cs
+++ b/cli/cimiimport/Services/MetadataExtractor.cs
@@ -654,9 +654,9 @@ public partial class MetadataExtractor
     {
         if (string.IsNullOrEmpty(value)) return value;
 
-        // cimipkg build-info YAML reliably contains ':' (every key-value line) and
-        // typically newlines too; base64 contains neither and is limited to
-        // A-Z, a-z, 0-9, '+', '/', and '='. Either marker is enough to short-circuit.
+        // cimipkg build-info YAML is expected to contain ':' and typically includes
+        // newlines, while a base64 string contains neither and is limited to
+        // A-Z, a-z, 0-9, '+', '/', and '='.
         if (value.Contains('\n') || value.Contains(':')) return value;
 
         try

--- a/cli/cimiimport/Services/MetadataExtractor.cs
+++ b/cli/cimiimport/Services/MetadataExtractor.cs
@@ -654,8 +654,9 @@ public partial class MetadataExtractor
     {
         if (string.IsNullOrEmpty(value)) return value;
 
-        // A YAML doc always contains a colon and a newline; a base64 string never
-        // does. Base64 is also strictly limited to A-Z, a-z, 0-9, '+', '/', and '='.
+        // cimipkg build-info YAML reliably contains ':' (every key-value line) and
+        // typically newlines too; base64 contains neither and is limited to
+        // A-Z, a-z, 0-9, '+', '/', and '='. Either marker is enough to short-circuit.
         if (value.Contains('\n') || value.Contains(':')) return value;
 
         try


### PR DESCRIPTION
## Summary

- Base64-decode `CIMIAN_PKG_BUILD_INFO` before YAML-parsing so cimiimport can read build-info from cimipkg-built MSIs (the property has been base64-encoded since the multi-line property-leak fix).
- Read `CIMIAN_PKG_FULL_VERSION` as the authoritative version when present, so import shows `2026.04.24.1640` instead of the truncated MSI ProductVersion `26.4.2416`.

## The bug

Running `cimiimport ReportMate-2026.04.24.1640.msi` was reporting:

```
Version: 26.4.2416
```

instead of the full `2026.04.24.1640`. cimipkg was writing the build-info YAML base64-encoded into `CIMIAN_PKG_BUILD_INFO` (single-line — multi-line values used to corrupt `PREVIOUSVERSIONSINSTALLED` at install time), but cimiimport was YAML-parsing the raw base64 string. The parse threw, a `catch {}` block swallowed the error, and version fell back to the lossy MSI ProductVersion.

## The fix

`MetadataExtractor.ExtractMsiMetadata`:

1. `DecodeBuildInfoYaml(...)` helper mirrors the one in `cimipkg/Services/MsiPropertyReader.cs`: reject values containing `:` or `\n` (YAML markers, not base64 alphabet) and base64-decode the rest. Legacy MSIs storing raw multi-line YAML keep working.
2. After the build-info path, read `CIMIAN_PKG_FULL_VERSION` as a final authoritative override.

## Companion PRs

- `windowsadmins/cimian-pkg` — renames `CIMIAN_FULL_VERSION` → `CIMIAN_PKG_FULL_VERSION` (this PR reads the new name)
- `windowsadmins/pkg-inspector` — same rename in the inspector

## Test plan

- [ ] `cimiimport <new-cimipkg-MSI>` prints full date version (e.g. `2026.04.24.1640`)
- [ ] `cimiimport <legacy-cimipkg-MSI>` (built before base64 encoding) still parses build-info and surfaces full version via the YAML path
- [ ] `cimiimport <commercial-MSI>` (no Cimian properties) still reads `ProductVersion` correctly