### PR TITLE
Centralize system paths in Cimian.Core.CimianPaths

### DIFF
--- a/cli/cimiimport/Program.cs
+++ b/cli/cimiimport/Program.cs
@@ -147,15 +147,23 @@ public class Program
             // Handle --config or --config-auto
             if (configRequested || configAuto)
             {
-                if (configAuto && !configRequested)
+                try
                 {
-                    configService.ConfigureNonInteractive(config);
+                    if (configAuto && !configRequested)
+                    {
+                        configService.ConfigureNonInteractive(config);
+                    }
+                    else
+                    {
+                        configService.ConfigureInteractive(config);
+                    }
+                    context.ExitCode = 0;
                 }
-                else
+                catch (InvalidOperationException ex)
                 {
-                    configService.ConfigureInteractive(config);
+                    Console.Error.WriteLine($"❌ {ex.Message}");
+                    context.ExitCode = 1;
                 }
-                context.ExitCode = 0;
                 return;
             }
 
@@ -221,7 +229,7 @@ public class Program
                 {
                     // Run makecatalogs
                     Console.WriteLine("Running makecatalogs...");
-                    RunMakeCatalogs();
+                    RunMakeCatalogs(config.RepoPath);
 
                     Console.WriteLine("Import completed successfully.");
                     context.ExitCode = 0;
@@ -248,7 +256,7 @@ public class Program
         Console.WriteLine($"cimiimport v{version.Major}.{version.Minor}.{version.Build}");
     }
 
-    private static void RunMakeCatalogs()
+    private static void RunMakeCatalogs(string repoPath)
     {
         try
         {
@@ -262,10 +270,15 @@ public class Program
             var psi = new System.Diagnostics.ProcessStartInfo
             {
                 FileName = makeCatalogsBinary,
-                Arguments = "--silent",
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
             };
+            if (!string.IsNullOrEmpty(repoPath))
+            {
+                psi.ArgumentList.Add("--repo_path");
+                psi.ArgumentList.Add(repoPath);
+            }
+            psi.ArgumentList.Add("--silent");
 
             using var process = System.Diagnostics.Process.Start(psi);
             process?.WaitForExit();

--- a/cli/cimiimport/Program.cs
+++ b/cli/cimiimport/Program.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.Reflection;
 using Cimian.CLI.Cimiimport.Models;
 using Cimian.CLI.Cimiimport.Services;
+using Cimian.Core;
 
 namespace Cimian.CLI.Cimiimport;
 
@@ -251,7 +252,7 @@ public class Program
     {
         try
         {
-            var makeCatalogsBinary = @"C:\Program Files\Cimian\makecatalogs.exe";
+            var makeCatalogsBinary = CimianPaths.MakeCatalogsExe;
             if (!File.Exists(makeCatalogsBinary))
             {
                 Console.WriteLine("⚠️ makecatalogs not found");

--- a/cli/cimiimport/Services/ConfigurationService.cs
+++ b/cli/cimiimport/Services/ConfigurationService.cs
@@ -1,4 +1,5 @@
 using Cimian.CLI.Cimiimport.Models;
+using Cimian.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -9,7 +10,7 @@ namespace Cimian.CLI.Cimiimport.Services;
 /// </summary>
 public class ConfigurationService
 {
-    public const string ConfigPath = @"C:\ProgramData\ManagedInstalls\Config.yaml";
+    public static readonly string ConfigPath = CimianPaths.ConfigYaml;
 
     private readonly IDeserializer _deserializer;
     private readonly ISerializer _serializer;
@@ -94,16 +95,14 @@ public class ConfigurationService
     }
 
     /// <summary>
-    /// Gets default configuration.
+    /// Gets default configuration. RepoPath is resolved at runtime from the
+    /// surrounding git checkout — never hardcoded to a user-profile path.
     /// </summary>
     public ImportConfiguration GetDefaultConfig()
     {
-        var userProfile = Environment.GetEnvironmentVariable("USERPROFILE") ?? 
-                         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
         return new ImportConfiguration
         {
-            RepoPath = Path.Combine(userProfile, "DevOps", "Cimian", "deployment"),
+            RepoPath = RepoResolver.ResolveDefaultRepoPath() ?? string.Empty,
             CloudProvider = "none",
             CloudBucket = "",
             DefaultCatalog = "Development",
@@ -119,7 +118,10 @@ public class ConfigurationService
     {
         var defaults = GetDefaultConfig();
 
-        Console.Write($"Enter Repo Path [{config.RepoPath ?? defaults.RepoPath}]: ");
+        var repoPrompt = !string.IsNullOrEmpty(config.RepoPath) ? config.RepoPath
+                       : !string.IsNullOrEmpty(defaults.RepoPath) ? defaults.RepoPath
+                       : "(no Cimian deployment detected — please enter)";
+        Console.Write($"Enter Repo Path [{repoPrompt}]: ");
         var input = Console.ReadLine()?.Trim();
         if (!string.IsNullOrEmpty(input))
         {

--- a/cli/cimiimport/Services/ConfigurationService.cs
+++ b/cli/cimiimport/Services/ConfigurationService.cs
@@ -118,18 +118,26 @@ public class ConfigurationService
     {
         var defaults = GetDefaultConfig();
 
-        var repoPrompt = !string.IsNullOrEmpty(config.RepoPath) ? config.RepoPath
-                       : !string.IsNullOrEmpty(defaults.RepoPath) ? defaults.RepoPath
-                       : "(no Cimian deployment detected — please enter)";
-        Console.Write($"Enter Repo Path [{repoPrompt}]: ");
-        var input = Console.ReadLine()?.Trim();
-        if (!string.IsNullOrEmpty(input))
+        string? input;
+
+        // Loop until we have a non-empty RepoPath. We refuse to save an empty
+        // value because downstream tools (makecatalogs, makepkginfo, etc.) all
+        // read RepoPath from Config.yaml and silently misbehave on empty.
+        var existingDefault = !string.IsNullOrEmpty(config.RepoPath) ? config.RepoPath : defaults.RepoPath;
+        while (true)
         {
-            config.RepoPath = input;
-        }
-        else if (string.IsNullOrEmpty(config.RepoPath))
-        {
-            config.RepoPath = defaults.RepoPath;
+            var prompt = !string.IsNullOrEmpty(existingDefault)
+                ? existingDefault
+                : "(no Cimian deployment detected — please enter)";
+            Console.Write($"Enter Repo Path [{prompt}]: ");
+            input = Console.ReadLine()?.Trim();
+            var chosen = !string.IsNullOrEmpty(input) ? input : existingDefault;
+            if (!string.IsNullOrEmpty(chosen))
+            {
+                config.RepoPath = chosen;
+                break;
+            }
+            Console.WriteLine("⚠️ RepoPath is required. Enter the path to your Cimian deployment workspace.");
         }
 
         Console.Write($"Enter Cloud Provider (aws/azure/none) [{config.CloudProvider ?? defaults.CloudProvider}]: ");
@@ -183,7 +191,9 @@ public class ConfigurationService
     }
 
     /// <summary>
-    /// Runs non-interactive configuration with defaults.
+    /// Runs non-interactive configuration with defaults. Throws if RepoPath
+    /// can't be resolved — non-interactive can't prompt, so silently saving
+    /// an empty path would just paper over the misconfiguration.
     /// </summary>
     public void ConfigureNonInteractive(ImportConfiguration config)
     {
@@ -197,6 +207,13 @@ public class ConfigurationService
             config.DefaultCatalog = defaults.DefaultCatalog;
         if (string.IsNullOrEmpty(config.DefaultArch))
             config.DefaultArch = defaults.DefaultArch;
+
+        if (string.IsNullOrEmpty(config.RepoPath))
+        {
+            throw new InvalidOperationException(
+                "RepoPath could not be resolved. Run from inside a Cimian deployment " +
+                "checkout, or use interactive --configure to set it explicitly.");
+        }
 
         SaveConfig(config);
         Console.WriteLine("✅ Configuration saved (non-interactive).");

--- a/cli/cimiimport/Services/ImportService.cs
+++ b/cli/cimiimport/Services/ImportService.cs
@@ -655,7 +655,9 @@ public class ImportService
     }
 
     /// <summary>
-    /// Runs makecatalogs.
+    /// Runs makecatalogs against the given repo path. Without --repo_path,
+    /// makecatalogs falls back to whatever Config.yaml says, which may not
+    /// be the workspace cimiimport just imported into.
     /// </summary>
     private void RunMakeCatalogs(string repoPath, bool silent)
     {
@@ -667,14 +669,21 @@ public class ImportService
 
         try
         {
-            var args = silent ? "--silent" : "";
             var psi = new ProcessStartInfo
             {
                 FileName = makeCatalogsBinary,
-                Arguments = args,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
             };
+            if (!string.IsNullOrEmpty(repoPath))
+            {
+                psi.ArgumentList.Add("--repo_path");
+                psi.ArgumentList.Add(repoPath);
+            }
+            if (silent)
+            {
+                psi.ArgumentList.Add("--silent");
+            }
             using var process = Process.Start(psi);
             process?.WaitForExit();
         }

--- a/cli/cimiimport/Services/ImportService.cs
+++ b/cli/cimiimport/Services/ImportService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Cimian.CLI.Cimiimport.Models;
+using Cimian.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -637,7 +638,8 @@ public class ImportService
     }
 
     /// <summary>
-    /// Replaces user profile path with variable.
+    /// Replaces the resolved user-profile prefix in a path with %USERPROFILE%
+    /// so the resulting metadata is portable across machines / users.
     /// </summary>
     private static string ReplacePathUserProfile(string path)
     {
@@ -647,7 +649,7 @@ public class ImportService
 
         if (path.StartsWith(userProfile, StringComparison.OrdinalIgnoreCase))
         {
-            return @"C:\Users\%USERPROFILE%" + path[userProfile.Length..];
+            return "%USERPROFILE%" + path[userProfile.Length..];
         }
         return path;
     }
@@ -657,7 +659,7 @@ public class ImportService
     /// </summary>
     private void RunMakeCatalogs(string repoPath, bool silent)
     {
-        var makeCatalogsBinary = @"C:\Program Files\Cimian\makecatalogs.exe";
+        var makeCatalogsBinary = CimianPaths.MakeCatalogsExe;
         if (!File.Exists(makeCatalogsBinary))
         {
             return; // Silently skip if not found

--- a/cli/cimiimport/Services/RepoResolver.cs
+++ b/cli/cimiimport/Services/RepoResolver.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+
+namespace Cimian.CLI.Cimiimport.Services;
+
+/// <summary>
+/// Resolves the Cimian deployment repo path at runtime instead of relying on a
+/// machine-specific default baked into the binary.
+///
+/// Resolution order (mirrors .githooks/sync-lib.ps1 → Resolve-CimianRepo):
+///   1. Walk up from cwd looking for any ancestor containing deployment/pkgsinfo/.
+///      That's the marker of a real Cimian deployment workspace — present in the
+///      outer repo even when running from a submodule under packages/.
+///   2. If that ancestor is also a git checkout whose origin matches the Cimian
+///      remote pattern, accept it.
+///   3. Otherwise return null — caller must prompt the user explicitly rather
+///      than silently fall back to a stale guess.
+/// </summary>
+public static class RepoResolver
+{
+    private const string CimianRemotePattern = "emilycarru-its-infra/Devices/_git/Cimian";
+
+    public static string? ResolveDefaultRepoPath()
+    {
+        var deploymentRoot = FindAncestorWithDeployment(Directory.GetCurrentDirectory());
+        if (deploymentRoot is null) return null;
+        if (!RemoteMatchesCimian(deploymentRoot)) return null;
+        return Path.Combine(deploymentRoot, "deployment");
+    }
+
+    private static string? FindAncestorWithDeployment(string startDir)
+    {
+        var dir = new DirectoryInfo(startDir);
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "deployment", "pkgsinfo")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static bool RemoteMatchesCimian(string repoRoot)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", "remote get-url origin")
+            {
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            using var p = Process.Start(psi);
+            if (p is null) return false;
+            var stdout = p.StandardOutput.ReadToEnd();
+            p.WaitForExit(2000);
+            return p.ExitCode == 0 &&
+                   stdout.Contains(CimianRemotePattern, StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/cli/cimiimport/Services/RepoResolver.cs
+++ b/cli/cimiimport/Services/RepoResolver.cs
@@ -49,14 +49,25 @@ public static class RepoResolver
             {
                 WorkingDirectory = repoRoot,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                // Don't redirect stderr — leaving it as inherited avoids an
+                // unread-pipe deadlock if git writes a lot to it. The text we
+                // care about ("origin URL") goes to stdout regardless.
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
             using var p = Process.Start(psi);
             if (p is null) return false;
-            var stdout = p.StandardOutput.ReadToEnd();
-            p.WaitForExit(2000);
+
+            // Drain stdout asynchronously so a stalled `git` (credential prompt,
+            // slow remote) can't block us — the WaitForExit timeout below is the
+            // hard cap.
+            var stdoutTask = p.StandardOutput.ReadToEndAsync();
+            if (!p.WaitForExit(2000))
+            {
+                try { p.Kill(entireProcessTree: true); } catch { }
+                return false;
+            }
+            var stdout = stdoutTask.GetAwaiter().GetResult();
             return p.ExitCode == 0 &&
                    stdout.Contains(CimianRemotePattern, StringComparison.OrdinalIgnoreCase);
         }

--- a/cli/cimitrigger/Cimian.CLI.cimitrigger.csproj
+++ b/cli/cimitrigger/Cimian.CLI.cimitrigger.csproj
@@ -19,4 +19,8 @@
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\core\Cimian.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/cli/cimitrigger/Services/DiagnosticService.cs
+++ b/cli/cimitrigger/Services/DiagnosticService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.ServiceProcess;
+using Cimian.Core;
 using CimianTools.CimiTrigger.Models;
 
 namespace CimianTools.CimiTrigger.Services;
@@ -156,7 +157,7 @@ public class DiagnosticService
     /// </summary>
     private bool CheckDirectoryAccess()
     {
-        var dir = @"C:\ProgramData\ManagedInstalls";
+        var dir = CimianPaths.ManagedInstallsRoot;
 
         if (!Directory.Exists(dir))
         {
@@ -322,7 +323,7 @@ public class DiagnosticService
         Console.WriteLine("   1. cimitrigger --force gui        # Direct elevation (bypasses service)");
         Console.WriteLine("   2. cimitrigger --force headless   # Direct headless elevation");
         Console.WriteLine("   3. Manual PowerShell elevation:");
-        Console.WriteLine("      PowerShell -Command \"Start-Process -FilePath 'C:\\Program Files\\Cimian\\managedsoftwareupdate.exe' -ArgumentList '--auto','--show-status','-vv' -Verb RunAs\"");
+        Console.WriteLine($"      PowerShell -Command \"Start-Process -FilePath '{CimianPaths.ManagedSoftwareUpdateExe}' -ArgumentList '--auto','--show-status','-vv' -Verb RunAs\"");
 
         Console.WriteLine("\n📋 Troubleshooting commands:");
         Console.WriteLine("   sc query CimianWatcher              # Check service status");
@@ -352,7 +353,7 @@ public class DiagnosticService
                 Console.WriteLine("   Solutions:");
                 Console.WriteLine("   1. Reinstall Cimian completely");
                 Console.WriteLine("   2. Register service manually:");
-                Console.WriteLine("      cd \"C:\\Program Files\\Cimian\"");
+                Console.WriteLine($"      cd \"{CimianPaths.CimianInstallDir}\"");
                 Console.WriteLine("      cimiwatcher.exe install");
                 Console.WriteLine("      sc start CimianWatcher");
                 Console.WriteLine("   3. Use direct method: cimitrigger --force gui");
@@ -373,7 +374,7 @@ public class DiagnosticService
                 Console.WriteLine("🔴 DIRECTORY ACCESS:");
                 Console.WriteLine("   Solutions:");
                 Console.WriteLine("   1. Run as administrator");
-                Console.WriteLine("   2. Check folder permissions on C:\\ProgramData\\ManagedInstalls");
+                Console.WriteLine($"   2. Check folder permissions on {CimianPaths.ManagedInstallsRoot}");
                 Console.WriteLine("   3. Create directory manually with proper permissions");
                 Console.WriteLine("   4. Use direct method: cimitrigger --force gui");
                 Console.WriteLine();

--- a/cli/cimitrigger/Services/ElevationService.cs
+++ b/cli/cimitrigger/Services/ElevationService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Cimian.Core;
 using CimianTools.CimiTrigger.Models;
 
 namespace CimianTools.CimiTrigger.Services;
@@ -13,7 +14,7 @@ public class ElevationService
     /// </summary>
     private static readonly string[] ExecutablePaths =
     [
-        @"C:\Program Files\Cimian\managedsoftwareupdate.exe",
+        CimianPaths.ManagedSoftwareUpdateExe,
         @"C:\Program Files (x86)\Cimian\managedsoftwareupdate.exe",
         @".\managedsoftwareupdate.exe",
         @"..\release\x64\managedsoftwareupdate.exe",
@@ -26,7 +27,7 @@ public class ElevationService
     /// </summary>
     private static readonly string[] StatusPaths =
     [
-        @"C:\Program Files\Cimian\cimistatus.exe",
+        CimianPaths.CimiStatusExe,
         @"C:\Program Files (x86)\Cimian\cimistatus.exe",
         @".\cimistatus.exe",
         @"..\release\x64\cimistatus.exe",
@@ -94,7 +95,7 @@ public class ElevationService
                     else
                     {
                         Console.WriteLine("📋 Update process completed quickly");
-                        Console.WriteLine("💡 Check CimianStatus GUI for results, or view logs in C:\\ProgramData\\ManagedInstalls\\logs");
+                        Console.WriteLine($"💡 Check CimianStatus GUI for results, or view logs in {CimianPaths.LogsDir}");
                     }
 
                     return new ElevationResult

--- a/cli/cimitrigger/Services/TriggerService.cs
+++ b/cli/cimitrigger/Services/TriggerService.cs
@@ -1,3 +1,4 @@
+using Cimian.Core;
 using CimianTools.CimiTrigger.Models;
 
 namespace CimianTools.CimiTrigger.Services;
@@ -10,8 +11,8 @@ public class TriggerService
     /// <summary>
     /// Bootstrap flag file paths.
     /// </summary>
-    public const string GuiBootstrapFile = @"C:\ProgramData\ManagedInstalls\.cimian.bootstrap";
-    public const string HeadlessBootstrapFile = @"C:\ProgramData\ManagedInstalls\.cimian.headless";
+    public static readonly string GuiBootstrapFile = CimianPaths.BootstrapFlagFile;
+    public static readonly string HeadlessBootstrapFile = CimianPaths.HeadlessFlagFile;
 
     private readonly ElevationService _elevationService;
 
@@ -226,7 +227,7 @@ public class TriggerService
     {
         try
         {
-            var logsDir = @"C:\ProgramData\ManagedInstalls\logs";
+            var logsDir = CimianPaths.LogsDir;
             if (!Directory.Exists(logsDir)) return null;
 
             var directories = Directory.GetDirectories(logsDir)

--- a/cli/cimiwatcher/Program.cs
+++ b/cli/cimiwatcher/Program.cs
@@ -7,13 +7,14 @@ using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
 using Cimian.CLI.Cimiwatcher.Services;
+using Cimian.Core;
 
 namespace Cimian.CLI.Cimiwatcher;
 
 class Program
 {
     private const string ServiceName = "CimianWatcher";
-    private const string LogPath = @"C:\ProgramData\ManagedInstalls\logs\cimiwatcher.log";
+    private static readonly string LogPath = CimianPaths.CimiwatcherLog;
 
     static async Task<int> Main(string[] args)
     {

--- a/cli/cimiwatcher/Services/FileWatcherService.cs
+++ b/cli/cimiwatcher/Services/FileWatcherService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Cimian.Core;
 using Cimian.Core.Services;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -11,9 +12,9 @@ namespace Cimian.CLI.Cimiwatcher.Services;
 /// </summary>
 public class FileWatcherService : BackgroundService
 {
-    private const string BootstrapFlagFile = @"C:\ProgramData\ManagedInstalls\.cimian.bootstrap";
-    private const string HeadlessFlagFile = @"C:\ProgramData\ManagedInstalls\.cimian.headless";
-    private const string CimianExePath = @"C:\Program Files\Cimian\managedsoftwareupdate.exe";
+    private static readonly string BootstrapFlagFile = CimianPaths.BootstrapFlagFile;
+    private static readonly string HeadlessFlagFile = CimianPaths.HeadlessFlagFile;
+    private static readonly string CimianExePath = CimianPaths.ManagedSoftwareUpdateExe;
     private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(10);
 
     private readonly ILogger<FileWatcherService> _logger;

--- a/cli/makecatalogs/Cimian.CLI.makecatalogs.csproj
+++ b/cli/makecatalogs/Cimian.CLI.makecatalogs.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\core\Cimian.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/cli/makecatalogs/Program.cs
+++ b/cli/makecatalogs/Program.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using Cimian.CLI.Makecatalogs.Services;
+using Cimian.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -8,7 +9,7 @@ namespace Cimian.CLI.Makecatalogs;
 class Program
 {
     private const string Version = "2.0.0";
-    private const string DefaultConfigPath = @"C:\ProgramData\ManagedInstalls\Config.yaml";
+    private static readonly string DefaultConfigPath = CimianPaths.ConfigYaml;
 
     static async Task<int> Main(string[] args)
     {

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -1,4 +1,5 @@
 using Cimian.CLI.Makepkginfo.Models;
+using Cimian.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -25,7 +26,7 @@ public class PkgInfoBuilder
     /// <summary>
     /// Configuration for loading repository settings
     /// </summary>
-    public const string DefaultConfigPath = @"C:\ProgramData\ManagedInstalls\Config.yaml";
+    public static readonly string DefaultConfigPath = CimianPaths.ConfigYaml;
 
     /// <summary>
     /// Loads Cimian configuration from the config file
@@ -347,7 +348,7 @@ public class PkgInfoBuilder
 
         if (path.StartsWith(userProfile, StringComparison.OrdinalIgnoreCase))
         {
-            return @"C:\Users\%USERPROFILE%" + path[userProfile.Length..];
+            return "%USERPROFILE%" + path[userProfile.Length..];
         }
 
         return path;

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -1,3 +1,4 @@
+using Cimian.Core;
 using YamlDotNet.Serialization;
 
 namespace Cimian.CLI.managedsoftwareupdate.Models;
@@ -14,13 +15,13 @@ public class CimianConfig
     public string ClientIdentifier { get; set; } = string.Empty;
 
     [YamlMember(Alias = "CachePath")]
-    public string CachePath { get; set; } = @"C:\ProgramData\ManagedInstalls\Cache";
+    public string CachePath { get; set; } = CimianPaths.CacheDir;
 
     [YamlMember(Alias = "CatalogsPath")]
-    public string CatalogsPath { get; set; } = @"C:\ProgramData\ManagedInstalls\catalogs";
+    public string CatalogsPath { get; set; } = CimianPaths.CatalogsDir;
 
     [YamlMember(Alias = "ManifestsPath")]
-    public string ManifestsPath { get; set; } = @"C:\ProgramData\ManagedInstalls\manifests";
+    public string ManifestsPath { get; set; } = CimianPaths.ManifestsDir;
 
     [YamlMember(Alias = "LogLevel")]
     public string LogLevel { get; set; } = "INFO";
@@ -118,7 +119,7 @@ public class CimianConfig
     // TODO: Localization / i18n — extract all hardcoded UI strings to resource files for multi-language support
     // TODO: License seat tracking — track available license seats per package (requires server-side component)
 
-    public static readonly string ConfigPath = @"C:\ProgramData\ManagedInstalls\Config.yaml";
+    public static readonly string ConfigPath = CimianPaths.ConfigYaml;
 }
 
 // TODO(pkg-sunset): Remove PkgBuildInfo, PkgProductInfo, PkgSignatureInfo, PkgCertificateInfo classes

--- a/cli/managedsoftwareupdate/Services/ConfigurationService.cs
+++ b/cli/managedsoftwareupdate/Services/ConfigurationService.cs
@@ -1,6 +1,7 @@
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.Core;
 using Cimian.Core.Services;
 
 namespace Cimian.CLI.managedsoftwareupdate.Services;
@@ -90,9 +91,9 @@ public class ConfigurationService
         {
             SoftwareRepoURL = "https://your-repo.example.com",
             ClientIdentifier = Environment.MachineName,
-            CachePath = @"C:\ProgramData\ManagedInstalls\Cache",
-            CatalogsPath = @"C:\ProgramData\ManagedInstalls\catalogs",
-            ManifestsPath = @"C:\ProgramData\ManagedInstalls\manifests",
+            CachePath = CimianPaths.CacheDir,
+            CatalogsPath = CimianPaths.CatalogsDir,
+            ManifestsPath = CimianPaths.ManifestsDir,
             LogLevel = "INFO",
             InstallerTimeout = 900,
             Catalogs = new List<string> { "Production" }
@@ -139,8 +140,8 @@ public class ConfigurationService
             config.CachePath,
             config.CatalogsPath,
             config.ManifestsPath,
-            @"C:\ProgramData\ManagedInstalls\logs",
-            @"C:\ProgramData\ManagedInstalls\reports"
+            CimianPaths.LogsDir,
+            CimianPaths.ReportsDir
         };
 
         foreach (var dir in directories)

--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -3,6 +3,7 @@ using System.Text;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.Core;
 using Cimian.Core.Services;
 using Cimian.Engine.Predicates;
 using Cimian.Infrastructure.System;
@@ -328,7 +329,7 @@ public class ManifestService
     /// <summary>
     /// Ensures SystemFacts are populated for predicate evaluation
     /// </summary>
-    private static readonly string ConditionsDir = @"C:\ProgramData\ManagedInstalls\conditions";
+    private static readonly string ConditionsDir = CimianPaths.ConditionsDir;
 
     private void EnsureSystemFacts()
     {

--- a/cli/managedsoftwareupdate/Services/ScriptService.cs
+++ b/cli/managedsoftwareupdate/Services/ScriptService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Management.Automation;
 using System.Text;
+using Cimian.Core;
 using Cimian.Core.Services;
 
 namespace Cimian.CLI.managedsoftwareupdate.Services;
@@ -300,8 +301,8 @@ public class ScriptService
         // Check multiple possible locations (matching Go behavior)
         var possiblePaths = new[]
         {
-            @"C:\Program Files\Cimian\preflight.ps1",
-            @"C:\ProgramData\ManagedInstalls\sbin\preflight.ps1"
+            CimianPaths.PreflightScriptInstall,
+            CimianPaths.PreflightScript
         };
 
         string? preflightPath = null;
@@ -332,8 +333,8 @@ public class ScriptService
         // Check multiple possible locations (matching Go behavior)
         var possiblePaths = new[]
         {
-            @"C:\Program Files\Cimian\postflight.ps1",
-            @"C:\ProgramData\ManagedInstalls\sbin\postflight.ps1"
+            CimianPaths.PostflightScriptInstall,
+            CimianPaths.PostflightScript
         };
 
         string? postflightPath = null;

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.Core;
 using Cimian.Core.Models;
 using Cimian.Core.Services;
 using Microsoft.Win32;
@@ -18,7 +19,7 @@ namespace Cimian.CLI.managedsoftwareupdate.Services;
 /// </summary>
 public class StatusService
 {
-    private const string BootstrapFlagFile = @"C:\ProgramData\ManagedInstalls\.cimian.bootstrap";
+    private static readonly string BootstrapFlagFile = CimianPaths.BootstrapFlagFile;
 
     /// <summary>
     /// Checks if the item is the Cimian/CimianTools self-update package

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.Core;
 using Cimian.Core.Models;
 using Cimian.Core.Services;
 using YamlDotNet.Serialization;
@@ -2369,7 +2370,7 @@ public class UpdateEngine : IDisposable
                 .Build();
 
             var yaml = serializer.Serialize(info);
-            var path = Path.Combine(Path.GetDirectoryName(_config.CachePath) ?? @"C:\ProgramData\ManagedInstalls", "InstallInfo.yaml");
+            var path = Path.Combine(Path.GetDirectoryName(_config.CachePath) ?? CimianPaths.ManagedInstallsRoot, "InstallInfo.yaml");
             File.WriteAllText(path, yaml);
 
             LogInfo($"Wrote {path}");

--- a/cli/manifestutil/Cimian.CLI.manifestutil.csproj
+++ b/cli/manifestutil/Cimian.CLI.manifestutil.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\core\Cimian.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/cli/manifestutil/Program.cs
+++ b/cli/manifestutil/Program.cs
@@ -1,12 +1,13 @@
 using System.CommandLine;
 using Cimian.CLI.Manifestutil.Services;
+using Cimian.Core;
 
 namespace Cimian.CLI.Manifestutil;
 
 class Program
 {
     private const string Version = "2.0.0";
-    private const string DefaultConfigPath = @"C:\ProgramData\ManagedInstalls\Config.yaml";
+    private static readonly string DefaultConfigPath = CimianPaths.ConfigYaml;
 
     static async Task<int> Main(string[] args)
     {

--- a/cli/manifestutil/Services/SelfServiceManifestService.cs
+++ b/cli/manifestutil/Services/SelfServiceManifestService.cs
@@ -1,4 +1,5 @@
 using Cimian.CLI.Manifestutil.Models;
+using Cimian.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -13,7 +14,7 @@ public class SelfServiceManifestService
     /// <summary>
     /// Default path to the self-service manifest
     /// </summary>
-    public const string DefaultManifestPath = @"C:\ProgramData\ManagedInstalls\SelfServeManifest.yaml";
+    public static readonly string DefaultManifestPath = CimianPaths.SelfServeManifestYaml;
 
     private readonly IDeserializer _deserializer;
     private readonly ISerializer _serializer;

--- a/shared/core/CimianPaths.cs
+++ b/shared/core/CimianPaths.cs
@@ -1,0 +1,57 @@
+namespace Cimian.Core;
+
+/// <summary>
+/// Canonical Cimian filesystem locations. All system paths used across CLI tools
+/// resolve here so the layout is defined exactly once.
+///
+/// Roots are computed from environment variables (ProgramData, ProgramFiles) so
+/// the binaries don't bake in a drive letter assumption — Windows can relocate
+/// these under group policy.
+/// </summary>
+public static class CimianPaths
+{
+    /// <summary>%ProgramData%\ManagedInstalls — Cimian's system data root.</summary>
+    public static readonly string ManagedInstallsRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+        "ManagedInstalls");
+
+    /// <summary>%ProgramFiles%\Cimian — Cimian's binary install root.</summary>
+    public static readonly string CimianInstallDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+        "Cimian");
+
+    // ── System config / state ────────────────────────────────────────────────
+    public static readonly string ConfigYaml             = Path.Combine(ManagedInstallsRoot, "Config.yaml");
+    public static readonly string SelfServeManifestYaml  = Path.Combine(ManagedInstallsRoot, "SelfServeManifest.yaml");
+    public static readonly string InstallInfoYaml        = Path.Combine(ManagedInstallsRoot, "InstallInfo.yaml");
+
+    // ── Subdirectories under ManagedInstallsRoot ─────────────────────────────
+    public static readonly string CacheDir       = Path.Combine(ManagedInstallsRoot, "Cache");
+    public static readonly string CatalogsDir    = Path.Combine(ManagedInstallsRoot, "catalogs");
+    public static readonly string ManifestsDir   = Path.Combine(ManagedInstallsRoot, "manifests");
+    public static readonly string LogsDir        = Path.Combine(ManagedInstallsRoot, "logs");
+    public static readonly string ReportsDir     = Path.Combine(ManagedInstallsRoot, "reports");
+    public static readonly string ConditionsDir  = Path.Combine(ManagedInstallsRoot, "conditions");
+    public static readonly string ReceiptsDir    = Path.Combine(ManagedInstallsRoot, "Receipts");
+    public static readonly string SbinDir        = Path.Combine(ManagedInstallsRoot, "sbin");
+    public static readonly string SelfUpdateBackupDir = Path.Combine(ManagedInstallsRoot, "SelfUpdateBackup");
+
+    // ── Script hooks (sbin) ──────────────────────────────────────────────────
+    public static readonly string PreflightScript  = Path.Combine(SbinDir, "preflight.ps1");
+    public static readonly string PostflightScript = Path.Combine(SbinDir, "postflight.ps1");
+
+    // ── Bootstrap / coordination flag files ──────────────────────────────────
+    public static readonly string BootstrapFlagFile  = Path.Combine(ManagedInstallsRoot, ".cimian.bootstrap");
+    public static readonly string HeadlessFlagFile   = Path.Combine(ManagedInstallsRoot, ".cimian.headless");
+    public static readonly string SelfUpdateFlagFile = Path.Combine(ManagedInstallsRoot, ".cimian.selfupdate");
+
+    // ── Specific log files ───────────────────────────────────────────────────
+    public static readonly string CimiwatcherLog = Path.Combine(LogsDir, "cimiwatcher.log");
+
+    // ── Installed Cimian binaries / scripts (under %ProgramFiles%\Cimian) ────
+    public static readonly string ManagedSoftwareUpdateExe = Path.Combine(CimianInstallDir, "managedsoftwareupdate.exe");
+    public static readonly string MakeCatalogsExe          = Path.Combine(CimianInstallDir, "makecatalogs.exe");
+    public static readonly string CimiStatusExe            = Path.Combine(CimianInstallDir, "cimistatus.exe");
+    public static readonly string PreflightScriptInstall   = Path.Combine(CimianInstallDir, "preflight.ps1");
+    public static readonly string PostflightScriptInstall  = Path.Combine(CimianInstallDir, "postflight.ps1");
+}

--- a/shared/core/Services/DataExporter.cs
+++ b/shared/core/Services/DataExporter.cs
@@ -21,21 +21,13 @@ public class DataExporter
     private List<SessionPackageInfo> _currentSessionPackagesInfo = new();
     private List<string> _currentSessionPackages = new();
 
-    private static readonly string DefaultBaseDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-        "ManagedInstalls", "Logs");
-
-    private static readonly string ReportsDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-        "ManagedInstalls", "reports");
-
-    private static readonly string ManifestsDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-        "ManagedInstalls", "manifests");
-
-    private static readonly string CatalogsDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-        "ManagedInstalls", "catalogs");
+    // DataExporter writes to ManagedInstalls\Logs (capital L) — distinct from
+    // SessionLogger's lowercase 'logs'. Preserved as-is for compatibility with
+    // existing on-disk layouts and external log shippers.
+    private static readonly string DefaultBaseDir = Path.Combine(CimianPaths.ManagedInstallsRoot, "Logs");
+    private static readonly string ReportsDir   = CimianPaths.ReportsDir;
+    private static readonly string ManifestsDir = CimianPaths.ManifestsDir;
+    private static readonly string CatalogsDir  = CimianPaths.CatalogsDir;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -682,9 +674,7 @@ public class DataExporter
     /// </summary>
     public SessionConfig? LoadCimianConfiguration()
     {
-        var configPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "ManagedInstalls", "preferences.yaml");
+        var configPath = Path.Combine(CimianPaths.ManagedInstallsRoot, "preferences.yaml");
 
         if (!File.Exists(configPath))
             return null;

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -29,25 +29,21 @@ namespace Cimian.Core.Services;
 ///   8+ installs → suppress indefinitely until manual clear
 ///   3 installs within 2 hours (rapid-fire) → suppress 12 hours
 ///
-/// State persisted to: C:\ProgramData\ManagedInstalls\reports\state.json
+/// State persisted to: %ProgramData%\ManagedInstalls\reports\state.json
 /// Clear with: managedsoftwareupdate --clear-loop (name or all)
 /// </summary>
 public class LoopGuard
 {
-    private static readonly string StateDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-        "ManagedInstalls");
-
-    private static readonly string ReportsDir = Path.Combine(StateDir, "reports");
+    private static readonly string ReportsDir = CimianPaths.ReportsDir;
 
     private static readonly string StatePath = Path.Combine(ReportsDir, "state.json");
 
     // Legacy path for migration from older versions
     private static readonly string LegacyStatePath = Path.Combine(ReportsDir, "loop_state.json");
 
-    private static readonly string LogsDir = Path.Combine(StateDir, "logs");
+    private static readonly string LogsDir = CimianPaths.LogsDir;
 
-    private static readonly string CacheDir = Path.Combine(StateDir, "Cache");
+    private static readonly string CacheDir = CimianPaths.CacheDir;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/shared/core/Services/SelfServiceManifestService.cs
+++ b/shared/core/Services/SelfServiceManifestService.cs
@@ -79,7 +79,7 @@ public interface ISelfServiceManifestService
 /// </summary>
 public class SelfServiceManifestService : ISelfServiceManifestService
 {
-    private const string SelfServiceManifestPath = @"C:\ProgramData\ManagedInstalls\SelfServeManifest.yaml";
+    private static readonly string SelfServiceManifestPath = CimianPaths.SelfServeManifestYaml;
     
     private readonly ILogger<SelfServiceManifestService>? _logger;
     private readonly IDeserializer _deserializer;

--- a/shared/core/Services/SelfUpdateService.cs
+++ b/shared/core/Services/SelfUpdateService.cs
@@ -7,14 +7,9 @@ namespace Cimian.Core.Services;
 /// </summary>
 public static class SelfUpdateService
 {
-    // Self-update flag file - indicates a self-update is pending
-    public const string SelfUpdateFlagFile = @"C:\ProgramData\ManagedInstalls\.cimian.selfupdate";
-    
-    // Backup directory for current installation during self-update
-    public const string SelfUpdateBackupDir = @"C:\ProgramData\ManagedInstalls\SelfUpdateBackup";
-    
-    // Installation directory for Cimian
-    public const string CimianInstallDir = @"C:\Program Files\Cimian";
+    private static readonly string SelfUpdateFlagFile = CimianPaths.SelfUpdateFlagFile;
+    private static readonly string SelfUpdateBackupDir = CimianPaths.SelfUpdateBackupDir;
+    private static readonly string CimianInstallDir = CimianPaths.CimianInstallDir;
 
     /// <summary>
     /// Metadata parsed from the self-update flag file
@@ -157,7 +152,7 @@ public static class SelfUpdateService
             case "msi":
             {
                 var logFile = Path.Combine(
-                    @"C:\ProgramData\ManagedInstalls\logs",
+                    CimianPaths.LogsDir,
                     $"selfupdate-{DateTime.Now:yyyyMMdd-HHmmss}.log");
                 Directory.CreateDirectory(Path.GetDirectoryName(logFile)!);
                 fileName = "msiexec.exe";
@@ -357,7 +352,7 @@ public static class SelfUpdateService
             ConsoleLogger.Info($"Executing MSI update: {msiPath}");
 
             var logFile = Path.Combine(
-                @"C:\ProgramData\ManagedInstalls\logs",
+                CimianPaths.LogsDir,
                 $"selfupdate-{DateTime.Now:yyyyMMdd-HHmmss}.log");
 
             // Ensure log directory exists

--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -19,8 +19,8 @@ namespace Cimian.Core.Services;
 /// </summary>
 public class SessionLogger : IDisposable
 {
-    private const string BaseLogsDir = @"C:\ProgramData\ManagedInstalls\logs";
-    private const string ReportsDir = @"C:\ProgramData\ManagedInstalls\reports";
+    private static readonly string BaseLogsDir = CimianPaths.LogsDir;
+    private static readonly string ReportsDir = CimianPaths.ReportsDir;
 
     // Retention policy: 30-day rolling window (~220MB at typical usage)
     private const int DefaultMaxAgeDays = 30;


### PR DESCRIPTION
## Summary
- Adds `shared/core/CimianPaths.cs` as the single source of truth for `%ProgramData%\ManagedInstalls` and `%ProgramFiles%\Cimian` locations. Roots derive from `Environment.GetFolderPath` so the binaries don't bake in a drive letter.
- Replaces ~30 inline `C:\ProgramData\ManagedInstalls\...` / `C:\Program Files\Cimian\...` literals across `cli/` and `shared/core/` with references to `CimianPaths`.
- Removes `cimiimport`'s hardcoded `%USERPROFILE%\DevOps\Cimian\deployment` default for `RepoPath`. New `RepoResolver` walks up from cwd looking for `deployment/pkgsinfo/` and verifies the git remote matches before using it; returns null otherwise rather than silently writing a stale guess back to `Config.yaml`.
- Fixes `ReplacePathUserProfile` in cimiimport `ImportService.cs` and makepkginfo `PkgInfoBuilder.cs` â€” was prepending `C:\Users\%USERPROFILE%`, but `%USERPROFILE%` already expands to `C:\Users\<name>`, producing doubled-up unusable paths. Now emits `%USERPROFILE%` only.
- Adds `Cimian.Core` ProjectReference to `cimitrigger`, `makecatalogs`, `manifestutil` (cimipkg unchanged â€” its only "hardcoded" path is inside an embedded chocolatey PowerShell template literal).

## Why
Original symptom: every `git commit` and `git push` printed `WARNING: Config.yaml RepoPath (C:\Users\<user>\DevOps\Cimian\deployment) is not a valid Cimian deployment - using ... (git-remote) instead`. Tracing it back: `cimiimport`'s `GetDefaultConfig()` had hardcoded the legacy `DevOps\Cimian\deployment` path, which it then wrote into `C:\ProgramData\ManagedInstalls\Config.yaml` on first run / reconfigure. Because that path is sparse on most modern checkouts (the repo lives under `Developer\AzDevOps\Devices\Cimian` now), the git hooks correctly flagged it as not-a-real-deployment. The fix is to stop hardcoding user-profile paths and resolve at runtime.

## Test plan
- [x] `dotnet build` â€” clean (0 warnings, 0 errors)
- [x] `dotnet test` â€” 592/593 pass; the 1 failure (`InstallAsync_ScriptOnlyItem_Succeeds`) is pre-existing on `main`, unrelated
- [ ] Verify on a clean machine: first `cimiimport --configure` run no longer auto-fills a user-profile RepoPath if cwd isn't inside a Cimian deployment checkout
- [ ] Verify `managedsoftwareupdate --checkonly` still resolves logs/cache/manifests dirs identically (paths are now derived from `%ProgramData%` instead of literal `C:\ProgramData`, same value on all standard Windows installs)

Refs [](https://dev.azure.com/example-org/f6d33719-4062-45ea-af9e-4e4f881c1409/_workitems/edit/256).
