### PR TITLE
managedsoftwareupdate: honour installer.product_code/upgrade_code for MSI status detection

### DIFF
--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -557,6 +557,14 @@ public class InstallerInfo
     [YamlMember(Alias = "size")]
     public long? Size { get; set; }
 
+    /// <summary>MSI ProductCode from the .msi (authoritative install identity per version).</summary>
+    [YamlMember(Alias = "product_code")]
+    public string? ProductCode { get; set; }
+
+    /// <summary>MSI UpgradeCode from the .msi (stable across versions; used to detect outdated installs).</summary>
+    [YamlMember(Alias = "upgrade_code")]
+    public string? UpgradeCode { get; set; }
+
     /// <summary>
     /// Custom temporary directory for package extraction
     /// Use shorter paths like C:\Temp to avoid Windows MAX_PATH (260 char) limit issues

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -212,24 +212,26 @@ public class StatusService
             }
 
             // Priority 6.5: top-level `installer:` block ProductCode/UpgradeCode (MSI authoritative).
-            // The Windows Installer database is the source of truth for MSI install state — query it
-            // directly when the pkgsinfo declares product_code/upgrade_code at the installer level,
-            // even when no installs[] array is present.
-            if (string.Equals(item.Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase)
-                && (!string.IsNullOrEmpty(item.Installer.ProductCode) ||
-                    !string.IsNullOrEmpty(item.Installer.UpgradeCode)))
+            // Look the package up in the Windows Uninstall / Installer\UpgradeCodes registry views
+            // — same source `msiexec` ultimately consults — when the pkgsinfo declares
+            // product_code/upgrade_code at the installer level, even with no installs[] array.
+            var msiInstaller = item.Installer;
+            if (msiInstaller != null
+                && string.Equals(msiInstaller.Type, "msi", StringComparison.OrdinalIgnoreCase)
+                && (!string.IsNullOrEmpty(msiInstaller.ProductCode) ||
+                    !string.IsNullOrEmpty(msiInstaller.UpgradeCode)))
             {
-                ConsoleLogger.Debug($"Verifying MSI via installer block item: {item.Name} productCode: {item.Installer.ProductCode} upgradeCode: {item.Installer.UpgradeCode}");
+                ConsoleLogger.Debug($"Verifying MSI via installer block item: {item.Name} productCode: {msiInstaller.ProductCode} upgradeCode: {msiInstaller.UpgradeCode}");
                 var (msiInstalled, msiVersionMatch, msiInstalledVersion) = CheckMsiWithUpgradeCode(
-                    item.Installer.ProductCode, item.Installer.UpgradeCode, item.Version, item.Name);
+                    msiInstaller.ProductCode, msiInstaller.UpgradeCode, item.Version, item.Name);
 
                 if (!msiInstalled)
                 {
-                    ConsoleLogger.Info($"MSI product not installed item: {item.Name} productCode: {item.Installer.ProductCode} upgradeCode: {item.Installer.UpgradeCode}");
+                    ConsoleLogger.Info($"MSI product not installed item: {item.Name} productCode: {msiInstaller.ProductCode} upgradeCode: {msiInstaller.UpgradeCode}");
                     result.Status = "pending";
                     result.NeedsAction = true;
                     result.IsUpdate = HasManagedInstallsEntry(item.Name);
-                    result.Reason = $"MSI not registered in Windows Installer (ProductCode={item.Installer.ProductCode}, UpgradeCode={item.Installer.UpgradeCode})";
+                    result.Reason = $"MSI not registered in Windows Installer (ProductCode={msiInstaller.ProductCode}, UpgradeCode={msiInstaller.UpgradeCode})";
                     result.ReasonCode = StatusReasonCode.ProductCodeMissing;
                     result.DetectionMethod = DetectionMethod.Msi;
                     return result;
@@ -955,13 +957,20 @@ if ($results.Count -gt 0) {{
     // MSI ProductVersion is capped at major.minor.build (255.255.65535), so cimipkg compresses
     // date-based versions like 2026.04.12.2144 into 26.4.1221 to fit. The expanded form is
     // persisted by Cimian to HKLM\SOFTWARE\ManagedInstalls\<Name>\Version after install.
-    // Prefer that when present so logs and version comparisons use the original date string.
+    // Prefer the expanded form only when it compares >= the MSI-reported version, so logs
+    // and comparisons keep the original date string for cimipkg packages, but apps that can
+    // auto-update outside Cimian (Chrome, etc.) still report the live MSI DisplayVersion
+    // instead of a stale Cimian receipt.
     private string ResolveExpandedVersion(string itemName, string msiVersion)
     {
         if (string.IsNullOrEmpty(itemName))
             return msiVersion;
         var expanded = GetManagedInstallsVersion(itemName);
-        return string.IsNullOrEmpty(expanded) ? msiVersion : expanded;
+        if (string.IsNullOrEmpty(expanded))
+            return msiVersion;
+        // CompareVersions returns >0 when first arg is greater. We want expanded only if
+        // expanded >= msiVersion, i.e. CompareVersions(msiVersion, expanded) <= 0.
+        return CatalogService.CompareVersions(msiVersion, expanded) <= 0 ? expanded : msiVersion;
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -211,7 +211,51 @@ public class StatusService
                 return result;
             }
 
-            // Go parity: If no checks are defined and no installs array, 
+            // Priority 6.5: top-level `installer:` block ProductCode/UpgradeCode (MSI authoritative).
+            // The Windows Installer database is the source of truth for MSI install state — query it
+            // directly when the pkgsinfo declares product_code/upgrade_code at the installer level,
+            // even when no installs[] array is present.
+            if (string.Equals(item.Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase)
+                && (!string.IsNullOrEmpty(item.Installer.ProductCode) ||
+                    !string.IsNullOrEmpty(item.Installer.UpgradeCode)))
+            {
+                ConsoleLogger.Debug($"Verifying MSI via installer block item: {item.Name} productCode: {item.Installer.ProductCode} upgradeCode: {item.Installer.UpgradeCode}");
+                var (msiInstalled, msiVersionMatch, msiInstalledVersion) = CheckMsiWithUpgradeCode(
+                    item.Installer.ProductCode, item.Installer.UpgradeCode, item.Version, item.Name);
+
+                if (!msiInstalled)
+                {
+                    ConsoleLogger.Info($"MSI product not installed item: {item.Name} productCode: {item.Installer.ProductCode} upgradeCode: {item.Installer.UpgradeCode}");
+                    result.Status = "pending";
+                    result.NeedsAction = true;
+                    result.IsUpdate = HasManagedInstallsEntry(item.Name);
+                    result.Reason = $"MSI not registered in Windows Installer (ProductCode={item.Installer.ProductCode}, UpgradeCode={item.Installer.UpgradeCode})";
+                    result.ReasonCode = StatusReasonCode.ProductCodeMissing;
+                    result.DetectionMethod = DetectionMethod.Msi;
+                    return result;
+                }
+                if (!msiVersionMatch)
+                {
+                    ConsoleLogger.Info($"MSI version outdated item: {item.Name} installedVersion: {msiInstalledVersion} catalogVersion: {item.Version}");
+                    result.Status = "pending";
+                    result.NeedsAction = true;
+                    result.IsUpdate = true;
+                    result.InstalledVersion = msiInstalledVersion;
+                    result.Reason = $"MSI version outdated: {msiInstalledVersion} -> {item.Version}";
+                    result.ReasonCode = StatusReasonCode.VersionOutdated;
+                    result.DetectionMethod = DetectionMethod.Msi;
+                    return result;
+                }
+                ConsoleLogger.Info($"MSI verification passed - version current or newer item: {item.Name} installedVersion: {msiInstalledVersion} catalogVersion: {item.Version}");
+                result.Status = "installed";
+                result.Reason = $"MSI ProductCode/UpgradeCode match — installed version {msiInstalledVersion}";
+                result.ReasonCode = StatusReasonCode.ProductCodeMatch;
+                result.DetectionMethod = DetectionMethod.Msi;
+                result.InstalledVersion = msiInstalledVersion;
+                return result;
+            }
+
+            // Go parity: If no checks are defined and no installs array,
             // assume item doesn't need action (it may not have verification methods)
             // Don't fall back to ManagedInstalls registry as Go doesn't do this
             ConsoleLogger.Debug($"No file tracking needed - registry/product code verification sufficient item: {item.Name}");
@@ -499,7 +543,7 @@ public class StatusService
                     // This handles auto-updating apps (Chrome, etc.) where ProductCode changes each version
                     var catalogVersion = !string.IsNullOrEmpty(installItem.Version) ? installItem.Version : item.Version;
                     var (msiInstalled, msiVersionMatch, msiInstalledVersion) = CheckMsiWithUpgradeCode(
-                        installItem.ProductCode, installItem.UpgradeCode, catalogVersion);
+                        installItem.ProductCode, installItem.UpgradeCode, catalogVersion, item.Name);
 
                     // If MSI detection failed, try registry lookup using item's display_name or name as fallback
                     // This handles cases where app was installed via EXE instead of MSI (e.g., Chrome auto-update)
@@ -848,14 +892,15 @@ if ($results.Count -gt 0) {{
     /// Returns: (installed, versionMatch, installedVersion)
     /// </summary>
     private (bool installed, bool versionMatch, string? installedVersion) CheckMsiWithUpgradeCode(
-        string? productCode, string? upgradeCode, string catalogVersion)
+        string? productCode, string? upgradeCode, string catalogVersion, string itemName = "")
     {
         // First try ProductCode lookup (faster, exact match)
         if (!string.IsNullOrEmpty(productCode))
         {
-            var (installed, installedVersion) = CheckMsiProductWithVersion(productCode);
-            if (installed && !string.IsNullOrEmpty(installedVersion))
+            var (installed, msiVersion) = CheckMsiProductWithVersion(productCode);
+            if (installed && !string.IsNullOrEmpty(msiVersion))
             {
+                var installedVersion = ResolveExpandedVersion(itemName, msiVersion);
                 ConsoleLogger.Debug($"Found MSI via ProductCode productCode: {productCode} installedVersion: {installedVersion}");
 
                 if (string.IsNullOrEmpty(catalogVersion))
@@ -879,9 +924,10 @@ if ($results.Count -gt 0) {{
         // ProductCode not found - try UpgradeCode (handles auto-updated apps)
         if (!string.IsNullOrEmpty(upgradeCode))
         {
-            var (installed, installedVersion) = FindMsiByUpgradeCode(upgradeCode);
-            if (installed && !string.IsNullOrEmpty(installedVersion))
+            var (installed, msiVersion) = FindMsiByUpgradeCode(upgradeCode);
+            if (installed && !string.IsNullOrEmpty(msiVersion))
             {
+                var installedVersion = ResolveExpandedVersion(itemName, msiVersion);
                 ConsoleLogger.Debug($"Found MSI via UpgradeCode upgradeCode: {upgradeCode} installedVersion: {installedVersion}");
 
                 if (string.IsNullOrEmpty(catalogVersion))
@@ -904,6 +950,18 @@ if ($results.Count -gt 0) {{
 
         ConsoleLogger.Debug($"MSI not found via ProductCode or UpgradeCode productCode: {productCode} upgradeCode: {upgradeCode}");
         return (false, false, null);
+    }
+
+    // MSI ProductVersion is capped at major.minor.build (255.255.65535), so cimipkg compresses
+    // date-based versions like 2026.04.12.2144 into 26.4.1221 to fit. The expanded form is
+    // persisted by Cimian to HKLM\SOFTWARE\ManagedInstalls\<Name>\Version after install.
+    // Prefer that when present so logs and version comparisons use the original date string.
+    private string ResolveExpandedVersion(string itemName, string msiVersion)
+    {
+        if (string.IsNullOrEmpty(itemName))
+            return msiVersion;
+        var expanded = GetManagedInstallsVersion(itemName);
+        return string.IsNullOrEmpty(expanded) ? msiVersion : expanded;
     }
 
     /// <summary>

--- a/tests/Managedsoftwareupdate/StatusServiceTests.cs
+++ b/tests/Managedsoftwareupdate/StatusServiceTests.cs
@@ -247,6 +247,79 @@ public class StatusServiceTests
 
     #endregion
 
+    #region MSI installer-block ProductCode/UpgradeCode Tests (Priority 6.5)
+
+    [Fact]
+    public void CheckStatus_MsiInstaller_WithFakeProductCode_ReportsProductCodeMissing()
+    {
+        // Priority 6.5: pkginfo declares installer.product_code on an MSI but the GUID
+        // is not registered with Windows Installer. Before the fix this fell through to
+        // NoChecks (silently "installed"); now it must surface as Pending with
+        // ProductCodeMissing so the package gets installed.
+        var item = new CatalogItem
+        {
+            Name = "TestPkgWithFakeProductCode",
+            Version = "1.0.0",
+            Installer = new InstallerInfo
+            {
+                Type = "msi",
+                ProductCode = "{00000000-0000-0000-0000-000000000000}",
+                UpgradeCode = "{11111111-1111-1111-1111-111111111111}"
+            }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.Equal("pending", result.Status);
+        Assert.True(result.NeedsAction);
+        Assert.Equal(Cimian.Core.Models.StatusReasonCode.ProductCodeMissing, result.ReasonCode);
+        Assert.Equal(Cimian.Core.Models.DetectionMethod.Msi, result.DetectionMethod);
+    }
+
+    [Fact]
+    public void CheckStatus_MsiInstaller_WithoutProductCodeOrUpgradeCode_FallsThroughToNoChecks()
+    {
+        // Regression guard: an MSI pkginfo that doesn't declare product_code/upgrade_code
+        // should keep the existing "no checks" fall-through behavior — Priority 6.5 only
+        // engages when authoritative MSI identity is provided.
+        var item = new CatalogItem
+        {
+            Name = "MsiWithoutCodes",
+            Version = "1.0.0",
+            Installer = new InstallerInfo { Type = "msi" }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.Equal("installed", result.Status);
+        Assert.False(result.NeedsAction);
+        Assert.Equal(Cimian.Core.Models.StatusReasonCode.NoChecks, result.ReasonCode);
+    }
+
+    [Fact]
+    public void CheckStatus_NonMsiInstaller_WithProductCodeIsIgnored()
+    {
+        // Priority 6.5 is gated on installer.type == "msi". A pkg/exe/script item that
+        // happens to carry a product_code (unusual, but possible) must not be routed
+        // through the MSI registry lookup.
+        var item = new CatalogItem
+        {
+            Name = "PkgWithProductCode",
+            Version = "1.0.0",
+            Installer = new InstallerInfo
+            {
+                Type = "pkg",
+                ProductCode = "{00000000-0000-0000-0000-000000000000}"
+            }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.NotEqual(Cimian.Core.Models.DetectionMethod.Msi, result.DetectionMethod);
+    }
+
+    #endregion
+
     #region Script Check Tests
 
     [Fact]

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -154,6 +154,8 @@ public class UpdateModelsTests
         Assert.Empty(installer.Args);
         Assert.Null(installer.Hash);
         Assert.Null(installer.Size);
+        Assert.Null(installer.ProductCode);
+        Assert.Null(installer.UpgradeCode);
     }
 
     [Fact]
@@ -165,7 +167,9 @@ public class UpdateModelsTests
             Type = "msi",
             Hash = "abc123def456",
             Size = 1024000,
-            Args = ["/qn", "/norestart"]
+            Args = ["/qn", "/norestart"],
+            ProductCode = "{12345678-1234-1234-1234-123456789012}",
+            UpgradeCode = "{abcdef01-2345-6789-abcd-ef0123456789}"
         };
 
         Assert.Equal("apps/myapp/myapp-1.0.0.msi", installer.Location);
@@ -173,6 +177,29 @@ public class UpdateModelsTests
         Assert.Equal("abc123def456", installer.Hash);
         Assert.Equal(1024000, installer.Size);
         Assert.Equal(2, installer.Args.Count);
+        Assert.Equal("{12345678-1234-1234-1234-123456789012}", installer.ProductCode);
+        Assert.Equal("{abcdef01-2345-6789-abcd-ef0123456789}", installer.UpgradeCode);
+    }
+
+    [Fact]
+    public void InstallerInfo_DeserializesProductCodeAndUpgradeCodeFromYaml()
+    {
+        var yaml = """
+            type: msi
+            location: apps/myapp/myapp-1.0.0.msi
+            product_code: '{12345678-1234-1234-1234-123456789012}'
+            upgrade_code: '{abcdef01-2345-6789-abcd-ef0123456789}'
+            """;
+
+        var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        var installer = deserializer.Deserialize<InstallerInfo>(yaml);
+
+        Assert.Equal("msi", installer.Type);
+        Assert.Equal("{12345678-1234-1234-1234-123456789012}", installer.ProductCode);
+        Assert.Equal("{abcdef01-2345-6789-abcd-ef0123456789}", installer.UpgradeCode);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

YAML pkginfos with a top-level `installer.product_code` and `installer.upgrade_code` were being silently dropped at parse — `InstallerInfo` had no fields for them — so `CheckStatus` fell through to `no_checks` and the item was treated as installed regardless of actual state. This left a large number of fleet devices stuck on stale versions of MSI packages (e.g. `CimianTools`, `TaskbarUtil`, `AudioInputPrefs`) that should have self-updated but never did.

## Changes

- **`cli/managedsoftwareupdate/Models/UpdateModels.cs`** — add `ProductCode` and `UpgradeCode` properties to `InstallerInfo` with `YamlMember` aliases (`product_code`, `upgrade_code`).
- **`cli/managedsoftwareupdate/Services/StatusService.cs`** — new **Priority 6.5** path: when `item.Installer.Type == "msi"` and a `product_code` or `upgrade_code` is declared at the installer level, query Windows Installer directly. Returns proper reason codes (`ProductCodeMissing`, `VersionOutdated`, `ProductCodeMatch`) instead of falling through to `NoChecks`.
- **`cli/managedsoftwareupdate/Services/StatusService.cs`** — prefer the expanded date-based version from `HKLM\SOFTWARE\ManagedInstalls\<Name>\Version` over the truncated MSI `ProductVersion`. cimipkg packs date strings like `2026.04.12.2144` into `26.4.1221` to fit MSI's `major.minor.build` (255.255.65535) limits; the expanded form is what Cimian writes after install and what version comparisons should use. New `ResolveExpandedVersion(itemName, msiVersion)` helper.

## Test plan

Verified end-to-end on two production devices (Camera 03 / Studio 16, x64, both on the buggy 2026.04.13.2237 build):

- [x] `--checkonly`: stale items correctly flagged `Pending Install` with `ReasonCode=product_code_missing` (was `no_checks` before)
- [x] Real `--auto` run: TaskbarUtil, AudioInputPrefs, ManageUsersPrefs (+ ManageUsers dependency) installed via `msiexec` / `sbin-installer`
- [x] Follow-up `--checkonly` reports each as `Installed` with the expanded date version
- [x] Status summary shows `2026.04.12.2144 | Installed` instead of `26.4.1221`
- [x] Run.log shows `Found Cimian-managed registry version item: TaskbarUtil registryVersion: 2026.04.12.2144`
- [x] Genuine third-party MSIs (PowerShell 7.6.1.0, AzureCLI 2.81.0, Chrome 147.0.7727.117) still report their authentic semver — no regression

The Priority 6 (`ManagedInstalls` registry) path remains the primary route for cimipkg-installed packages on follow-up runs; Priority 6.5 fills the gap for first-time installs and for MSIs installed by other means (e.g. Intune-pushed) where only the Windows Installer registry has an entry.