### PR TITLE
managedsoftwareupdate: synthesize MSI uninstaller from installer.product_code

### DIFF
--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -557,6 +557,14 @@ public class InstallerInfo
     [YamlMember(Alias = "size")]
     public long? Size { get; set; }
 
+    /// <summary>MSI ProductCode from the .msi (authoritative install identity per version).</summary>
+    [YamlMember(Alias = "product_code")]
+    public string? ProductCode { get; set; }
+
+    /// <summary>MSI UpgradeCode from the .msi (stable across versions; used to detect outdated installs).</summary>
+    [YamlMember(Alias = "upgrade_code")]
+    public string? UpgradeCode { get; set; }
+
     /// <summary>
     /// Custom temporary directory for package extraction
     /// Use shorter paths like C:\Temp to avoid Windows MAX_PATH (260 char) limit issues

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -411,6 +411,11 @@ public class CatalogItem
     public bool IsUninstallable() => Uninstallable && (
         Uninstaller.Count > 0
         || Check.Registry.Name != null
+        // Self-uninstallable MSI: cimipkg-built MSI pkginfos carry the ProductCode in
+        // installer.product_code. Same GUID is what msiexec /x needs — UninstallAsync
+        // synthesizes an UninstallerInfo from it.
+        || (string.Equals(Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrEmpty(Installer.ProductCode))
         // Self-uninstallable MSIX: installs-array entry of type msix/appx with a
         // usable identity_name. Without identity_name, UninstallAsync can't
         // synthesize an uninstaller — so in that case this clause must be false.

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -414,8 +414,9 @@ public class CatalogItem
         // Self-uninstallable MSI: cimipkg-built MSI pkginfos carry the ProductCode in
         // installer.product_code. Same GUID is what msiexec /x needs — UninstallAsync
         // synthesizes an UninstallerInfo from it.
-        || (string.Equals(Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase)
-            && !string.IsNullOrEmpty(Installer.ProductCode))
+        || (Installer is { } msi
+            && string.Equals(msi.Type, "msi", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrEmpty(msi.ProductCode))
         // Self-uninstallable MSIX: installs-array entry of type msix/appx with a
         // usable identity_name. Without identity_name, UninstallAsync can't
         // synthesize an uninstaller — so in that case this clause must be false.

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -692,14 +692,16 @@ public class InstallerService
             // ProductCode in installer.product_code (PR #10). The same GUID is what
             // msiexec /x needs to remove the package — there is no reason to require
             // a hand-rolled uninstaller: block when we already have authoritative data.
-            if (string.Equals(item.Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase)
-                && !string.IsNullOrEmpty(item.Installer.ProductCode))
+            var msiInstaller = item.Installer;
+            if (msiInstaller != null
+                && string.Equals(msiInstaller.Type, "msi", StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrEmpty(msiInstaller.ProductCode))
             {
-                ConsoleLogger.Debug($"Synthesizing MSI uninstaller from installer.product_code item: {item.Name} productCode: {item.Installer.ProductCode}");
+                ConsoleLogger.Debug($"Synthesizing MSI uninstaller from installer.product_code item: {item.Name} productCode: {msiInstaller.ProductCode}");
                 var synthetic = new UninstallerInfo
                 {
                     Type = "msi",
-                    ProductCode = item.Installer.ProductCode
+                    ProductCode = msiInstaller.ProductCode
                 };
                 result = await UninstallMsiAsync(synthetic, cancellationToken);
             }

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -688,21 +688,39 @@ public class InstallerService
         }
         else
         {
-            // Self-uninstallable MSIX: the pkginfo has an installs-array entry of type
-            // msix but no explicit uninstaller block. Synthesize one from the installs
-            // entry — the identity_name there carries everything we need.
-            var msixInstall = item.Installs.FirstOrDefault(i =>
-                string.Equals(i.Type, "msix", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(i.Type, "appx", StringComparison.OrdinalIgnoreCase));
-
-            if (msixInstall != null && !string.IsNullOrEmpty(msixInstall.IdentityName))
+            // Self-uninstallable MSI: cimipkg-built MSI pkginfos already carry the
+            // ProductCode in installer.product_code (PR #10). The same GUID is what
+            // msiexec /x needs to remove the package — there is no reason to require
+            // a hand-rolled uninstaller: block when we already have authoritative data.
+            if (string.Equals(item.Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrEmpty(item.Installer.ProductCode))
             {
+                ConsoleLogger.Debug($"Synthesizing MSI uninstaller from installer.product_code item: {item.Name} productCode: {item.Installer.ProductCode}");
                 var synthetic = new UninstallerInfo
                 {
-                    Type = "msix",
-                    IdentityName = msixInstall.IdentityName
+                    Type = "msi",
+                    ProductCode = item.Installer.ProductCode
                 };
-                result = await UninstallMsixAsync(item, synthetic, cancellationToken);
+                result = await UninstallMsiAsync(synthetic, cancellationToken);
+            }
+            else
+            {
+                // Self-uninstallable MSIX: the pkginfo has an installs-array entry of type
+                // msix but no explicit uninstaller block. Synthesize one from the installs
+                // entry — the identity_name there carries everything we need.
+                var msixInstall = item.Installs.FirstOrDefault(i =>
+                    string.Equals(i.Type, "msix", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(i.Type, "appx", StringComparison.OrdinalIgnoreCase));
+
+                if (msixInstall != null && !string.IsNullOrEmpty(msixInstall.IdentityName))
+                {
+                    var synthetic = new UninstallerInfo
+                    {
+                        Type = "msix",
+                        IdentityName = msixInstall.IdentityName
+                    };
+                    result = await UninstallMsixAsync(item, synthetic, cancellationToken);
+                }
             }
         }
 

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -212,24 +212,26 @@ public class StatusService
             }
 
             // Priority 6.5: top-level `installer:` block ProductCode/UpgradeCode (MSI authoritative).
-            // The Windows Installer database is the source of truth for MSI install state — query it
-            // directly when the pkgsinfo declares product_code/upgrade_code at the installer level,
-            // even when no installs[] array is present.
-            if (string.Equals(item.Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase)
-                && (!string.IsNullOrEmpty(item.Installer.ProductCode) ||
-                    !string.IsNullOrEmpty(item.Installer.UpgradeCode)))
+            // Look the package up in the Windows Uninstall / Installer\UpgradeCodes registry views
+            // — same source `msiexec` ultimately consults — when the pkgsinfo declares
+            // product_code/upgrade_code at the installer level, even with no installs[] array.
+            var msiInstaller = item.Installer;
+            if (msiInstaller != null
+                && string.Equals(msiInstaller.Type, "msi", StringComparison.OrdinalIgnoreCase)
+                && (!string.IsNullOrEmpty(msiInstaller.ProductCode) ||
+                    !string.IsNullOrEmpty(msiInstaller.UpgradeCode)))
             {
-                ConsoleLogger.Debug($"Verifying MSI via installer block item: {item.Name} productCode: {item.Installer.ProductCode} upgradeCode: {item.Installer.UpgradeCode}");
+                ConsoleLogger.Debug($"Verifying MSI via installer block item: {item.Name} productCode: {msiInstaller.ProductCode} upgradeCode: {msiInstaller.UpgradeCode}");
                 var (msiInstalled, msiVersionMatch, msiInstalledVersion) = CheckMsiWithUpgradeCode(
-                    item.Installer.ProductCode, item.Installer.UpgradeCode, item.Version, item.Name);
+                    msiInstaller.ProductCode, msiInstaller.UpgradeCode, item.Version, item.Name);
 
                 if (!msiInstalled)
                 {
-                    ConsoleLogger.Info($"MSI product not installed item: {item.Name} productCode: {item.Installer.ProductCode} upgradeCode: {item.Installer.UpgradeCode}");
+                    ConsoleLogger.Info($"MSI product not installed item: {item.Name} productCode: {msiInstaller.ProductCode} upgradeCode: {msiInstaller.UpgradeCode}");
                     result.Status = "pending";
                     result.NeedsAction = true;
                     result.IsUpdate = HasManagedInstallsEntry(item.Name);
-                    result.Reason = $"MSI not registered in Windows Installer (ProductCode={item.Installer.ProductCode}, UpgradeCode={item.Installer.UpgradeCode})";
+                    result.Reason = $"MSI not registered in Windows Installer (ProductCode={msiInstaller.ProductCode}, UpgradeCode={msiInstaller.UpgradeCode})";
                     result.ReasonCode = StatusReasonCode.ProductCodeMissing;
                     result.DetectionMethod = DetectionMethod.Msi;
                     return result;
@@ -955,13 +957,20 @@ if ($results.Count -gt 0) {{
     // MSI ProductVersion is capped at major.minor.build (255.255.65535), so cimipkg compresses
     // date-based versions like 2026.04.12.2144 into 26.4.1221 to fit. The expanded form is
     // persisted by Cimian to HKLM\SOFTWARE\ManagedInstalls\<Name>\Version after install.
-    // Prefer that when present so logs and version comparisons use the original date string.
+    // Prefer the expanded form only when it compares >= the MSI-reported version, so logs
+    // and comparisons keep the original date string for cimipkg packages, but apps that can
+    // auto-update outside Cimian (Chrome, etc.) still report the live MSI DisplayVersion
+    // instead of a stale Cimian receipt.
     private string ResolveExpandedVersion(string itemName, string msiVersion)
     {
         if (string.IsNullOrEmpty(itemName))
             return msiVersion;
         var expanded = GetManagedInstallsVersion(itemName);
-        return string.IsNullOrEmpty(expanded) ? msiVersion : expanded;
+        if (string.IsNullOrEmpty(expanded))
+            return msiVersion;
+        // CompareVersions returns >0 when first arg is greater. We want expanded only if
+        // expanded >= msiVersion, i.e. CompareVersions(msiVersion, expanded) <= 0.
+        return CatalogService.CompareVersions(msiVersion, expanded) <= 0 ? expanded : msiVersion;
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -211,7 +211,51 @@ public class StatusService
                 return result;
             }
 
-            // Go parity: If no checks are defined and no installs array, 
+            // Priority 6.5: top-level `installer:` block ProductCode/UpgradeCode (MSI authoritative).
+            // The Windows Installer database is the source of truth for MSI install state — query it
+            // directly when the pkgsinfo declares product_code/upgrade_code at the installer level,
+            // even when no installs[] array is present.
+            if (string.Equals(item.Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase)
+                && (!string.IsNullOrEmpty(item.Installer.ProductCode) ||
+                    !string.IsNullOrEmpty(item.Installer.UpgradeCode)))
+            {
+                ConsoleLogger.Debug($"Verifying MSI via installer block item: {item.Name} productCode: {item.Installer.ProductCode} upgradeCode: {item.Installer.UpgradeCode}");
+                var (msiInstalled, msiVersionMatch, msiInstalledVersion) = CheckMsiWithUpgradeCode(
+                    item.Installer.ProductCode, item.Installer.UpgradeCode, item.Version, item.Name);
+
+                if (!msiInstalled)
+                {
+                    ConsoleLogger.Info($"MSI product not installed item: {item.Name} productCode: {item.Installer.ProductCode} upgradeCode: {item.Installer.UpgradeCode}");
+                    result.Status = "pending";
+                    result.NeedsAction = true;
+                    result.IsUpdate = HasManagedInstallsEntry(item.Name);
+                    result.Reason = $"MSI not registered in Windows Installer (ProductCode={item.Installer.ProductCode}, UpgradeCode={item.Installer.UpgradeCode})";
+                    result.ReasonCode = StatusReasonCode.ProductCodeMissing;
+                    result.DetectionMethod = DetectionMethod.Msi;
+                    return result;
+                }
+                if (!msiVersionMatch)
+                {
+                    ConsoleLogger.Info($"MSI version outdated item: {item.Name} installedVersion: {msiInstalledVersion} catalogVersion: {item.Version}");
+                    result.Status = "pending";
+                    result.NeedsAction = true;
+                    result.IsUpdate = true;
+                    result.InstalledVersion = msiInstalledVersion;
+                    result.Reason = $"MSI version outdated: {msiInstalledVersion} -> {item.Version}";
+                    result.ReasonCode = StatusReasonCode.VersionOutdated;
+                    result.DetectionMethod = DetectionMethod.Msi;
+                    return result;
+                }
+                ConsoleLogger.Info($"MSI verification passed - version current or newer item: {item.Name} installedVersion: {msiInstalledVersion} catalogVersion: {item.Version}");
+                result.Status = "installed";
+                result.Reason = $"MSI ProductCode/UpgradeCode match — installed version {msiInstalledVersion}";
+                result.ReasonCode = StatusReasonCode.ProductCodeMatch;
+                result.DetectionMethod = DetectionMethod.Msi;
+                result.InstalledVersion = msiInstalledVersion;
+                return result;
+            }
+
+            // Go parity: If no checks are defined and no installs array,
             // assume item doesn't need action (it may not have verification methods)
             // Don't fall back to ManagedInstalls registry as Go doesn't do this
             ConsoleLogger.Debug($"No file tracking needed - registry/product code verification sufficient item: {item.Name}");
@@ -499,7 +543,7 @@ public class StatusService
                     // This handles auto-updating apps (Chrome, etc.) where ProductCode changes each version
                     var catalogVersion = !string.IsNullOrEmpty(installItem.Version) ? installItem.Version : item.Version;
                     var (msiInstalled, msiVersionMatch, msiInstalledVersion) = CheckMsiWithUpgradeCode(
-                        installItem.ProductCode, installItem.UpgradeCode, catalogVersion);
+                        installItem.ProductCode, installItem.UpgradeCode, catalogVersion, item.Name);
 
                     // If MSI detection failed, try registry lookup using item's display_name or name as fallback
                     // This handles cases where app was installed via EXE instead of MSI (e.g., Chrome auto-update)
@@ -848,14 +892,15 @@ if ($results.Count -gt 0) {{
     /// Returns: (installed, versionMatch, installedVersion)
     /// </summary>
     private (bool installed, bool versionMatch, string? installedVersion) CheckMsiWithUpgradeCode(
-        string? productCode, string? upgradeCode, string catalogVersion)
+        string? productCode, string? upgradeCode, string catalogVersion, string itemName = "")
     {
         // First try ProductCode lookup (faster, exact match)
         if (!string.IsNullOrEmpty(productCode))
         {
-            var (installed, installedVersion) = CheckMsiProductWithVersion(productCode);
-            if (installed && !string.IsNullOrEmpty(installedVersion))
+            var (installed, msiVersion) = CheckMsiProductWithVersion(productCode);
+            if (installed && !string.IsNullOrEmpty(msiVersion))
             {
+                var installedVersion = ResolveExpandedVersion(itemName, msiVersion);
                 ConsoleLogger.Debug($"Found MSI via ProductCode productCode: {productCode} installedVersion: {installedVersion}");
 
                 if (string.IsNullOrEmpty(catalogVersion))
@@ -879,9 +924,10 @@ if ($results.Count -gt 0) {{
         // ProductCode not found - try UpgradeCode (handles auto-updated apps)
         if (!string.IsNullOrEmpty(upgradeCode))
         {
-            var (installed, installedVersion) = FindMsiByUpgradeCode(upgradeCode);
-            if (installed && !string.IsNullOrEmpty(installedVersion))
+            var (installed, msiVersion) = FindMsiByUpgradeCode(upgradeCode);
+            if (installed && !string.IsNullOrEmpty(msiVersion))
             {
+                var installedVersion = ResolveExpandedVersion(itemName, msiVersion);
                 ConsoleLogger.Debug($"Found MSI via UpgradeCode upgradeCode: {upgradeCode} installedVersion: {installedVersion}");
 
                 if (string.IsNullOrEmpty(catalogVersion))
@@ -904,6 +950,18 @@ if ($results.Count -gt 0) {{
 
         ConsoleLogger.Debug($"MSI not found via ProductCode or UpgradeCode productCode: {productCode} upgradeCode: {upgradeCode}");
         return (false, false, null);
+    }
+
+    // MSI ProductVersion is capped at major.minor.build (255.255.65535), so cimipkg compresses
+    // date-based versions like 2026.04.12.2144 into 26.4.1221 to fit. The expanded form is
+    // persisted by Cimian to HKLM\SOFTWARE\ManagedInstalls\<Name>\Version after install.
+    // Prefer that when present so logs and version comparisons use the original date string.
+    private string ResolveExpandedVersion(string itemName, string msiVersion)
+    {
+        if (string.IsNullOrEmpty(itemName))
+            return msiVersion;
+        var expanded = GetManagedInstallsVersion(itemName);
+        return string.IsNullOrEmpty(expanded) ? msiVersion : expanded;
     }
 
     /// <summary>

--- a/tests/Managedsoftwareupdate/StatusServiceTests.cs
+++ b/tests/Managedsoftwareupdate/StatusServiceTests.cs
@@ -247,6 +247,79 @@ public class StatusServiceTests
 
     #endregion
 
+    #region MSI installer-block ProductCode/UpgradeCode Tests (Priority 6.5)
+
+    [Fact]
+    public void CheckStatus_MsiInstaller_WithFakeProductCode_ReportsProductCodeMissing()
+    {
+        // Priority 6.5: pkginfo declares installer.product_code on an MSI but the GUID
+        // is not registered with Windows Installer. Before the fix this fell through to
+        // NoChecks (silently "installed"); now it must surface as Pending with
+        // ProductCodeMissing so the package gets installed.
+        var item = new CatalogItem
+        {
+            Name = "TestPkgWithFakeProductCode",
+            Version = "1.0.0",
+            Installer = new InstallerInfo
+            {
+                Type = "msi",
+                ProductCode = "{00000000-0000-0000-0000-000000000000}",
+                UpgradeCode = "{11111111-1111-1111-1111-111111111111}"
+            }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.Equal("pending", result.Status);
+        Assert.True(result.NeedsAction);
+        Assert.Equal(Cimian.Core.Models.StatusReasonCode.ProductCodeMissing, result.ReasonCode);
+        Assert.Equal(Cimian.Core.Models.DetectionMethod.Msi, result.DetectionMethod);
+    }
+
+    [Fact]
+    public void CheckStatus_MsiInstaller_WithoutProductCodeOrUpgradeCode_FallsThroughToNoChecks()
+    {
+        // Regression guard: an MSI pkginfo that doesn't declare product_code/upgrade_code
+        // should keep the existing "no checks" fall-through behavior — Priority 6.5 only
+        // engages when authoritative MSI identity is provided.
+        var item = new CatalogItem
+        {
+            Name = "MsiWithoutCodes",
+            Version = "1.0.0",
+            Installer = new InstallerInfo { Type = "msi" }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.Equal("installed", result.Status);
+        Assert.False(result.NeedsAction);
+        Assert.Equal(Cimian.Core.Models.StatusReasonCode.NoChecks, result.ReasonCode);
+    }
+
+    [Fact]
+    public void CheckStatus_NonMsiInstaller_WithProductCodeIsIgnored()
+    {
+        // Priority 6.5 is gated on installer.type == "msi". A pkg/exe/script item that
+        // happens to carry a product_code (unusual, but possible) must not be routed
+        // through the MSI registry lookup.
+        var item = new CatalogItem
+        {
+            Name = "PkgWithProductCode",
+            Version = "1.0.0",
+            Installer = new InstallerInfo
+            {
+                Type = "pkg",
+                ProductCode = "{00000000-0000-0000-0000-000000000000}"
+            }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.NotEqual(Cimian.Core.Models.DetectionMethod.Msi, result.DetectionMethod);
+    }
+
+    #endregion
+
     #region Script Check Tests
 
     [Fact]

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -139,6 +139,59 @@ public class UpdateModelsTests
         Assert.False(item.IsUninstallable());
     }
 
+    [Fact]
+    public void CatalogItem_IsUninstallable_MsiInstallerWithProductCode_ReturnsTrue()
+    {
+        // Self-uninstallable MSI: no uninstaller block, but installer.product_code is
+        // enough — UninstallAsync synthesizes msiexec /x from it.
+        var item = new CatalogItem
+        {
+            Uninstallable = true,
+            Uninstaller = [],
+            Installer = new InstallerInfo
+            {
+                Type = "msi",
+                ProductCode = "{12345678-1234-1234-1234-123456789012}"
+            }
+        };
+
+        Assert.True(item.IsUninstallable());
+    }
+
+    [Fact]
+    public void CatalogItem_IsUninstallable_MsiInstallerWithoutProductCode_ReturnsFalse()
+    {
+        // An MSI installer with no product_code can't be uninstalled — we have nothing
+        // to feed msiexec /x.
+        var item = new CatalogItem
+        {
+            Uninstallable = true,
+            Uninstaller = [],
+            Installer = new InstallerInfo { Type = "msi" }
+        };
+
+        Assert.False(item.IsUninstallable());
+    }
+
+    [Fact]
+    public void CatalogItem_IsUninstallable_NonMsiWithProductCode_ReturnsFalse()
+    {
+        // The MSI synthesis clause is gated on installer.type == "msi". A pkg/exe
+        // pkginfo that happens to carry a product_code (unusual) does not qualify.
+        var item = new CatalogItem
+        {
+            Uninstallable = true,
+            Uninstaller = [],
+            Installer = new InstallerInfo
+            {
+                Type = "pkg",
+                ProductCode = "{12345678-1234-1234-1234-123456789012}"
+            }
+        };
+
+        Assert.False(item.IsUninstallable());
+    }
+
     #endregion
 
     #region InstallerInfo Tests

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -154,6 +154,8 @@ public class UpdateModelsTests
         Assert.Empty(installer.Args);
         Assert.Null(installer.Hash);
         Assert.Null(installer.Size);
+        Assert.Null(installer.ProductCode);
+        Assert.Null(installer.UpgradeCode);
     }
 
     [Fact]
@@ -165,7 +167,9 @@ public class UpdateModelsTests
             Type = "msi",
             Hash = "abc123def456",
             Size = 1024000,
-            Args = ["/qn", "/norestart"]
+            Args = ["/qn", "/norestart"],
+            ProductCode = "{12345678-1234-1234-1234-123456789012}",
+            UpgradeCode = "{abcdef01-2345-6789-abcd-ef0123456789}"
         };
 
         Assert.Equal("apps/myapp/myapp-1.0.0.msi", installer.Location);
@@ -173,6 +177,29 @@ public class UpdateModelsTests
         Assert.Equal("abc123def456", installer.Hash);
         Assert.Equal(1024000, installer.Size);
         Assert.Equal(2, installer.Args.Count);
+        Assert.Equal("{12345678-1234-1234-1234-123456789012}", installer.ProductCode);
+        Assert.Equal("{abcdef01-2345-6789-abcd-ef0123456789}", installer.UpgradeCode);
+    }
+
+    [Fact]
+    public void InstallerInfo_DeserializesProductCodeAndUpgradeCodeFromYaml()
+    {
+        var yaml = """
+            type: msi
+            location: apps/myapp/myapp-1.0.0.msi
+            product_code: '{12345678-1234-1234-1234-123456789012}'
+            upgrade_code: '{abcdef01-2345-6789-abcd-ef0123456789}'
+            """;
+
+        var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        var installer = deserializer.Deserialize<InstallerInfo>(yaml);
+
+        Assert.Equal("msi", installer.Type);
+        Assert.Equal("{12345678-1234-1234-1234-123456789012}", installer.ProductCode);
+        Assert.Equal("{abcdef01-2345-6789-abcd-ef0123456789}", installer.UpgradeCode);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

cimipkg-built MSI pkginfos already carry the ProductCode in `installer.product_code` (see #10). `msiexec /x` needs the same GUID — there is no reason to require a hand-rolled `uninstaller:` block in every YAML for the same fact, and today listing a cimipkg MSI under `managed_uninstalls` silently does nothing because `CatalogItem.IsUninstallable()` returns false for it.

## Changes

- **`cli/managedsoftwareupdate/Models/UpdateModels.cs`** — extend `CatalogItem.IsUninstallable()` to return `true` when `installer.type == "msi"` and `installer.product_code` is non-empty. Mirrors the existing self-uninstallable MSIX clause.
- **`cli/managedsoftwareupdate/Services/InstallerService.cs`** — when no `uninstaller:` block and no `uninstall_script` are declared, synthesize an `UninstallerInfo { Type = "msi", ProductCode = ... }` from `installer.product_code` and call `UninstallMsiAsync`. Mirrors the existing MSIX synthesis pattern below it in the same method.

## Test plan

Verified end-to-end on a live device with `--local-only-manifest`:

```yaml
name: test-msi-uninstall
catalogs: [Production]
managed_uninstalls:
- TaskbarUtil
- AudioInputPrefs
```

- [x] Both items had **no `uninstaller:` block** in their pkginfos — only `installer.product_code`
- [x] Cimian resolved the action correctly: `Pending actions: 2 (0 installs, 0 updates, 2 removals)`
- [x] Synthesized `msiexec.exe /x {6ffbde58-…} /qn /norestart` and `msiexec.exe /x {0173e13b-…} /qn /norestart` — both exited 0
- [x] `HKLM\…\Uninstall\{ProductCode}` and `HKLM\SOFTWARE\ManagedInstalls\<Name>` were both cleaned up
- [x] Subsequent `--auto` against the regular server manifest reinstalled both cleanly (round-trip verified)

## Dependencies

This builds on #10 — the `installer.product_code` field on `InstallerInfo` is introduced there. PR base is set to `fix/msi-product-code-status-detection` so the diff stays minimal; rebase to `main` after #10 lands.