### PR TITLE
cimiimport: stop rewriting semver as date versions

### DIFF
--- a/cli/cimiimport/Services/MetadataExtractor.cs
+++ b/cli/cimiimport/Services/MetadataExtractor.cs
@@ -502,85 +502,16 @@ public partial class MetadataExtractor
     }
 
     /// <summary>
-    /// Normalizes version string, handling date-based versions.
+    /// Returns the version string as-is. Date detection was removed because it
+    /// repeatedly mis-identified semver releases like "5.2.1" as "2005.02.01"
+    /// (any major < 100 with minor in 1-12 and patch in 1-31 collided with the
+    /// Chocolatey-truncated date heuristic, and even genuine semvers starting
+    /// with 2000-2100 were rewritten). Installers that already publish their
+    /// version as a real date string keep that format unchanged here.
     /// </summary>
     public static string ParseVersion(string? versionStr)
     {
-        if (string.IsNullOrEmpty(versionStr))
-            return versionStr ?? "";
-
-        var parts = versionStr.Split('.');
-        if (parts.Length < 3 || parts.Length > 4)
-            return versionStr;
-
-        // Try to parse as date format
-        if (int.TryParse(parts[0], out var yearNum))
-        {
-            bool isDateFormat = false;
-
-            // Full 4-digit years
-            if (yearNum is >= 2000 and <= 2100)
-            {
-                isDateFormat = true;
-            }
-            // Chocolatey-truncated 2-digit years
-            else if (yearNum is >= 0 and <= 99)
-            {
-                if (int.TryParse(parts[1], out var monthNum) && monthNum is >= 1 and <= 12 &&
-                    int.TryParse(parts[2], out var dayNum) && dayNum is >= 1 and <= 31)
-                {
-                    isDateFormat = true;
-                }
-            }
-
-            if (isDateFormat)
-            {
-                // Validate all parts are numeric
-                var numericParts = new List<int>();
-                bool allNumeric = true;
-                foreach (var part in parts)
-                {
-                    if (int.TryParse(part, out var num))
-                    {
-                        numericParts.Add(num);
-                    }
-                    else
-                    {
-                        allNumeric = false;
-                        break;
-                    }
-                }
-
-                if (allNumeric && numericParts.Count >= 3)
-                {
-                    var year = numericParts[0];
-                    var month = numericParts[1];
-                    var day = numericParts[2];
-
-                    // Convert 2-digit year to 4-digit year
-                    if (year < 100)
-                    {
-                        year = year <= 50 ? 2000 + year : 1900 + year;
-                    }
-
-                    if (numericParts.Count == 4)
-                    {
-                        // Preserve the original 4th segment string to keep leading zeros
-                        // (e.g. "0838" HHMM timestamps must not become "838"). Month and day
-                        // are still zero-padded from parsed ints so "2026.4.9.0838" normalizes
-                        // to "2026.04.09.0838". Trim incidental whitespace (CR/LF, spaces)
-                        // that int.TryParse accepts but shouldn't bleed into the output.
-                        return $"{year}.{month:D2}.{day:D2}.{parts[3].Trim()}";
-                    }
-                    else
-                    {
-                        return $"{year}.{month:D2}.{day:D2}";
-                    }
-                }
-            }
-        }
-
-        return versionStr;
+        return versionStr ?? "";
     }
 
     /// <summary>

--- a/cli/cimiimport/Services/MetadataExtractor.cs
+++ b/cli/cimiimport/Services/MetadataExtractor.cs
@@ -502,12 +502,14 @@ public partial class MetadataExtractor
     }
 
     /// <summary>
-    /// Returns the version string as-is. Date detection was removed because it
-    /// repeatedly mis-identified semver releases like "5.2.1" as "2005.02.01"
-    /// (any major < 100 with minor in 1-12 and patch in 1-31 collided with the
-    /// Chocolatey-truncated date heuristic, and even genuine semvers starting
-    /// with 2000-2100 were rewritten). Installers that already publish their
-    /// version as a real date string keep that format unchanged here.
+    /// Returns the version string unchanged, or an empty string if
+    /// <paramref name="versionStr"/> is null. Date detection was removed
+    /// because it repeatedly mis-identified semver releases like "5.2.1"
+    /// as "2005.02.01" (any major &lt; 100 with minor in 1-12 and patch in
+    /// 1-31 collided with the Chocolatey-truncated date heuristic, and
+    /// even genuine semvers starting with 2000-2100 were rewritten).
+    /// Installers that already publish their version as a real date string
+    /// keep that format unchanged here.
     /// </summary>
     public static string ParseVersion(string? versionStr)
     {

--- a/tests/CLI/Cimiimport/MetadataExtractorTests.cs
+++ b/tests/CLI/Cimiimport/MetadataExtractorTests.cs
@@ -64,20 +64,15 @@ public class MetadataExtractorTests
         Assert.Equal(expected, result);
     }
 
-    [Fact]
-    public void ParseVersion_HandlesSingleDateComponents()
+    [Theory]
+    [InlineData("5.2.1")]          // semver previously misread as 2005.02.01
+    [InlineData("2024.1.5")]       // genuine date kept verbatim, no zero-padding
+    [InlineData("2026.4.9.0838")]  // 4-part date+timestamp passes through
+    [InlineData("1.0.0")]          // plain semver
+    public void ParseVersion_PassesVersionsThroughUnchanged(string version)
     {
-        // Single digit month/day should be zero-padded for date-like versions
-        var result = MetadataExtractor.ParseVersion("2024.1.5");
-        Assert.Equal("2024.01.05", result);
-    }
-
-    [Fact]
-    public void ParseVersion_Returns3PartVersions()
-    {
-        // 3-part non-date versions
-        var result = MetadataExtractor.ParseVersion("1.0.0");
-        Assert.Equal("1.0.0", result);
+        var result = MetadataExtractor.ParseVersion(version);
+        Assert.Equal(version, result);
     }
 
     [Fact]
@@ -197,8 +192,6 @@ public class MetadataExtractorTests
         try
         {
             var msixPath = Path.Combine(tempDir, "TestApp.msix");
-            // Version 4.45.69.0 mirrors real Slack MSIX and avoids the ParseVersion
-            // date-format heuristic (which would rewrite 2.5.1.0 → 2002.05.01.0).
             await WriteMsixFixtureAsync(msixPath, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
   <Identity Name=""com.example.testapp"" Version=""4.45.69.0"" ProcessorArchitecture=""x64"" Publisher=""CN=Example Corp"" />


### PR DESCRIPTION
## Summary
- `MetadataExtractor.ParseVersion` treated any 3-part version with major `<100`, minor `1-12`, patch `1-31` as a Chocolatey-truncated date, so semvers like `5.2.1` were written to pkginfo as `2005.02.01` (reproduced importing `sonic-visualiser-5.2.1-win64.msi`). The 4-digit-year branch was similarly risky for legitimate semvers starting `2000-2100`.
- Removed the date heuristic entirely. `ParseVersion` now passes installer-reported version strings through verbatim. Installers that genuinely publish a date string (e.g. `2026.04.29`) keep it as-is; they no longer need a normalization pass.
- Updated `MetadataExtractorTests` to pin passthrough behavior, including the regressing `5.2.1` case and a 4-part date+timestamp.

## Test plan
- [x] `dotnet build cli/cimiimport/Cimian.CLI.cimiimport.csproj` — clean
- [x] `dotnet test tests/Cimian.Tests.csproj --filter MetadataExtractorTests` — 56/56 pass
- [ ] Smoke: re-run the `sonic-visualiser-5.2.1-win64.msi` import and confirm version stays `5.2.1`