### PR TITLE
UpdateEngine: exclude unsubscribed-catalog items from status tables

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1882,10 +1882,11 @@ public class UpdateEngine : IDisposable
     }
 
     /// <summary>
-    /// Returns only manifest items resolvable in this device's catalog set, and emits an
-    /// INFO log for each item that's in the manifest but missing from every catalog the
-    /// device subscribes to. Items in unsubscribed catalogs are excluded from display
-    /// because the device cannot act on them.
+    /// Returns only manifest items present in the loaded catalog map for this device,
+    /// and emits an INFO log for each item that's in the manifest but absent from that
+    /// map. The map is built by <see cref="CatalogService.LoadCatalogsAsync"/>, which
+    /// includes only items from the device's subscribed catalogs that also pass the
+    /// architecture filter — both reasons can cause exclusion here.
     /// </summary>
     private List<ManifestItem> FilterToDeviceCatalog(
         List<ManifestItem> items,
@@ -1895,16 +1896,19 @@ public class UpdateEngine : IDisposable
         var inCatalog = new List<ManifestItem>(items.Count);
         foreach (var item in items)
         {
-            if (catalogMap.ContainsKey(item.Name.ToLowerInvariant()))
+            if (catalogMap.TryGetValue(item.Name, out _))
             {
                 inCatalog.Add(item);
             }
             else
             {
-                var catalogList = _config.Catalogs.Count > 0
-                    ? string.Join(", ", _config.Catalogs)
-                    : "(none configured)";
-                LogInfo($"{sectionLabel}: '{item.Name}' is in the manifest but not in this device's catalog(s) [{catalogList}] — excluded from display");
+                // Mirror CatalogService.LoadCatalogsAsync defaulting: empty config
+                // resolves to ["Production"] at load time, so report that here too.
+                var effectiveCatalogs = _config.Catalogs.Count > 0
+                    ? _config.Catalogs
+                    : new List<string> { "Production" };
+                var catalogList = string.Join(", ", effectiveCatalogs);
+                LogInfo($"{sectionLabel}: '{item.Name}' is in the manifest but not in this device's loaded catalog(s) [{catalogList}] — excluded from display");
             }
         }
         return inCatalog;
@@ -1926,8 +1930,14 @@ public class UpdateEngine : IDisposable
 
         if (managedInstalls.Count == 0) return;
 
-        managedInstalls = FilterToDeviceCatalog(managedInstalls, catalogMap, "MANAGED INSTALLS");
-        if (managedInstalls.Count == 0) return;
+        // Only filter when a catalog map was actually loaded. An empty map (e.g.
+        // catalog download failed) keeps the prior behavior of showing the section
+        // rather than silently hiding everything.
+        if (catalogMap.Count > 0)
+        {
+            managedInstalls = FilterToDeviceCatalog(managedInstalls, catalogMap, "MANAGED INSTALLS");
+            if (managedInstalls.Count == 0) return;
+        }
 
         // Build status for each item
         var packageStatuses = new List<(string Name, string Version, string Status)>();
@@ -2007,8 +2017,11 @@ public class UpdateEngine : IDisposable
 
         if (managedUpdates.Count == 0) return;
 
-        managedUpdates = FilterToDeviceCatalog(managedUpdates, catalogMap, "MANAGED UPDATES");
-        if (managedUpdates.Count == 0) return;
+        if (catalogMap.Count > 0)
+        {
+            managedUpdates = FilterToDeviceCatalog(managedUpdates, catalogMap, "MANAGED UPDATES");
+            if (managedUpdates.Count == 0) return;
+        }
 
         // Build status for each item
         var packageStatuses = new List<(string Name, string Version, string Status)>();
@@ -2074,8 +2087,11 @@ public class UpdateEngine : IDisposable
 
         if (managedUninstalls.Count == 0) return;
 
-        managedUninstalls = FilterToDeviceCatalog(managedUninstalls, catalogMap, "MANAGED UNINSTALLS");
-        if (managedUninstalls.Count == 0) return;
+        if (catalogMap.Count > 0)
+        {
+            managedUninstalls = FilterToDeviceCatalog(managedUninstalls, catalogMap, "MANAGED UNINSTALLS");
+            if (managedUninstalls.Count == 0) return;
+        }
 
         // Build status for each item
         var packageStatuses = new List<(string Name, string Version, string Status)>();

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1880,7 +1880,36 @@ public class UpdateEngine : IDisposable
             PrintManifestTree(node.Children[childNames[i]], childPrefix, i == childNames.Count - 1, packages);
         }
     }
-    
+
+    /// <summary>
+    /// Returns only manifest items resolvable in this device's catalog set, and emits an
+    /// INFO log for each item that's in the manifest but missing from every catalog the
+    /// device subscribes to. Items in unsubscribed catalogs are excluded from display
+    /// because the device cannot act on them.
+    /// </summary>
+    private List<ManifestItem> FilterToDeviceCatalog(
+        List<ManifestItem> items,
+        Dictionary<string, CatalogItem> catalogMap,
+        string sectionLabel)
+    {
+        var inCatalog = new List<ManifestItem>(items.Count);
+        foreach (var item in items)
+        {
+            if (catalogMap.ContainsKey(item.Name.ToLowerInvariant()))
+            {
+                inCatalog.Add(item);
+            }
+            else
+            {
+                var catalogList = _config.Catalogs.Count > 0
+                    ? string.Join(", ", _config.Catalogs)
+                    : "(none configured)";
+                LogInfo($"{sectionLabel}: '{item.Name}' is in the manifest but not in this device's catalog(s) [{catalogList}] — excluded from display");
+            }
+        }
+        return inCatalog;
+    }
+
     /// <summary>
     /// Prints the managed installs status table - matches Go output
     /// </summary>
@@ -1894,9 +1923,12 @@ public class UpdateEngine : IDisposable
         var managedInstalls = manifestItems
             .Where(m => m.Action?.ToLowerInvariant() == "install")
             .ToList();
-        
+
         if (managedInstalls.Count == 0) return;
-        
+
+        managedInstalls = FilterToDeviceCatalog(managedInstalls, catalogMap, "MANAGED INSTALLS");
+        if (managedInstalls.Count == 0) return;
+
         // Build status for each item
         var packageStatuses = new List<(string Name, string Version, string Status)>();
         var toInstallNames = toInstall.Select(i => i.Name.ToLowerInvariant()).ToHashSet();
@@ -1972,9 +2004,12 @@ public class UpdateEngine : IDisposable
         var managedUpdates = manifestItems
             .Where(m => m.Action?.ToLowerInvariant() == "update")
             .ToList();
-        
+
         if (managedUpdates.Count == 0) return;
-        
+
+        managedUpdates = FilterToDeviceCatalog(managedUpdates, catalogMap, "MANAGED UPDATES");
+        if (managedUpdates.Count == 0) return;
+
         // Build status for each item
         var packageStatuses = new List<(string Name, string Version, string Status)>();
         var toUpdateNames = toUpdate.Select(i => i.Name.ToLowerInvariant()).ToHashSet();
@@ -2036,9 +2071,12 @@ public class UpdateEngine : IDisposable
         var managedUninstalls = manifestItems
             .Where(m => m.Action?.ToLowerInvariant() == "uninstall")
             .ToList();
-        
+
         if (managedUninstalls.Count == 0) return;
-        
+
+        managedUninstalls = FilterToDeviceCatalog(managedUninstalls, catalogMap, "MANAGED UNINSTALLS");
+        if (managedUninstalls.Count == 0) return;
+
         // Build status for each item
         var packageStatuses = new List<(string Name, string Version, string Status)>();
         var toUninstallNames = toUninstall.Select(i => i.Name.ToLowerInvariant()).ToHashSet();


### PR DESCRIPTION
## Summary

Manifest items whose pkginfo lives only in catalogs the device does **not** subscribe to were being rendered with version `Unknown` in the `MANAGED INSTALLS`, `MANAGED UPDATES`, and `MANAGED UNINSTALLS` status tables. The device can't act on those items at all (they don't exist in any catalog it pulls), so showing them as `Installed | Unknown` is misleading.

Now they're filtered out of the tables, and one `INFO` line is emitted per excluded item naming the device's catalog set, e.g.:

```
INFO  MANAGED INSTALLS: 'TerminalPrefs' is in the manifest but not in this device's catalog(s) [Production] — excluded from display
```

## Background

Real-world example surfaced this: a device on `catalogs: [Production]` had `TerminalPrefs` (in `Testing`/`All` only) and `AmdAdrenalinDriver` (in `Testing`/`Development` only) referenced from its merged manifest. Both rendered as `Unknown`. The fix is in display logic — pkginfo-to-catalog promotion is a separate concern.

## Changes

`cli/managedsoftwareupdate/Services/UpdateEngine.cs`:
- New `FilterToDeviceCatalog(items, catalogMap, sectionLabel)` helper: returns only items present in `catalogMap`, logs `INFO` for each excluded item.
- Wired into `PrintManagedInstallsTable`, `PrintManagedUpdatesTable`, `PrintManagedUninstallsTable`.

## Test plan

- [ ] `dotnet build cli/managedsoftwareupdate/Cimian.CLI.managedsoftwareupdate.csproj -c Release` — passes locally
- [ ] Run `managedsoftwareupdate.exe -v --checkonly` on a device whose manifest references a package not in its subscribed catalog; confirm:
  - The package no longer appears in the `MANAGED INSTALLS` table.
  - One `INFO` line is logged naming the package and the device's catalog list.
  - Item count in the section header reflects the filtered total.
- [ ] Run on a device with no such mismatch; confirm tables and counts are unchanged.