### PR TITLE
ManifestService: Munki-parity action precedence in dedup

### DIFF
--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -658,9 +658,17 @@ public class ManifestService
     }
 
     /// <summary>
-    /// Deduplicates manifest items, keeping the highest version for each item name.
-    /// Go parity: pkg/status.DeduplicateManifestItems - uses just name as key,
-    /// keeps highest version if duplicate found, preserves original order.
+    /// Deduplicates manifest items by name. When the same name appears with
+    /// different actions across the manifest tree, the strongest action wins
+    /// regardless of encounter order — matching Munki's behavior where an item
+    /// listed in both managed_installs and optional_installs is treated as a
+    /// managed install.
+    ///
+    /// Action precedence (highest to lowest):
+    ///   install &gt; uninstall &gt; update &gt; optional &gt; profile &gt; app
+    ///
+    /// Within the same action, the highest version wins; otherwise the first
+    /// occurrence's position is preserved.
     /// </summary>
     public List<ManifestItem> DeduplicateItems(List<ManifestItem> items)
     {
@@ -673,24 +681,31 @@ public class ManifestService
                 continue;
 
             var key = item.Name.ToLowerInvariant();
-            
+
             if (dedup.TryGetValue(key, out var existing))
             {
-                // If we find a newer version, update it but keep the original position
-                if (IsOlderVersion(existing.Version, item.Version))
+                var existingRank = ActionPrecedence(existing.Action);
+                var incomingRank = ActionPrecedence(item.Action);
+
+                if (incomingRank > existingRank)
                 {
+                    // Stronger action supersedes (e.g. install supersedes optional)
                     dedup[key] = item;
                 }
+                else if (incomingRank == existingRank && IsOlderVersion(existing.Version, item.Version))
+                {
+                    // Same action, prefer the newer version
+                    dedup[key] = item;
+                }
+                // Otherwise keep the existing entry
             }
             else
             {
-                // First time seeing this item - track its order
                 orderedKeys.Add(key);
                 dedup[key] = item;
             }
         }
 
-        // Build result in the original order items were first encountered
         var result = new List<ManifestItem>();
         foreach (var key in orderedKeys)
         {
@@ -698,6 +713,22 @@ public class ManifestService
         }
         return result;
     }
+
+    /// <summary>
+    /// Ranks manifest actions by precedence so that stronger directives win
+    /// when the same item name appears with conflicting actions across
+    /// included manifests. Higher number = stronger directive.
+    /// </summary>
+    private static int ActionPrecedence(string? action) => action?.ToLowerInvariant() switch
+    {
+        "install" => 5,
+        "uninstall" => 4,
+        "update" => 3,
+        "optional" => 2,
+        "profile" => 1,
+        "app" => 1,
+        _ => 0,
+    };
 
     /// <summary>
     /// Compare versions to determine if v1 is older than v2.

--- a/tests/Managedsoftwareupdate/ManifestServiceTests.cs
+++ b/tests/Managedsoftwareupdate/ManifestServiceTests.cs
@@ -1,0 +1,171 @@
+using Xunit;
+using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.CLI.managedsoftwareupdate.Services;
+using Cimian.Core;
+
+namespace Cimian.Tests.Managedsoftwareupdate;
+
+/// <summary>
+/// Tests for ManifestService - in particular the action-precedence rules
+/// applied during deduplication, which are how Cimian matches Munki's behavior
+/// for items listed in multiple manifest sections.
+/// </summary>
+public class ManifestServiceTests
+{
+    private static ManifestService CreateService() => new(new CimianConfig());
+
+    [Fact]
+    public void DeduplicateItems_ManagedInstallSupersedesOptional_RegardlessOfOrder()
+    {
+        var service = CreateService();
+
+        // Optional encountered first (e.g. via Staff.yaml), install encountered
+        // later (via CoreApps). Install must win.
+        var items = new List<ManifestItem>
+        {
+            new() { Name = "PowerShell", Action = "optional", SourceManifest = "Staff" },
+            new() { Name = "PowerShell", Action = "install", SourceManifest = "CoreApps" },
+        };
+
+        var result = service.DeduplicateItems(items);
+
+        var entry = Assert.Single(result);
+        Assert.Equal("install", entry.Action);
+        Assert.Equal("CoreApps", entry.SourceManifest);
+    }
+
+    [Fact]
+    public void DeduplicateItems_ManagedInstallSupersedesOptional_WhenInstallEncounteredFirst()
+    {
+        var service = CreateService();
+
+        var items = new List<ManifestItem>
+        {
+            new() { Name = "PowerShell", Action = "install", SourceManifest = "CoreApps" },
+            new() { Name = "PowerShell", Action = "optional", SourceManifest = "Staff" },
+        };
+
+        var result = service.DeduplicateItems(items);
+
+        var entry = Assert.Single(result);
+        Assert.Equal("install", entry.Action);
+        Assert.Equal("CoreApps", entry.SourceManifest);
+    }
+
+    [Fact]
+    public void DeduplicateItems_UninstallSupersedesOptionalAndUpdate()
+    {
+        var service = CreateService();
+
+        var items = new List<ManifestItem>
+        {
+            new() { Name = "LegacyApp", Action = "optional", SourceManifest = "OldOptional" },
+            new() { Name = "LegacyApp", Action = "update", SourceManifest = "Updates" },
+            new() { Name = "LegacyApp", Action = "uninstall", SourceManifest = "Cleanup" },
+        };
+
+        var result = service.DeduplicateItems(items);
+
+        var entry = Assert.Single(result);
+        Assert.Equal("uninstall", entry.Action);
+        Assert.Equal("Cleanup", entry.SourceManifest);
+    }
+
+    [Fact]
+    public void DeduplicateItems_InstallSupersedesUninstall()
+    {
+        var service = CreateService();
+
+        // install outranks uninstall — admin's "this should be present" wins over
+        // a stale "remove this" listing.
+        var items = new List<ManifestItem>
+        {
+            new() { Name = "FleetTool", Action = "uninstall", SourceManifest = "Cleanup" },
+            new() { Name = "FleetTool", Action = "install", SourceManifest = "CoreApps" },
+        };
+
+        var result = service.DeduplicateItems(items);
+
+        var entry = Assert.Single(result);
+        Assert.Equal("install", entry.Action);
+    }
+
+    [Fact]
+    public void DeduplicateItems_SameAction_PrefersHigherVersion()
+    {
+        var service = CreateService();
+
+        var items = new List<ManifestItem>
+        {
+            new() { Name = "Tool", Action = "install", Version = "1.0.0", SourceManifest = "A" },
+            new() { Name = "Tool", Action = "install", Version = "2.0.0", SourceManifest = "B" },
+        };
+
+        var result = service.DeduplicateItems(items);
+
+        var entry = Assert.Single(result);
+        Assert.Equal("2.0.0", entry.Version);
+    }
+
+    [Fact]
+    public void DeduplicateItems_PreservesFirstOccurrenceOrdering()
+    {
+        var service = CreateService();
+
+        var items = new List<ManifestItem>
+        {
+            new() { Name = "Alpha", Action = "install" },
+            new() { Name = "Beta", Action = "install" },
+            new() { Name = "Alpha", Action = "optional" }, // does not displace; keep position 0
+            new() { Name = "Gamma", Action = "install" },
+        };
+
+        var result = service.DeduplicateItems(items);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal("Alpha", result[0].Name);
+        Assert.Equal("install", result[0].Action);
+        Assert.Equal("Beta", result[1].Name);
+        Assert.Equal("Gamma", result[2].Name);
+    }
+
+    [Fact]
+    public void DeduplicateItems_StrongerActionRetainsOriginalPosition()
+    {
+        var service = CreateService();
+
+        // Optional is encountered first (claims position 0). When the install
+        // later supersedes it, the result still occupies position 0.
+        var items = new List<ManifestItem>
+        {
+            new() { Name = "PowerShell", Action = "optional", SourceManifest = "Staff" },
+            new() { Name = "Teams", Action = "install", SourceManifest = "CoreApps" },
+            new() { Name = "PowerShell", Action = "install", SourceManifest = "CoreApps" },
+        };
+
+        var result = service.DeduplicateItems(items);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("PowerShell", result[0].Name);
+        Assert.Equal("install", result[0].Action);
+        Assert.Equal("CoreApps", result[0].SourceManifest);
+        Assert.Equal("Teams", result[1].Name);
+    }
+
+    [Fact]
+    public void DeduplicateItems_IgnoresEmptyNames()
+    {
+        var service = CreateService();
+
+        var items = new List<ManifestItem>
+        {
+            new() { Name = "", Action = "install" },
+            new() { Name = "Real", Action = "install" },
+        };
+
+        var result = service.DeduplicateItems(items);
+
+        Assert.Single(result);
+        Assert.Equal("Real", result[0].Name);
+    }
+}


### PR DESCRIPTION
## Summary
- Items appearing in multiple manifest sections now resolve to the strongest action **regardless of encounter order**, matching Munki's behavior where `managed_installs` supersedes `optional_installs`.
- Precedence: `install` > `uninstall` > `update` > `optional` > `profile`/`app`. Same-action collisions still fall through to the existing version comparison.
- Adds `ManifestServiceTests` covering each precedence rule plus position preservation and version-tiebreak behavior.

## Why
On a real device run, `PowerShell` and `VisualStudioCode` were silently dropped from the install set. Both are listed in `CoreApps.yaml` under `managed_installs` *and* in `Assigned/Staff.yaml` under `optional_installs`. The previous `DeduplicateItems` keyed only on item name and kept whichever entry was encountered first — so the `optional` entry from Staff was shadowing the `install` entry from CoreApps, and `PrintManifestHierarchy` (which only displays `Action == "install"`) showed `CoreApps [1 items]` with just `Teams`.

Munki accumulates each manifest list separately and treats `managed_installs` as authoritative when the same name appears as optional. This change reproduces that effect inside Cimian's flat `List<ManifestItem>` model by promoting the stronger action during deduplication.

## Test plan
- [x] `dotnet test tests/Cimian.Tests.csproj --filter ManifestServiceTests` — 8 new tests pass
- [x] Full suite: 609 pass / 1 pre-existing failure (`InstallAsync_ScriptOnlyItem_Succeeds`) confirmed to fail on `main` before this change, unrelated
- [ ] Verify on a real device that `PowerShell` and `VisualStudioCode` now appear under `CoreApps` in the manifest hierarchy and are scheduled to install

## Follow-up (separate from this PR, in the deployment repo)
`PowerShell` and `VisualStudioCode` are listed in both `Assigned/Staff.yaml` and `Assigned/Faculty.yaml` `optional_installs` while already being managed by `CoreApps`. Those entries are now redundant and should be removed.