### PR TITLE
UpdateEngine: check filesystem state before reinstalling requires deps

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1281,6 +1281,25 @@ public class UpdateEngine : IDisposable
                     return false;
                 }
 
+                // Verify the dependency actually needs install — defer to its own
+                // installs array / installcheck_script / receipts (Munki parity).
+                // CheckDependencies() only consults in-memory lists; without this the
+                // dep gets reinstalled every run when not yet recorded as installed.
+                var depStatus = _statusService.CheckStatus(depItem, "install", _config.CachePath);
+                if (!depStatus.NeedsAction)
+                {
+                    LogDetail($"Dependency {depName} already installed: {depStatus.Reason}");
+                    if (!installedItems.Contains(depItem.Name, StringComparer.OrdinalIgnoreCase))
+                    {
+                        installedItems.Add(depItem.Name);
+                    }
+                    if (!scheduledItems.Contains(dep, StringComparer.OrdinalIgnoreCase))
+                    {
+                        scheduledItems.Add(dep);
+                    }
+                    continue;
+                }
+
                 // Download the dependency if not already downloaded
                 if (!downloadedPaths.ContainsKey(depItem.Name))
                 {


### PR DESCRIPTION
## Summary
- `ProcessInstallWithDependenciesAsync` was treating `requires` differently from `update_for`. The `requires` path only consulted the in-memory `installedItems` / `scheduledItems` lists via `CatalogService.CheckDependencies`; it never asked the dependency's own installs array / `installcheck_script` / receipts whether the install was actually needed.
- Result: any dep that was present on disk but not yet recorded in the in-memory tracking lists (fresh run, partial run, dep first introduced via `requires` chain) got downloaded and reinstalled every cycle. Reported on https://example.org/device/MJ0KP6FJ#installs as the same deps reinstalling repeatedly.
- Fix mirrors the `update_for` path immediately above: after resolving the dep from the catalog, call `_statusService.CheckStatus(depItem, "install", _config.CachePath)`. When `!NeedsAction`, log the reason, mark it installed/scheduled in-memory, and `continue` instead of downloading + recursing.

## Test plan
- [ ] `dotnet build` of `Cimian.CLI.managedsoftwareupdate.csproj` succeeds (verified locally, Release).
- [ ] On MJ0KP6FJ (or another device showing the loop), run `sudo managedsoftwareupdate.exe -v --checkonly` and confirm deps that were previously reinstalling now report "already installed" with the StatusService reason.
- [ ] Verify `update_for` items still install when their parent gets installed (regression check on the unchanged path).
- [ ] Verify a genuinely-missing dep still installs (positive case).
