### PR TITLE
cimiimport: emit installs[] entry for MSI packages

### DIFF
--- a/cli/cimiimport/Models/ImportModels.cs
+++ b/cli/cimiimport/Models/ImportModels.cs
@@ -136,6 +136,14 @@ public class InstallItem
     [YamlMember(Alias = "version")]
     public string? Version { get; set; }
 
+    /// <summary>MSI ProductCode (per-version install identity). Used by managedsoftwareupdate to verify MSI registration in Windows Installer.</summary>
+    [YamlMember(Alias = "product_code")]
+    public string? ProductCode { get; set; }
+
+    /// <summary>MSI UpgradeCode (stable across versions). Fallback when ProductCode lookup misses.</summary>
+    [YamlMember(Alias = "upgrade_code")]
+    public string? UpgradeCode { get; set; }
+
     /// <summary>MSIX/APPX package identity name (from AppxManifest Identity/@Name).</summary>
     [YamlMember(Alias = "identity_name")]
     public string? IdentityName { get; set; }

--- a/cli/cimiimport/Services/ImportService.cs
+++ b/cli/cimiimport/Services/ImportService.cs
@@ -218,6 +218,29 @@ public class ImportService
                 }
             ];
         }
+        else if (metadata.InstallerType == "msi"
+            && (!string.IsNullOrEmpty(metadata.ProductCode) || !string.IsNullOrEmpty(metadata.UpgradeCode)))
+        {
+            // MSI packages are verified by querying Windows Installer for the ProductCode
+            // (per-version) or UpgradeCode (stable). Without an installs[] entry of type=msi
+            // the runtime verifier emits "No installs array for X — cannot verify".
+            var productCode = string.IsNullOrEmpty(metadata.ProductCode) ? null : metadata.ProductCode.Trim();
+            var upgradeCode = string.IsNullOrEmpty(metadata.UpgradeCode) ? null : metadata.UpgradeCode.Trim();
+            var codeSummary = !string.IsNullOrEmpty(productCode)
+                ? (!string.IsNullOrEmpty(upgradeCode) ? $"ProductCode={productCode}, UpgradeCode={upgradeCode}" : $"ProductCode={productCode}")
+                : $"UpgradeCode={upgradeCode}";
+            Console.WriteLine($"Using MSI {codeSummary}");
+            finalInstalls =
+            [
+                new InstallItem
+                {
+                    Type = "msi",
+                    ProductCode = productCode,
+                    UpgradeCode = upgradeCode,
+                    Version = pkgsInfo.Version
+                }
+            ];
+        }
         else
         {
             finalInstalls = [];
@@ -920,6 +943,10 @@ public class ImportService
                         sb.AppendLine($"  md5checksum: {item.MD5Checksum}");
                     if (!string.IsNullOrEmpty(item.Version))
                         sb.AppendLine($"  version: {item.Version}");
+                    if (!string.IsNullOrEmpty(item.ProductCode))
+                        sb.AppendLine($"  product_code: {EscapeYamlString(item.ProductCode)}");
+                    if (!string.IsNullOrEmpty(item.UpgradeCode))
+                        sb.AppendLine($"  upgrade_code: {EscapeYamlString(item.UpgradeCode)}");
                     if (!string.IsNullOrEmpty(item.IdentityName))
                         sb.AppendLine($"  identity_name: {item.IdentityName}");
                 }


### PR DESCRIPTION
## Summary
- Add `product_code` / `upgrade_code` fields to `cimiimport`'s `InstallItem` model (matches shape already in `makepkginfo` and `makecatalogs`).
- Auto-emit a `type: msi` `installs[]` entry when extracted MSI metadata carries a ProductCode or UpgradeCode, the same way `exe`/`msix` already do.

## Why
Without a `type: msi` entry in `installs[]`, `managedsoftwareupdate`'s `VerifyInstallationBeforeRegistry` (cli/managedsoftwareupdate/Services/InstallerService.cs) has nothing to check and emits one of these warnings for every MSI install:

```
No installs array for CimianAuth - cannot verify, assuming success
No installs array for StartSet - cannot verify, assuming success
No installs array for TaskbarUtil - cannot verify, assuming success
```

The verifier already supports `case "msi"` with ProductCode/UpgradeCode lookup via Windows Installer (InstallerService.cs:1499-1532) — `cimiimport` just wasn't producing the entry.

A repo-wide audit of `deployment/pkgsinfo/` showed 51 of 86 MSI pkginfos (59%) are missing `installs:` for this exact reason. They will be backfilled separately in the deployment repo.

## Changes
- `cli/cimiimport/Models/ImportModels.cs`: `InstallItem` gains `ProductCode` and `UpgradeCode` (both nullable, YAML aliases `product_code`/`upgrade_code`).
- `cli/cimiimport/Services/ImportService.cs`: new `else if (msi && (ProductCode || UpgradeCode))` branch in the installs-array build step.

## Test plan
- [x] `dotnet build cli/cimiimport` — succeeds, 0 warnings.
- [ ] Run `cimiimport` against a freshly-built `.msi` and confirm the emitted YAML now includes a `type: msi` entry under `installs:` with the correct ProductCode/UpgradeCode.
- [ ] Run `managedsoftwareupdate -v --checkonly` against the new pkginfo and confirm the "No installs array" warning is gone.