### PR TITLE
Enforce minimum_os_version and maximum_os_version gates

### DIFF
--- a/cli/managedsoftwareupdate/Cimian.CLI.managedsoftwareupdate.csproj
+++ b/cli/managedsoftwareupdate/Cimian.CLI.managedsoftwareupdate.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Cimian.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="WixToolset.Dtf.WindowsInstaller" Version="5.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.0-preview.*" />

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -131,7 +131,7 @@ public class UpdateEngine : IDisposable
         return LoopGuard.ComputeFingerprint(sb.ToString());
     }
 
-    private static bool IsEligibleForOsVersion(CatalogItem item, out string reason, out string reasonCode)
+    internal static bool IsEligibleForOsVersion(CatalogItem item, out string reason, out string reasonCode)
     {
         reason = string.Empty;
         reasonCode = string.Empty;
@@ -820,26 +820,29 @@ public class UpdateEngine : IDisposable
                 continue;
             }
 
-            if (!IsEligibleForOsVersion(catalogItem, out var osReason, out var osReasonCode))
-            {
-                ConsoleLogger.Info($"Skipping {item.Name}: {osReason}");
-                _sessionLogger?.LogStatusCheck(
-                    catalogItem.Name,
-                    catalogItem.Version,
-                    "skipped",
-                    osReason,
-                    osReasonCode,
-                    DetectionMethod.None,
-                    null,
-                    false);
-                continue;
-            }
-
             switch (item.Action.ToLowerInvariant())
             {
                 case "install":
                 case "update":
                 case "default":
+                    // Gate install-like actions on OS-version eligibility. Uninstall is
+                    // intentionally excluded so an item that becomes unsupported on the
+                    // current OS can still be removed.
+                    if (!IsEligibleForOsVersion(catalogItem, out var osReason, out var osReasonCode))
+                    {
+                        ConsoleLogger.Info($"Skipping {item.Name}: {osReason}");
+                        _sessionLogger?.LogStatusCheck(
+                            catalogItem.Name,
+                            catalogItem.Version,
+                            "skipped",
+                            osReason,
+                            osReasonCode,
+                            DetectionMethod.None,
+                            null,
+                            false);
+                        break;
+                    }
+
                     // Go treats both install and update actions the same - calls CheckStatus
                     var status = _statusService.CheckStatus(catalogItem, item.Action.ToLowerInvariant(), _config.CachePath);
                     ConsoleLogger.Detail($"    CheckStatus for {item.Name}: NeedsAction={status.NeedsAction}, IsUpdate={status.IsUpdate}, Status={status.Status}, Reason={status.Reason}, ReasonCode={status.ReasonCode}");
@@ -894,9 +897,25 @@ public class UpdateEngine : IDisposable
 
                 case "optional":
                     // Optional items are normally user-selected via the GUI.
-                    // But if force_install_after_date has passed, enforce installation (Munki behavior).
+                    // But if force_install_after_date has passed, enforce installation.
                     if (catalogItem.ForceInstallAfterDate != null && DateTime.Now >= catalogItem.ForceInstallAfterDate.Value)
                     {
+                        // Gate forced-optional installs on OS-version eligibility.
+                        if (!IsEligibleForOsVersion(catalogItem, out var optOsReason, out var optOsReasonCode))
+                        {
+                            ConsoleLogger.Info($"Skipping forced optional {item.Name}: {optOsReason}");
+                            _sessionLogger?.LogStatusCheck(
+                                catalogItem.Name,
+                                catalogItem.Version,
+                                "skipped",
+                                optOsReason,
+                                optOsReasonCode,
+                                DetectionMethod.None,
+                                null,
+                                false);
+                            break;
+                        }
+
                         var optStatus = _statusService.CheckStatus(catalogItem, "install", _config.CachePath);
                         ConsoleLogger.Detail($"    CheckStatus for {item.Name} (forced deadline): NeedsAction={optStatus.NeedsAction}, Status={optStatus.Status}");
 

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -131,6 +131,37 @@ public class UpdateEngine : IDisposable
         return LoopGuard.ComputeFingerprint(sb.ToString());
     }
 
+    private static bool IsEligibleForOsVersion(CatalogItem item, out string reason, out string reasonCode)
+    {
+        reason = string.Empty;
+        reasonCode = string.Empty;
+
+        var min = item.MinimumOsVersion;
+        var max = item.MaximumOsVersion;
+        if (string.IsNullOrWhiteSpace(min) && string.IsNullOrWhiteSpace(max))
+            return true;
+
+        var current = Cimian.Core.Version.VersionService.GetCurrentOsVersion();
+
+        if (!string.IsNullOrWhiteSpace(min) &&
+            Cimian.Core.Version.VersionService.CompareVersions(current, min) < 0)
+        {
+            reason = $"requires OS {min} or newer, running {current}";
+            reasonCode = StatusReasonCode.OsVersionTooOld;
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(max) &&
+            Cimian.Core.Version.VersionService.CompareVersions(current, max) > 0)
+        {
+            reason = $"requires OS {max} or older, running {current}";
+            reasonCode = StatusReasonCode.OsVersionTooNew;
+            return false;
+        }
+
+        return true;
+    }
+
     /// <summary>
     /// Enable ANSI escape codes for colored output on Windows console
     /// </summary>
@@ -789,6 +820,21 @@ public class UpdateEngine : IDisposable
                 continue;
             }
 
+            if (!IsEligibleForOsVersion(catalogItem, out var osReason, out var osReasonCode))
+            {
+                ConsoleLogger.Info($"Skipping {item.Name}: {osReason}");
+                _sessionLogger?.LogStatusCheck(
+                    catalogItem.Name,
+                    catalogItem.Version,
+                    "skipped",
+                    osReason,
+                    osReasonCode,
+                    DetectionMethod.None,
+                    null,
+                    false);
+                continue;
+            }
+
             switch (item.Action.ToLowerInvariant())
             {
                 case "install":
@@ -1253,6 +1299,21 @@ public class UpdateEngine : IDisposable
         {
             LogInfo($"Skipping {item.Name}: architecture mismatch (system: {systemArch})");
             return true; // Not an error, just skipped
+        }
+
+        if (!IsEligibleForOsVersion(item, out var osReason, out var osReasonCode))
+        {
+            LogInfo($"Skipping {item.Name}: {osReason}");
+            _sessionLogger?.LogStatusCheck(
+                item.Name,
+                item.Version,
+                "skipped",
+                osReason,
+                osReasonCode,
+                DetectionMethod.None,
+                null,
+                false);
+            return true;
         }
 
         // Check and install requires dependencies first

--- a/shared/core/Models/StatusReasonCode.cs
+++ b/shared/core/Models/StatusReasonCode.cs
@@ -117,6 +117,12 @@ public static class StatusReasonCode
     /// <summary>OS version not supported</summary>
     public const string OsVersionMismatch = "os_version_mismatch";
 
+    /// <summary>Running OS version is below the package's minimum_os_version</summary>
+    public const string OsVersionTooOld = "os_version_too_old";
+
+    /// <summary>Running OS version is above the package's maximum_os_version</summary>
+    public const string OsVersionTooNew = "os_version_too_new";
+
     /// <summary>force_install_after_date deadline has passed — item forced to install</summary>
     public const string ForceInstallDeadline = "force_install_deadline";
 

--- a/shared/core/Version/VersionService.cs
+++ b/shared/core/Version/VersionService.cs
@@ -84,6 +84,14 @@ public static class VersionService
     }
     
     /// <summary>
+    /// Returns the running Windows OS version as a string in the form "10.0.x.y".
+    /// </summary>
+    public static string GetCurrentOsVersion()
+    {
+        return Environment.OSVersion.Version.ToString();
+    }
+
+    /// <summary>
     /// Normalizes a version string by trimming trailing ".0" segments.
     /// Migrated from Go: pkg/version/version.go Normalize()
     /// </summary>

--- a/tests/Managedsoftwareupdate/OsVersionGateTests.cs
+++ b/tests/Managedsoftwareupdate/OsVersionGateTests.cs
@@ -1,0 +1,76 @@
+using Xunit;
+using FluentAssertions;
+using Cimian.Core.Version;
+
+namespace Cimian.Tests.Managedsoftwareupdate;
+
+/// <summary>
+/// Coverage for the OS-version eligibility gate exercised by UpdateEngine.
+/// The gate helper inside UpdateEngine is private static; these tests verify
+/// the building blocks (current OS detection + version comparison) that
+/// drive every branch of the gate. The wired-up skip path is exercised via
+/// integration / dogfooding (see PR description).
+/// </summary>
+public class OsVersionGateTests
+{
+    [Fact]
+    public void GetCurrentOsVersion_ReturnsNonEmptyDottedString()
+    {
+        var current = VersionService.GetCurrentOsVersion();
+
+        current.Should().NotBeNullOrWhiteSpace();
+        current.Should().Contain(".");
+        current.Split('.')[0].Should().Be("10");
+    }
+
+    [Fact]
+    public void GateLogic_BothBoundsEmpty_IsEligible()
+    {
+        // Mirrors the early-return branch: no min, no max => always eligible.
+        var min = (string?)null;
+        var max = string.Empty;
+
+        var hasBound = !string.IsNullOrWhiteSpace(min) || !string.IsNullOrWhiteSpace(max);
+        hasBound.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GateLogic_RunningEqualsMinimum_IsEligible()
+    {
+        var current = VersionService.GetCurrentOsVersion();
+
+        VersionService.CompareVersions(current, current).Should().Be(0);
+    }
+
+    [Fact]
+    public void GateLogic_RunningAboveMinimum_IsEligible()
+    {
+        VersionService.CompareVersions("10.0.22631", "10.0.19045")
+            .Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void GateLogic_RunningBelowMinimum_IsIneligible_TooOld()
+    {
+        VersionService.CompareVersions("10.0.19045", "10.0.22631")
+            .Should().BeLessThan(0);
+    }
+
+    [Fact]
+    public void GateLogic_RunningAboveMaximum_IsIneligible_TooNew()
+    {
+        VersionService.CompareVersions("10.0.26200", "10.0.22631")
+            .Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void GateLogic_RunningInRange_IsEligible()
+    {
+        var min = "10.0.19045";
+        var max = "10.0.26200";
+        var current = "10.0.22631";
+
+        VersionService.CompareVersions(current, min).Should().BeGreaterThan(0);
+        VersionService.CompareVersions(current, max).Should().BeLessThan(0);
+    }
+}

--- a/tests/Managedsoftwareupdate/OsVersionGateTests.cs
+++ b/tests/Managedsoftwareupdate/OsVersionGateTests.cs
@@ -1,15 +1,17 @@
 using Xunit;
 using FluentAssertions;
+using Cimian.Core.Models;
 using Cimian.Core.Version;
+using Cimian.CLI.managedsoftwareupdate.Services;
+using CatalogItem = Cimian.CLI.managedsoftwareupdate.Models.CatalogItem;
 
 namespace Cimian.Tests.Managedsoftwareupdate;
 
 /// <summary>
 /// Coverage for the OS-version eligibility gate exercised by UpdateEngine.
-/// The gate helper inside UpdateEngine is private static; these tests verify
-/// the building blocks (current OS detection + version comparison) that
-/// drive every branch of the gate. The wired-up skip path is exercised via
-/// integration / dogfooding (see PR description).
+/// Drives UpdateEngine.IsEligibleForOsVersion directly via InternalsVisibleTo
+/// so all branches (no bounds, in-range, below-min, above-max, boundary) are
+/// asserted against the real helper, not just the underlying VersionService.
 /// </summary>
 public class OsVersionGateTests
 {
@@ -19,58 +21,126 @@ public class OsVersionGateTests
         var current = VersionService.GetCurrentOsVersion();
 
         current.Should().NotBeNullOrWhiteSpace();
-        current.Should().Contain(".");
-        current.Split('.')[0].Should().Be("10");
+        current.Should().MatchRegex(@"^\d+(\.\d+)+$");
     }
 
     [Fact]
-    public void GateLogic_BothBoundsEmpty_IsEligible()
+    public void Gate_NoBounds_IsEligible()
     {
-        // Mirrors the early-return branch: no min, no max => always eligible.
-        var min = (string?)null;
-        var max = string.Empty;
+        var item = new CatalogItem { Name = "Test", Version = "1.0" };
 
-        var hasBound = !string.IsNullOrWhiteSpace(min) || !string.IsNullOrWhiteSpace(max);
-        hasBound.Should().BeFalse();
+        var eligible = UpdateEngine.IsEligibleForOsVersion(item, out var reason, out var code);
+
+        eligible.Should().BeTrue();
+        reason.Should().BeEmpty();
+        code.Should().BeEmpty();
     }
 
     [Fact]
-    public void GateLogic_RunningEqualsMinimum_IsEligible()
+    public void Gate_RunningEqualsMinimum_IsEligible()
+    {
+        // Boundary equality at the minimum bound must be eligible.
+        var current = VersionService.GetCurrentOsVersion();
+        var item = new CatalogItem
+        {
+            Name = "Test",
+            Version = "1.0",
+            MinimumOsVersion = current
+        };
+
+        var eligible = UpdateEngine.IsEligibleForOsVersion(item, out _, out _);
+
+        eligible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Gate_RunningEqualsMaximum_IsEligible()
+    {
+        // Boundary equality at the maximum bound must be eligible.
+        var current = VersionService.GetCurrentOsVersion();
+        var item = new CatalogItem
+        {
+            Name = "Test",
+            Version = "1.0",
+            MaximumOsVersion = current
+        };
+
+        var eligible = UpdateEngine.IsEligibleForOsVersion(item, out _, out _);
+
+        eligible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Gate_RunningInRange_IsEligible()
     {
         var current = VersionService.GetCurrentOsVersion();
+        var item = new CatalogItem
+        {
+            Name = "Test",
+            Version = "1.0",
+            MinimumOsVersion = "0.0.0.1",
+            MaximumOsVersion = "999999.0"
+        };
 
-        VersionService.CompareVersions(current, current).Should().Be(0);
+        var eligible = UpdateEngine.IsEligibleForOsVersion(item, out _, out _);
+
+        eligible.Should().BeTrue();
+        // Sanity: current sits strictly inside the constructed range.
+        VersionService.CompareVersions(current, "0.0.0.1").Should().BeGreaterThan(0);
+        VersionService.CompareVersions(current, "999999.0").Should().BeLessThan(0);
     }
 
     [Fact]
-    public void GateLogic_RunningAboveMinimum_IsEligible()
+    public void Gate_RunningBelowMinimum_IsIneligible_TooOld()
     {
-        VersionService.CompareVersions("10.0.22631", "10.0.19045")
-            .Should().BeGreaterThan(0);
+        // A min above any plausible current OS forces the too-old branch.
+        var item = new CatalogItem
+        {
+            Name = "Test",
+            Version = "1.0",
+            MinimumOsVersion = "999999.0"
+        };
+
+        var eligible = UpdateEngine.IsEligibleForOsVersion(item, out var reason, out var code);
+
+        eligible.Should().BeFalse();
+        reason.Should().Contain("999999.0");
+        reason.Should().Contain("newer");
+        code.Should().Be(StatusReasonCode.OsVersionTooOld);
     }
 
     [Fact]
-    public void GateLogic_RunningBelowMinimum_IsIneligible_TooOld()
+    public void Gate_RunningAboveMaximum_IsIneligible_TooNew()
     {
-        VersionService.CompareVersions("10.0.19045", "10.0.22631")
-            .Should().BeLessThan(0);
+        // A max below any plausible current OS forces the too-new branch.
+        var item = new CatalogItem
+        {
+            Name = "Test",
+            Version = "1.0",
+            MaximumOsVersion = "0.0.0.1"
+        };
+
+        var eligible = UpdateEngine.IsEligibleForOsVersion(item, out var reason, out var code);
+
+        eligible.Should().BeFalse();
+        reason.Should().Contain("0.0.0.1");
+        reason.Should().Contain("older");
+        code.Should().Be(StatusReasonCode.OsVersionTooNew);
     }
 
     [Fact]
-    public void GateLogic_RunningAboveMaximum_IsIneligible_TooNew()
+    public void Gate_BothBoundsSetAndInRange_IsEligible()
     {
-        VersionService.CompareVersions("10.0.26200", "10.0.22631")
-            .Should().BeGreaterThan(0);
-    }
+        var item = new CatalogItem
+        {
+            Name = "Test",
+            Version = "1.0",
+            MinimumOsVersion = "0.0.0.1",
+            MaximumOsVersion = "999999.0"
+        };
 
-    [Fact]
-    public void GateLogic_RunningInRange_IsEligible()
-    {
-        var min = "10.0.19045";
-        var max = "10.0.26200";
-        var current = "10.0.22631";
+        var eligible = UpdateEngine.IsEligibleForOsVersion(item, out _, out _);
 
-        VersionService.CompareVersions(current, min).Should().BeGreaterThan(0);
-        VersionService.CompareVersions(current, max).Should().BeLessThan(0);
+        eligible.Should().BeTrue();
     }
 }


### PR DESCRIPTION
## Summary
- Wires install-time enforcement for the existing `minimum_os_version` and `maximum_os_version` pkginfo fields.
- Adds `VersionService.GetCurrentOsVersion()` and two new status reason codes (`os_version_too_old`, `os_version_too_new`).
- Mirrors the existing architecture-mismatch skip pattern in `UpdateEngine.IdentifyActions` and `ProcessInstallWithDependenciesAsync`.

## Why
Both fields have been declared in the pkginfo schema (`shared/core/Models/CatalogItem.cs`, `cli/makepkginfo/Models/PkgsInfo.cs`, `cli/managedsoftwareupdate/Models/UpdateModels.cs`, `cli/makecatalogs/Models/PkgsInfo.cs`, `cli/cimiimport/Models/ImportModels.cs`) and exposed in CLI flags, but were never read at install time. Pkginfo authors expecting these to gate installs were surprised when packages installed anyway.

## Test plan
- [x] `dotnet test` (619 passing; one pre-existing unrelated failure in `InstallerServiceTests.InstallAsync_ScriptOnlyItem_Succeeds` from a prior MSIX commit)
- [x] `.\build.ps1 -Sign -Binary managedsoftwareupdate` (x64 + arm64, signed)
- [ ] Manual: install a pkginfo with `minimum_os_version: "10.0.99999"` on a current host -- should skip with `os_version_too_old` reason
- [ ] Manual: install with `maximum_os_version: "10.0.1"` -- should skip with `os_version_too_new`

## Notes
- The new gate helper (`UpdateEngine.IsEligibleForOsVersion`) is `private static`; tests cover the underlying `VersionService.GetCurrentOsVersion()` and `CompareVersions` building blocks rather than the helper itself, since the test project does not have `InternalsVisibleTo` configured for managedsoftwareupdate. The wired-up skip path is exercised via integration / dogfooding.