### PR TITLE
Add minimum_cimian_version pkginfo field with install-time enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ supported_architectures:
   - x64
   - x86
 minimum_os_version: "10.0.19041"
+minimum_cimian_version: "2026.05.01.0000"  # skip on agents older than this build
 unattended_install: true
 unattended_uninstall: true
 ```
@@ -603,6 +604,7 @@ uninstaller:
 supported_architectures:
   - x64
 minimum_os_version: "10.0.17763"
+minimum_cimian_version: "2026.05.01.0000"  # skip on agents older than this build
 unattended_install: true
 unattended_uninstall: true
 ```
@@ -715,6 +717,7 @@ supported_architectures:
   - x64
 minimum_os_version: "10.0.19041"
 maximum_os_version: ""
+minimum_cimian_version: "2026.05.01.0000"  # skip on agents older than this build
 unattended_install: true
 unattended_uninstall: true
 ```

--- a/cli/cimiimport/Models/ImportModels.cs
+++ b/cli/cimiimport/Models/ImportModels.cs
@@ -63,6 +63,9 @@ public class PkgsInfo
     [YamlMember(Alias = "maximum_os_version")]
     public string? MaxOSVersion { get; set; }
 
+    [YamlMember(Alias = "minimum_cimian_version")]
+    public string? MinCimianVersion { get; set; }
+
     [YamlMember(Alias = "installer")]
     public Installer? Installer { get; set; }
 

--- a/cli/cimiimport/Program.cs
+++ b/cli/cimiimport/Program.cs
@@ -46,6 +46,10 @@ public class Program
             "--maximum_os_version",
             "Maximum Windows version supported (e.g. 11.0.22000)");
 
+        var minCimianVersionOption = new Option<string?>(
+            "--minimum_cimian_version",
+            "Minimum Cimian agent version required (e.g. 2026.05.01.0000)");
+
         var preinstallScriptOption = new Option<string?>(
             "--preinstall-script",
             "Path to preinstall script");
@@ -100,6 +104,7 @@ public class Program
         rootCommand.AddOption(uninstallerOption);
         rootCommand.AddOption(minOSVersionOption);
         rootCommand.AddOption(maxOSVersionOption);
+        rootCommand.AddOption(minCimianVersionOption);
         rootCommand.AddOption(preinstallScriptOption);
         rootCommand.AddOption(postinstallScriptOption);
         rootCommand.AddOption(preuninstallScriptOption);
@@ -122,6 +127,7 @@ public class Program
             var uninstaller = context.ParseResult.GetValueForOption(uninstallerOption);
             var minOSVersion = context.ParseResult.GetValueForOption(minOSVersionOption);
             var maxOSVersion = context.ParseResult.GetValueForOption(maxOSVersionOption);
+            var minCimianVersion = context.ParseResult.GetValueForOption(minCimianVersionOption);
             var preinstallScript = context.ParseResult.GetValueForOption(preinstallScriptOption);
             var postinstallScript = context.ParseResult.GetValueForOption(postinstallScriptOption);
             var preuninstallScript = context.ParseResult.GetValueForOption(preuninstallScriptOption);
@@ -220,6 +226,7 @@ public class Program
                     installsArray.ToList(),
                     minOSVersion,
                     maxOSVersion,
+                    minCimianVersion,
                     extractIcon,
                     iconOutput,
                     noInteractive

--- a/cli/cimiimport/Services/ImportService.cs
+++ b/cli/cimiimport/Services/ImportService.cs
@@ -43,6 +43,7 @@ public class ImportService
         List<string> installsPaths,
         string? minOSVersion,
         string? maxOSVersion,
+        string? minCimianVersion = null,
         bool extractIcon = false,
         string? iconOutputPath = null,
         bool noInteractive = false)
@@ -154,6 +155,7 @@ public class ImportService
             Installs = [],
             MinOSVersion = minOSVersion,
             MaxOSVersion = maxOSVersion,
+            MinCimianVersion = minCimianVersion,
             Installer = new Installer
             {
                 Hash = fileHash,
@@ -837,6 +839,9 @@ public class ImportService
 
         if (!string.IsNullOrEmpty(pkgsInfo.MinOSVersion))
             otherProps["minimum_os_version"] = pkgsInfo.MinOSVersion;
+
+        if (!string.IsNullOrEmpty(pkgsInfo.MinCimianVersion))
+            otherProps["minimum_cimian_version"] = pkgsInfo.MinCimianVersion;
 
         if (!string.IsNullOrEmpty(pkgsInfo.PostinstallScript))
             otherProps["postinstall_script"] = pkgsInfo.PostinstallScript;

--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -134,6 +134,9 @@ public class PkgsInfo
     [YamlMember(Alias = "maximum_os_version")]
     public string? MaxOSVersion { get; set; }
 
+    [YamlMember(Alias = "minimum_cimian_version")]
+    public string? MinCimianVersion { get; set; }
+
     [YamlMember(Alias = "installer")]
     public Installer? Installer { get; set; }
 

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -97,40 +97,43 @@ public class PkgsInfo
     [YamlMember(Alias = "maximum_os_version", Order = 12, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? MaxOSVersion { get; set; }
 
-    [YamlMember(Alias = "installs", Order = 13, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    [YamlMember(Alias = "minimum_cimian_version", Order = 13, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string? MinCimianVersion { get; set; }
+
+    [YamlMember(Alias = "installs", Order = 14, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
     public List<InstallItem>? Installs { get; set; }
 
-    [YamlMember(Alias = "installcheck_script", Order = 14, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [YamlMember(Alias = "installcheck_script", Order = 15, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? InstallCheckScript { get; set; }
 
-    [YamlMember(Alias = "uninstallcheck_script", Order = 15, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [YamlMember(Alias = "uninstallcheck_script", Order = 16, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? UninstallCheckScript { get; set; }
 
-    [YamlMember(Alias = "preinstall_script", Order = 16, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [YamlMember(Alias = "preinstall_script", Order = 17, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? PreinstallScript { get; set; }
 
-    [YamlMember(Alias = "postinstall_script", Order = 17, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [YamlMember(Alias = "postinstall_script", Order = 18, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? PostinstallScript { get; set; }
 
-    [YamlMember(Alias = "preuninstall_script", Order = 18, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [YamlMember(Alias = "preuninstall_script", Order = 19, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? PreuninstallScript { get; set; }
 
-    [YamlMember(Alias = "postuninstall_script", Order = 19, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [YamlMember(Alias = "postuninstall_script", Order = 20, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? PostuninstallScript { get; set; }
 
-    [YamlMember(Alias = "uninstaller_path", Order = 20, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [YamlMember(Alias = "uninstaller_path", Order = 21, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? UninstallerPath { get; set; }
 
-    [YamlMember(Alias = "OnDemand", Order = 21, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    [YamlMember(Alias = "OnDemand", Order = 22, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
     public bool OnDemand { get; set; }
 
-    [YamlMember(Alias = "managed_profiles", Order = 22, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    [YamlMember(Alias = "managed_profiles", Order = 23, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
     public List<string>? ManagedProfiles { get; set; }
 
-    [YamlMember(Alias = "managed_apps", Order = 23, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    [YamlMember(Alias = "managed_apps", Order = 24, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
     public List<string>? ManagedApps { get; set; }
 
-    [YamlMember(Alias = "installer", Order = 24, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [YamlMember(Alias = "installer", Order = 25, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public Installer? Installer { get; set; }
 }
 

--- a/cli/makepkginfo/Program.cs
+++ b/cli/makepkginfo/Program.cs
@@ -85,6 +85,10 @@ class Program
             "--maximum_os_version",
             "Maximum OS version supported");
 
+        var minCimianVersionOption = new Option<string?>(
+            "--minimum_cimian_version",
+            "Minimum Cimian agent version required");
+
         var unattendedInstallOption = new Option<bool>(
             "--unattended_install",
             "Set 'unattended_install: true'");
@@ -133,6 +137,7 @@ class Program
         rootCommand.AddOption(versionOption);
         rootCommand.AddOption(minOSVersionOption);
         rootCommand.AddOption(maxOSVersionOption);
+        rootCommand.AddOption(minCimianVersionOption);
         rootCommand.AddOption(unattendedInstallOption);
         rootCommand.AddOption(unattendedUninstallOption);
         rootCommand.AddOption(onDemandOption);
@@ -159,6 +164,7 @@ class Program
             var version = context.ParseResult.GetValueForOption(versionOption);
             var minOSVersion = context.ParseResult.GetValueForOption(minOSVersionOption);
             var maxOSVersion = context.ParseResult.GetValueForOption(maxOSVersionOption);
+            var minCimianVersion = context.ParseResult.GetValueForOption(minCimianVersionOption);
             var unattendedInstall = context.ParseResult.GetValueForOption(unattendedInstallOption);
             var unattendedUninstall = context.ParseResult.GetValueForOption(unattendedUninstallOption);
             var onDemand = context.ParseResult.GetValueForOption(onDemandOption);
@@ -230,6 +236,7 @@ class Program
                     OnDemand = onDemand,
                     MinOSVersion = minOSVersion,
                     MaxOSVersion = maxOSVersion,
+                    MinCimianVersion = minCimianVersion,
                     InstallCheckScriptPath = installCheckScript,
                     UninstallCheckScriptPath = uninstallCheckScript,
                     PreinstallScriptPath = preinstallScript,
@@ -271,6 +278,7 @@ class Program
                         OnDemand = onDemand,
                         MinOSVersion = minOSVersion,
                         MaxOSVersion = maxOSVersion,
+                        MinCimianVersion = minCimianVersion,
                         Installs = builder.BuildInstallsArray(additionalFiles.ToList())
                     };
 

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -170,6 +170,7 @@ public class PkgInfoBuilder
             OnDemand = options.OnDemand,
             MinOSVersion = options.MinOSVersion,
             MaxOSVersion = options.MaxOSVersion,
+            MinCimianVersion = options.MinCimianVersion,
             Installs = installs
         };
 
@@ -392,6 +393,7 @@ public class PkgsInfoOptions
     public bool OnDemand { get; set; }
     public string? MinOSVersion { get; set; }
     public string? MaxOSVersion { get; set; }
+    public string? MinCimianVersion { get; set; }
     public string? InstallCheckScriptPath { get; set; }
     public string? UninstallCheckScriptPath { get; set; }
     public string? PreinstallScriptPath { get; set; }

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -357,6 +357,9 @@ public class CatalogItem
     [YamlMember(Alias = "maximum_os_version")]
     public string? MaximumOsVersion { get; set; }
 
+    [YamlMember(Alias = "minimum_cimian_version")]
+    public string? MinimumCimianVersion { get; set; }
+
     [YamlMember(Alias = "check")]
     public CheckInfo Check { get; set; } = new();
 

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -1,10 +1,10 @@
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using Cimian.CLI.managedsoftwareupdate.Models;
 using Cimian.Core;
 using Cimian.Core.Models;
 using Cimian.Core.Services;
+using Cimian.Core.Version;
 using Microsoft.Win32;
 
 // Resolve ambiguous references between CLI and Core models
@@ -62,30 +62,7 @@ public class StatusService
     /// <summary>
     /// Gets the running version of the managedsoftwareupdate binary
     /// </summary>
-    private static string GetRunningVersion()
-    {
-        var assembly = Assembly.GetExecutingAssembly();
-        
-        var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-        if (!string.IsNullOrEmpty(informationalVersion))
-        {
-            var plusIndex = informationalVersion.IndexOf('+');
-            if (plusIndex >= 0)
-            {
-                return informationalVersion[..plusIndex];
-            }
-            return informationalVersion;
-        }
-        
-        var fileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
-        if (!string.IsNullOrEmpty(fileVersion))
-        {
-            return fileVersion;
-        }
-        
-        var version = assembly.GetName().Version;
-        return version?.ToString() ?? "UNKNOWN";
-    }
+    private static string GetRunningVersion() => VersionService.GetRunningAgentVersion();
 
     /// <summary>
     /// Checks if the item needs to be installed/updated

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -820,29 +820,14 @@ public class UpdateEngine : IDisposable
                 continue;
             }
 
-            if (!IsEligibleForAgentVersion(catalogItem, out var agentSkipReason, out var agentSkipCode))
-            {
-                ConsoleLogger.Info($"Skipping {item.Name}: {agentSkipReason}");
-                _sessionLogger?.LogStatusCheck(
-                    catalogItem.Name,
-                    catalogItem.Version,
-                    "skipped",
-                    agentSkipReason,
-                    agentSkipCode,
-                    DetectionMethod.None,
-                    null,
-                    false);
-                continue;
-            }
-
             switch (item.Action.ToLowerInvariant())
             {
                 case "install":
                 case "update":
                 case "default":
-                    // Gate install-like actions on OS-version eligibility. Uninstall is
-                    // intentionally excluded so an item that becomes unsupported on the
-                    // current OS can still be removed.
+                    // Gate install-like actions on OS-version and agent-version eligibility.
+                    // Uninstall is intentionally excluded so an item that becomes unsupported
+                    // on the current OS or requires a newer agent can still be removed.
                     if (!IsEligibleForOsVersion(catalogItem, out var osReason, out var osReasonCode))
                     {
                         ConsoleLogger.Info($"Skipping {item.Name}: {osReason}");
@@ -852,6 +837,21 @@ public class UpdateEngine : IDisposable
                             "skipped",
                             osReason,
                             osReasonCode,
+                            DetectionMethod.None,
+                            null,
+                            false);
+                        break;
+                    }
+
+                    if (!IsEligibleForAgentVersion(catalogItem, out var agentSkipReason, out var agentSkipCode))
+                    {
+                        ConsoleLogger.Info($"Skipping {item.Name}: {agentSkipReason}");
+                        _sessionLogger?.LogStatusCheck(
+                            catalogItem.Name,
+                            catalogItem.Version,
+                            "skipped",
+                            agentSkipReason,
+                            agentSkipCode,
                             DetectionMethod.None,
                             null,
                             false);
@@ -915,7 +915,7 @@ public class UpdateEngine : IDisposable
                     // But if force_install_after_date has passed, enforce installation.
                     if (catalogItem.ForceInstallAfterDate != null && DateTime.Now >= catalogItem.ForceInstallAfterDate.Value)
                     {
-                        // Gate forced-optional installs on OS-version eligibility.
+                        // Gate forced-optional installs on OS-version and agent-version eligibility.
                         if (!IsEligibleForOsVersion(catalogItem, out var optOsReason, out var optOsReasonCode))
                         {
                             ConsoleLogger.Info($"Skipping forced optional {item.Name}: {optOsReason}");
@@ -925,6 +925,21 @@ public class UpdateEngine : IDisposable
                                 "skipped",
                                 optOsReason,
                                 optOsReasonCode,
+                                DetectionMethod.None,
+                                null,
+                                false);
+                            break;
+                        }
+
+                        if (!IsEligibleForAgentVersion(catalogItem, out var optAgentReason, out var optAgentCode))
+                        {
+                            ConsoleLogger.Info($"Skipping forced optional {item.Name}: {optAgentReason}");
+                            _sessionLogger?.LogStatusCheck(
+                                catalogItem.Name,
+                                catalogItem.Version,
+                                "skipped",
+                                optAgentReason,
+                                optAgentCode,
                                 DetectionMethod.None,
                                 null,
                                 false);
@@ -1803,7 +1818,9 @@ public class UpdateEngine : IDisposable
     #region Verbose Output Methods (Go Parity)
     
     /// <summary>
-    /// Gets the version string in YYYY.MM.DD.HHMM format
+    /// Gets the running agent version string from assembly metadata.
+    /// CI builds embed yyyy.MM.dd.HHmm via AssemblyInformationalVersion, but
+    /// dev builds may fall back to AssemblyFileVersion (e.g. 1.0.0.0).
     /// </summary>
     private static string GetFormattedVersion() => VersionService.GetRunningAgentVersion();
     
@@ -2558,7 +2575,7 @@ public class UpdateEngine : IDisposable
         return item;
     }
 
-    private static bool IsEligibleForAgentVersion(CatalogItem item, out string reason, out string reasonCode)
+    internal static bool IsEligibleForAgentVersion(CatalogItem item, out string reason, out string reasonCode)
     {
         reason = string.Empty;
         reasonCode = string.Empty;

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1,10 +1,10 @@
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using Cimian.CLI.managedsoftwareupdate.Models;
 using Cimian.Core;
 using Cimian.Core.Models;
 using Cimian.Core.Services;
+using Cimian.Core.Version;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -820,6 +820,21 @@ public class UpdateEngine : IDisposable
                 continue;
             }
 
+            if (!IsEligibleForAgentVersion(catalogItem, out var agentSkipReason, out var agentSkipCode))
+            {
+                ConsoleLogger.Info($"Skipping {item.Name}: {agentSkipReason}");
+                _sessionLogger?.LogStatusCheck(
+                    catalogItem.Name,
+                    catalogItem.Version,
+                    "skipped",
+                    agentSkipReason,
+                    agentSkipCode,
+                    DetectionMethod.None,
+                    null,
+                    false);
+                continue;
+            }
+
             switch (item.Action.ToLowerInvariant())
             {
                 case "install":
@@ -1335,6 +1350,21 @@ public class UpdateEngine : IDisposable
             return true;
         }
 
+        if (!IsEligibleForAgentVersion(item, out var agentSkipReason, out var agentSkipCode))
+        {
+            LogInfo($"Skipping {item.Name}: {agentSkipReason}");
+            _sessionLogger?.LogStatusCheck(
+                item.Name,
+                item.Version,
+                "skipped",
+                agentSkipReason,
+                agentSkipCode,
+                DetectionMethod.None,
+                null,
+                false);
+            return true;
+        }
+
         // Check and install requires dependencies first
         if (item.Requires.Count > 0)
         {
@@ -1775,32 +1805,7 @@ public class UpdateEngine : IDisposable
     /// <summary>
     /// Gets the version string in YYYY.MM.DD.HHMM format
     /// </summary>
-    private static string GetFormattedVersion()
-    {
-        var assembly = Assembly.GetExecutingAssembly();
-        
-        // Try AssemblyInformationalVersion first (has proper YYYY.MM.DD.HHMM format)
-        var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-        if (!string.IsNullOrEmpty(informationalVersion))
-        {
-            var plusIndex = informationalVersion.IndexOf('+');
-            if (plusIndex >= 0)
-            {
-                return informationalVersion[..plusIndex];
-            }
-            return informationalVersion;
-        }
-        
-        // Fall back to AssemblyFileVersion
-        var fileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
-        if (!string.IsNullOrEmpty(fileVersion))
-        {
-            return fileVersion;
-        }
-        
-        // Last resort - assembly version (may lose leading zeros)
-        return assembly.GetName().Version?.ToString() ?? "Unknown";
-    }
+    private static string GetFormattedVersion() => VersionService.GetRunningAgentVersion();
     
     /// <summary>
     /// Prints the verbose header banner - matches Go output with timestamps
@@ -2551,6 +2556,27 @@ public class UpdateEngine : IDisposable
             ForceInstallAfterDate = cat?.ForceInstallAfterDate,
         };
         return item;
+    }
+
+    private static bool IsEligibleForAgentVersion(CatalogItem item, out string reason, out string reasonCode)
+    {
+        reason = string.Empty;
+        reasonCode = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(item.MinimumCimianVersion))
+        {
+            return true;
+        }
+
+        var currentVersion = VersionService.GetRunningAgentVersion();
+        if (VersionService.CompareVersions(currentVersion, item.MinimumCimianVersion) >= 0)
+        {
+            return true;
+        }
+
+        reason = $"requires Cimian {item.MinimumCimianVersion} or newer, running {currentVersion}";
+        reasonCode = StatusReasonCode.AgentVersionTooOld;
+        return false;
     }
 
     /// <summary>

--- a/shared/core/Models/CatalogItem.cs
+++ b/shared/core/Models/CatalogItem.cs
@@ -132,6 +132,12 @@ public class CatalogItem
     public string? MaximumOsVersion { get; set; }
 
     /// <summary>
+    /// Minimum Cimian agent version required to install this package
+    /// </summary>
+    [YamlMember(Alias = "minimum_cimian_version")]
+    public string? MinimumCimianVersion { get; set; }
+
+    /// <summary>
     /// Supported architectures (x64, arm64, etc.)
     /// </summary>
     [YamlMember(Alias = "supported_architectures")]

--- a/shared/core/Models/StatusReasonCode.cs
+++ b/shared/core/Models/StatusReasonCode.cs
@@ -123,6 +123,9 @@ public static class StatusReasonCode
     /// <summary>Running OS version is above the package's maximum_os_version</summary>
     public const string OsVersionTooNew = "os_version_too_new";
 
+    /// <summary>Running Cimian agent version is older than the package's minimum_cimian_version</summary>
+    public const string AgentVersionTooOld = "agent_version_too_old";
+
     /// <summary>force_install_after_date deadline has passed — item forced to install</summary>
     public const string ForceInstallDeadline = "force_install_deadline";
 

--- a/shared/core/Version/VersionService.cs
+++ b/shared/core/Version/VersionService.cs
@@ -20,9 +20,12 @@ public static class VersionService
     private static readonly Regex PreReleaseRegex = new(@"-(.+)$", RegexOptions.Compiled);
 
     /// <summary>
-    /// Returns the running Cimian agent version (the entry assembly's
-    /// AssemblyInformationalVersion with any "+commit" suffix stripped, falling
-    /// back to AssemblyFileVersion and then AssemblyVersion).
+    /// Returns the running Cimian agent version from assembly metadata.
+    /// Reads the entry assembly's AssemblyInformationalVersion (CI builds embed
+    /// yyyy.MM.dd.HHmm here) with any "+commit" suffix stripped, falling back
+    /// to AssemblyFileVersion and then AssemblyVersion (e.g. "1.0.0.0") for
+    /// dev builds without an informational version stamp. Format is therefore
+    /// build-dependent; do not assume yyyy.MM.dd.HHmm.
     /// </summary>
     public static string GetRunningAgentVersion()
     {

--- a/shared/core/Version/VersionService.cs
+++ b/shared/core/Version/VersionService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace Cimian.Core.Version;
@@ -17,6 +18,31 @@ public static class VersionService
 {
     private static readonly Regex VersionCleanupRegex = new(@"^v", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex PreReleaseRegex = new(@"-(.+)$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns the running Cimian agent version (the entry assembly's
+    /// AssemblyInformationalVersion with any "+commit" suffix stripped, falling
+    /// back to AssemblyFileVersion and then AssemblyVersion).
+    /// </summary>
+    public static string GetRunningAgentVersion()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+
+        var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrEmpty(informationalVersion))
+        {
+            var plusIndex = informationalVersion.IndexOf('+');
+            return plusIndex >= 0 ? informationalVersion[..plusIndex] : informationalVersion;
+        }
+
+        var fileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+        if (!string.IsNullOrEmpty(fileVersion))
+        {
+            return fileVersion;
+        }
+
+        return assembly.GetName().Version?.ToString() ?? "UNKNOWN";
+    }
     
     /// <summary>
     /// Compares two version strings and returns true if local is older than remote.

--- a/tests/Managedsoftwareupdate/AgentVersionGateTests.cs
+++ b/tests/Managedsoftwareupdate/AgentVersionGateTests.cs
@@ -1,0 +1,69 @@
+using Xunit;
+using FluentAssertions;
+using Cimian.Core.Version;
+
+namespace Cimian.Tests.Managedsoftwareupdate;
+
+/// <summary>
+/// Coverage for the agent-version eligibility gate exercised by UpdateEngine.
+/// The gate helper inside UpdateEngine is private static; these tests verify
+/// the building blocks (running-agent version lookup + version comparison)
+/// that drive every branch of the gate.
+/// </summary>
+public class AgentVersionGateTests
+{
+    [Fact]
+    public void GetRunningAgentVersion_ReturnsNonEmpty()
+    {
+        var current = VersionService.GetRunningAgentVersion();
+
+        current.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void GateLogic_MinimumNull_IsEligible()
+    {
+        string? minimum = null;
+
+        var hasBound = !string.IsNullOrWhiteSpace(minimum);
+        hasBound.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GateLogic_MinimumEmpty_IsEligible()
+    {
+        var minimum = string.Empty;
+
+        var hasBound = !string.IsNullOrWhiteSpace(minimum);
+        hasBound.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GateLogic_RunningEqualsMinimum_IsEligible()
+    {
+        var version = "2026.05.01.0000";
+
+        VersionService.CompareVersions(version, version).Should().Be(0);
+    }
+
+    [Fact]
+    public void GateLogic_RunningAboveMinimum_IsEligible()
+    {
+        VersionService.CompareVersions("2026.05.01.0000", "2025.10.15.1200")
+            .Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void GateLogic_RunningBelowMinimum_IsIneligible()
+    {
+        VersionService.CompareVersions("2025.10.15.1200", "2026.05.01.0000")
+            .Should().BeLessThan(0);
+    }
+
+    [Fact]
+    public void GateLogic_PreReleaseRunning_IsOlderThanRelease()
+    {
+        VersionService.CompareVersions("2026.05.01.0000-beta1", "2026.05.01.0000")
+            .Should().BeLessThan(0);
+    }
+}

--- a/tests/Managedsoftwareupdate/AgentVersionGateTests.cs
+++ b/tests/Managedsoftwareupdate/AgentVersionGateTests.cs
@@ -1,68 +1,123 @@
 using Xunit;
 using FluentAssertions;
+using Cimian.Core.Models;
 using Cimian.Core.Version;
+using Cimian.CLI.managedsoftwareupdate.Services;
+using CatalogItem = Cimian.CLI.managedsoftwareupdate.Models.CatalogItem;
 
 namespace Cimian.Tests.Managedsoftwareupdate;
 
 /// <summary>
 /// Coverage for the agent-version eligibility gate exercised by UpdateEngine.
-/// The gate helper inside UpdateEngine is private static; these tests verify
-/// the building blocks (running-agent version lookup + version comparison)
-/// that drive every branch of the gate.
+/// Calls UpdateEngine.IsEligibleForAgentVersion directly (exposed via
+/// InternalsVisibleTo) so the real decision branches and reason codes are
+/// asserted, not just the underlying string/version-comparison primitives.
 /// </summary>
 public class AgentVersionGateTests
 {
+    private static readonly string RunningVersion = VersionService.GetRunningAgentVersion();
+
+    private static CatalogItem ItemWithMinimum(string? minimum)
+        => new() { Name = "test-pkg", Version = "1.0", MinimumCimianVersion = minimum };
+
+    /// <summary>
+    /// Bumps the leading numeric segment by +1 so the resulting version is
+    /// strictly greater than the running agent version under
+    /// VersionService.CompareVersions, regardless of build-time format.
+    /// </summary>
+    private static string OneAboveRunning()
+    {
+        var parts = RunningVersion.Split('.');
+        if (parts.Length == 0 || !long.TryParse(parts[0], out var major))
+        {
+            return "9999.0.0.0";
+        }
+        parts[0] = (major + 1).ToString();
+        return string.Join('.', parts);
+    }
+
     [Fact]
     public void GetRunningAgentVersion_ReturnsNonEmpty()
     {
-        var current = VersionService.GetRunningAgentVersion();
-
-        current.Should().NotBeNullOrWhiteSpace();
+        RunningVersion.Should().NotBeNullOrWhiteSpace();
     }
 
     [Fact]
-    public void GateLogic_MinimumNull_IsEligible()
+    public void IsEligible_MinimumNull_AllowsInstall()
     {
-        string? minimum = null;
+        var item = ItemWithMinimum(null);
 
-        var hasBound = !string.IsNullOrWhiteSpace(minimum);
-        hasBound.Should().BeFalse();
+        var eligible = UpdateEngine.IsEligibleForAgentVersion(item, out var reason, out var code);
+
+        eligible.Should().BeTrue();
+        reason.Should().BeEmpty();
+        code.Should().BeEmpty();
     }
 
     [Fact]
-    public void GateLogic_MinimumEmpty_IsEligible()
+    public void IsEligible_MinimumEmpty_AllowsInstall()
     {
-        var minimum = string.Empty;
+        var item = ItemWithMinimum(string.Empty);
 
-        var hasBound = !string.IsNullOrWhiteSpace(minimum);
-        hasBound.Should().BeFalse();
+        var eligible = UpdateEngine.IsEligibleForAgentVersion(item, out var reason, out var code);
+
+        eligible.Should().BeTrue();
+        reason.Should().BeEmpty();
+        code.Should().BeEmpty();
     }
 
     [Fact]
-    public void GateLogic_RunningEqualsMinimum_IsEligible()
+    public void IsEligible_MinimumWhitespace_AllowsInstall()
     {
-        var version = "2026.05.01.0000";
+        var item = ItemWithMinimum("   ");
 
-        VersionService.CompareVersions(version, version).Should().Be(0);
+        var eligible = UpdateEngine.IsEligibleForAgentVersion(item, out _, out _);
+
+        eligible.Should().BeTrue();
     }
 
     [Fact]
-    public void GateLogic_RunningAboveMinimum_IsEligible()
+    public void IsEligible_RunningEqualsMinimum_AllowsInstall_AtBoundary()
     {
-        VersionService.CompareVersions("2026.05.01.0000", "2025.10.15.1200")
-            .Should().BeGreaterThan(0);
+        var item = ItemWithMinimum(RunningVersion);
+
+        var eligible = UpdateEngine.IsEligibleForAgentVersion(item, out var reason, out var code);
+
+        eligible.Should().BeTrue();
+        reason.Should().BeEmpty();
+        code.Should().BeEmpty();
     }
 
     [Fact]
-    public void GateLogic_RunningBelowMinimum_IsIneligible()
+    public void IsEligible_RunningAboveMinimum_AllowsInstall()
     {
-        VersionService.CompareVersions("2025.10.15.1200", "2026.05.01.0000")
-            .Should().BeLessThan(0);
+        // Use "0.0.0.1" as a minimum that any real running version will exceed.
+        var item = ItemWithMinimum("0.0.0.1");
+
+        var eligible = UpdateEngine.IsEligibleForAgentVersion(item, out _, out _);
+
+        eligible.Should().BeTrue();
     }
 
     [Fact]
-    public void GateLogic_PreReleaseRunning_IsOlderThanRelease()
+    public void IsEligible_RunningBelowMinimum_BlocksInstall_WithReasonCode()
     {
+        var futureMinimum = OneAboveRunning();
+        var item = ItemWithMinimum(futureMinimum);
+
+        var eligible = UpdateEngine.IsEligibleForAgentVersion(item, out var reason, out var code);
+
+        eligible.Should().BeFalse();
+        code.Should().Be(StatusReasonCode.AgentVersionTooOld);
+        reason.Should().Contain(futureMinimum);
+        reason.Should().Contain(RunningVersion);
+    }
+
+    [Fact]
+    public void IsEligible_PreReleaseRunning_TreatedAsOlderThanRelease()
+    {
+        // Sanity check on the underlying comparator that the gate relies on:
+        // pre-release < same numeric release.
         VersionService.CompareVersions("2026.05.01.0000-beta1", "2026.05.01.0000")
             .Should().BeLessThan(0);
     }

--- a/wiki/cimian-munki-comparison.md
+++ b/wiki/cimian-munki-comparison.md
@@ -36,7 +36,9 @@ For the engineering-level parity ledger (which individual Munki features are imp
 
 ## What maps 1:1 (the happy path)
 
-Most pkginfo fields transfer verbatim. `name`, `display_name`, `version`, `catalogs`, `requires`, `update_for`, `blocking_applications`, `unattended_install`, `unattended_uninstall`, `installer` / `uninstaller` blocks, `installs` detection arrays, `preinstall_script`, `postinstall_script`, `preuninstall_script`, `postuninstall_script`, `installcheck_script`, `uninstallcheck_script`, `OnDemand`, `force_install_after_date`, `version_script`, `default_installs`, `precache`, `installable_condition`, `supported_architectures`, `minimum_os_version`, and `maximum_os_version` all exist in Cimian and behave as documented in Munki.
+Most pkginfo fields transfer verbatim. `name`, `display_name`, `version`, `catalogs`, `requires`, `update_for`, `blocking_applications`, `unattended_install`, `unattended_uninstall`, `installer` / `uninstaller` blocks, `installs` detection arrays, `preinstall_script`, `postinstall_script`, `preuninstall_script`, `postuninstall_script`, `installcheck_script`, `uninstallcheck_script`, `OnDemand`, `force_install_after_date`, `version_script`, `default_installs`, `precache`, `installable_condition`, `supported_architectures`, `minimum_os_version`, `maximum_os_version`, and `minimum_cimian_version` all exist in Cimian and behave as documented in Munki.
+
+`minimum_cimian_version` gates installs on the running Cimian agent's own version: if set, packages are skipped on agents older than the declared minimum, with a structured `agent_version_too_old` reason in the session log. Use it for pkginfos that depend on capabilities introduced in a specific Cimian build.
 
 **`installcheck_script` exit codes match Munki.** This is worth calling out explicitly because it is the question people always ask:
 

--- a/wiki/cimian-munki-comparison.md
+++ b/wiki/cimian-munki-comparison.md
@@ -36,9 +36,9 @@ For the engineering-level parity ledger (which individual Munki features are imp
 
 ## What maps 1:1 (the happy path)
 
-Most pkginfo fields transfer verbatim. `name`, `display_name`, `version`, `catalogs`, `requires`, `update_for`, `blocking_applications`, `unattended_install`, `unattended_uninstall`, `installer` / `uninstaller` blocks, `installs` detection arrays, `preinstall_script`, `postinstall_script`, `preuninstall_script`, `postuninstall_script`, `installcheck_script`, `uninstallcheck_script`, `OnDemand`, `force_install_after_date`, `version_script`, `default_installs`, `precache`, `installable_condition`, `supported_architectures`, `minimum_os_version`, `maximum_os_version`, and `minimum_cimian_version` all exist in Cimian and behave as documented in Munki.
+Most pkginfo fields transfer verbatim. `name`, `display_name`, `version`, `catalogs`, `requires`, `update_for`, `blocking_applications`, `unattended_install`, `unattended_uninstall`, `installer` / `uninstaller` blocks, `installs` detection arrays, `preinstall_script`, `postinstall_script`, `preuninstall_script`, `postuninstall_script`, `installcheck_script`, `uninstallcheck_script`, `OnDemand`, `force_install_after_date`, `version_script`, `default_installs`, `precache`, `installable_condition`, `supported_architectures`, `minimum_os_version`, and `maximum_os_version` all exist in Cimian and behave as documented in Munki.
 
-`minimum_cimian_version` gates installs on the running Cimian agent's own version: if set, packages are skipped on agents older than the declared minimum, with a structured `agent_version_too_old` reason in the session log. Use it for pkginfos that depend on capabilities introduced in a specific Cimian build.
+Cimian also adds `minimum_cimian_version` as a Cimian-specific extension for gating installs on the running agent's own version. If set, packages are skipped on agents older than the declared minimum, with a structured `agent_version_too_old` reason in the session log. Use it for pkginfos that depend on capabilities introduced in a specific Cimian build.
 
 **`installcheck_script` exit codes match Munki.** This is worth calling out explicitly because it is the question people always ask:
 


### PR DESCRIPTION
## Summary
- New pkginfo field `minimum_cimian_version` with `[YamlMember]` attributes across all 5 schema model files.
- New CLI flag `--minimum_cimian_version` on `makepkginfo` and `cimiimport`.
- New `StatusReasonCode.AgentVersionTooOld` (`agent_version_too_old`).
- Consolidates the running-agent-version lookup into a single `VersionService.GetRunningAgentVersion()`; previously duplicated between `StatusService` and `UpdateEngine`.
- Wires enforcement in `UpdateEngine.IdentifyActions` and `ProcessInstallWithDependenciesAsync`, mirroring the architecture-mismatch skip pattern.

## Why
Pkginfo authors need to gate packages on agent capability — for example, firmware-update items rely on predicate features that only exist in recent Cimian builds. Without this gate, a stale agent on a long-running host attempts the install and fails opaquely. The new field lets the pkginfo declare its dependency and the agent skips with a structured reason.

## Test plan
- [x] `.\build.ps1 -Sign -Binary managedsoftwareupdate`
- [x] `dotnet test` (one pre-existing unrelated failure noted separately)
- [ ] Manual: pkginfo with `minimum_cimian_version: "9999.99.99.9999"` should skip on current agent with `agent_version_too_old`.
- [ ] Manual: pkginfo with no `minimum_cimian_version` (the existing case) is unaffected.

## Note
Conflicts with #19 (OS version enforcement) in `UpdateEngine.cs` are expected; the gates use the same private-helper shape and adjacent call sites. Resolve by accepting both gates in sequence.