### PR TITLE
Move MSI ProductCode/UpgradeCode from installer block to installs[]

### DIFF
--- a/cli/cimiimport/Services/ImportService.cs
+++ b/cli/cimiimport/Services/ImportService.cs
@@ -160,9 +160,7 @@ public class ImportService
             {
                 Hash = fileHash,
                 Type = metadata.InstallerType,
-                Size = fileSizeKB,
-                ProductCode = string.IsNullOrEmpty(metadata.ProductCode) ? null : metadata.ProductCode.Trim(),
-                UpgradeCode = string.IsNullOrEmpty(metadata.UpgradeCode) ? null : metadata.UpgradeCode.Trim()
+                Size = fileSizeKB
             },
             Uninstaller = uninstaller != null ? [uninstaller] : null,
             UnattendedInstall = metadata.UnattendedInstall,
@@ -914,7 +912,9 @@ public class ImportService
             else if (kvp.Value is Installer installer)
             {
                 sb.AppendLine($"{kvp.Key}:");
-                // Output installer properties in a specific order
+                // MSI ProductCode/UpgradeCode belong in installs[] (type=msi), not here —
+                // installer is the artifact metadata (hash/size/location), installs[] is
+                // the install identity used to verify registration.
                 if (!string.IsNullOrEmpty(installer.Type))
                     sb.AppendLine($"  type: {installer.Type}");
                 if (installer.Size > 0)
@@ -923,10 +923,6 @@ public class ImportService
                     sb.AppendLine($"  location: {installer.Location}");
                 if (!string.IsNullOrEmpty(installer.Hash))
                     sb.AppendLine($"  hash: {installer.Hash}");
-                if (!string.IsNullOrEmpty(installer.ProductCode))
-                    sb.AppendLine($"  product_code: {EscapeYamlString(installer.ProductCode)}");
-                if (!string.IsNullOrEmpty(installer.UpgradeCode))
-                    sb.AppendLine($"  upgrade_code: {EscapeYamlString(installer.UpgradeCode)}");
                 if (installer.Arguments != null && installer.Arguments.Count > 0)
                 {
                     sb.AppendLine("  arguments:");

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -20,12 +20,7 @@ public class Installer
     [YamlMember(Alias = "hash", Order = 4)]
     public string? Hash { get; set; }
 
-    [YamlMember(Alias = "product_code", Order = 5)]
-    public string? ProductCode { get; set; }
-
-    [YamlMember(Alias = "upgrade_code", Order = 6)]
-    public string? UpgradeCode { get; set; }
-
+    // MSI ProductCode/UpgradeCode live on the installs[] type=msi entry, not here.
     [YamlMember(Alias = "arguments", Order = 7)]
     public List<string>? Arguments { get; set; }
 }

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -34,8 +34,10 @@ public class InstallItem
     [YamlMember(Alias = "type")]
     public string Type { get; set; } = "file";
 
+    // Nullable so OmitNull suppresses the key on type=msi entries (which have
+    // no path — install identity comes from product_code/upgrade_code).
     [YamlMember(Alias = "path")]
-    public string Path { get; set; } = string.Empty;
+    public string? Path { get; set; }
 
     [YamlMember(Alias = "md5checksum")]
     public string? Md5Checksum { get; set; }

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -98,13 +98,14 @@ public class PkgInfoBuilder
                 // Munki convention: MSI install identity belongs in installs[] of type=msi,
                 // not as a hash-only file entry pointing at the .msi artifact itself. The
                 // ProductCode/UpgradeCode here are what managedsoftwareupdate uses to
-                // verify Windows Installer registration.
+                // verify Windows Installer registration. Empty extractor results pass
+                // through as null so OmitNull suppresses the keys.
                 installs.Add(new InstallItem
                 {
                     Type = "msi",
-                    ProductCode = productCode,
-                    UpgradeCode = upgradeCode,
-                    Version = metaVersion
+                    ProductCode = string.IsNullOrEmpty(productCode) ? null : productCode,
+                    UpgradeCode = string.IsNullOrEmpty(upgradeCode) ? null : upgradeCode,
+                    Version = string.IsNullOrEmpty(metaVersion) ? null : metaVersion
                 });
                 break;
 

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -94,12 +94,16 @@ public class PkgInfoBuilder
                 metaDesc = msiMeta.Description;
                 productCode = msiMeta.ProductCode;
                 upgradeCode = msiMeta.UpgradeCode;
-                
+
+                // Munki convention: MSI install identity belongs in installs[] of type=msi,
+                // not as a hash-only file entry pointing at the .msi artifact itself. The
+                // ProductCode/UpgradeCode here are what managedsoftwareupdate uses to
+                // verify Windows Installer registration.
                 installs.Add(new InstallItem
                 {
-                    Type = "file",
-                    Path = installerPath,
-                    Md5Checksum = _extractor.CalculateMd5(installerPath),
+                    Type = "msi",
+                    ProductCode = productCode,
+                    UpgradeCode = upgradeCode,
                     Version = metaVersion
                 });
                 break;
@@ -187,12 +191,8 @@ public class PkgInfoBuilder
                 Type = installerType,
                 Size = sizeKB
             };
-
-            if (installerType == "msi")
-            {
-                pkgsinfo.Installer.ProductCode = productCode;
-                pkgsinfo.Installer.UpgradeCode = upgradeCode;
-            }
+            // ProductCode/UpgradeCode intentionally left off the installer block —
+            // they're carried in the installs[] type=msi entry above.
         }
         catch
         {

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -414,9 +414,13 @@ public class CatalogItem
     public bool IsUninstallable() => Uninstallable && (
         Uninstaller.Count > 0
         || Check.Registry.Name != null
-        // Self-uninstallable MSI: cimipkg-built MSI pkginfos carry the ProductCode in
-        // installer.product_code. Same GUID is what msiexec /x needs — UninstallAsync
-        // synthesizes an UninstallerInfo from it.
+        // Self-uninstallable MSI (canonical): installs[] entry of type=msi with a
+        // ProductCode. UninstallAsync synthesizes an UninstallerInfo from it.
+        || Installs.Any(i =>
+            string.Equals(i.Type, "msi", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrEmpty(i.ProductCode))
+        // Self-uninstallable MSI (legacy): pkginfos written before product_code moved
+        // out of the installer: block. Same msiexec /x path either way.
         || (Installer is { } msi
             && string.Equals(msi.Type, "msi", StringComparison.OrdinalIgnoreCase)
             && !string.IsNullOrEmpty(msi.ProductCode))

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -688,20 +688,27 @@ public class InstallerService
         }
         else
         {
-            // Self-uninstallable MSI: cimipkg-built MSI pkginfos already carry the
-            // ProductCode in installer.product_code (PR #10). The same GUID is what
-            // msiexec /x needs to remove the package — there is no reason to require
-            // a hand-rolled uninstaller: block when we already have authoritative data.
-            var msiInstaller = item.Installer;
-            if (msiInstaller != null
-                && string.Equals(msiInstaller.Type, "msi", StringComparison.OrdinalIgnoreCase)
-                && !string.IsNullOrEmpty(msiInstaller.ProductCode))
+            // Self-uninstallable MSI: prefer the installs[] type=msi ProductCode (canonical
+            // Munki shape, emitted by current cimiimport/makepkginfo). Fall back to legacy
+            // installer.product_code for pkginfos written before that change. Either GUID
+            // is what msiexec /x needs.
+            var msiProductCode = item.Installs
+                .FirstOrDefault(i => string.Equals(i.Type, "msi", StringComparison.OrdinalIgnoreCase)
+                                     && !string.IsNullOrEmpty(i.ProductCode))?.ProductCode;
+            if (string.IsNullOrEmpty(msiProductCode)
+                && item.Installer is { } legacyMsi
+                && string.Equals(legacyMsi.Type, "msi", StringComparison.OrdinalIgnoreCase))
             {
-                ConsoleLogger.Debug($"Synthesizing MSI uninstaller from installer.product_code item: {item.Name} productCode: {msiInstaller.ProductCode}");
+                msiProductCode = legacyMsi.ProductCode;
+            }
+
+            if (!string.IsNullOrEmpty(msiProductCode))
+            {
+                ConsoleLogger.Debug($"Synthesizing MSI uninstaller from product_code item: {item.Name} productCode: {msiProductCode}");
                 var synthetic = new UninstallerInfo
                 {
                     Type = "msi",
-                    ProductCode = msiInstaller.ProductCode
+                    ProductCode = msiProductCode
                 };
                 result = await UninstallMsiAsync(synthetic, cancellationToken);
             }

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -188,10 +188,11 @@ public class StatusService
                 return result;
             }
 
-            // Priority 6.5: top-level `installer:` block ProductCode/UpgradeCode (MSI authoritative).
-            // Look the package up in the Windows Uninstall / Installer\UpgradeCodes registry views
-            // — same source `msiexec` ultimately consults — when the pkgsinfo declares
-            // product_code/upgrade_code at the installer level, even with no installs[] array.
+            // Priority 6.5 (legacy): top-level `installer:` block ProductCode/UpgradeCode.
+            // Current cimiimport/makepkginfo emit the MSI install identity in installs[] of
+            // type=msi (handled in Priority 2 → CheckInstallsArray); this branch only fires
+            // for older pkgsinfos written before that move. Same Windows Installer registry
+            // lookup either way.
             var msiInstaller = item.Installer;
             if (msiInstaller != null
                 && string.Equals(msiInstaller.Type, "msi", StringComparison.OrdinalIgnoreCase)

--- a/tests/Makepkginfo/PkgInfoBuilderTests.cs
+++ b/tests/Makepkginfo/PkgInfoBuilderTests.cs
@@ -215,17 +215,26 @@ public class PkgInfoBuilderTests
                 Type = "msi",
                 Size = 1024,
                 Location = "test.msi",
-                Hash = "abc123",
-                ProductCode = "{GUID}",
-                UpgradeCode = "{GUID2}"
+                Hash = "abc123"
+            },
+            Installs = new List<InstallItem>
+            {
+                new InstallItem
+                {
+                    Type = "msi",
+                    ProductCode = "{GUID}",
+                    UpgradeCode = "{GUID2}",
+                    Version = "1.0.0"
+                }
             }
         };
-        
+
         var yaml = _builder.SerializePkgsInfo(pkgsinfo);
-        
+
         Assert.Contains("installer:", yaml);
         Assert.Contains("type:", yaml);
         Assert.Contains("msi", yaml);
+        Assert.Contains("installs:", yaml);
         Assert.Contains("product_code:", yaml);
     }
 
@@ -318,17 +327,13 @@ public class PkgsInfoModelTests
             Size = 2048,
             Location = "package.msi",
             Hash = "sha256hash",
-            ProductCode = "{12345}",
-            UpgradeCode = "{67890}",
             Arguments = new List<string> { "/quiet", "/norestart" }
         };
-        
+
         Assert.Equal("msi", installer.Type);
         Assert.Equal(2048, installer.Size);
         Assert.Equal("package.msi", installer.Location);
         Assert.Equal("sha256hash", installer.Hash);
-        Assert.Equal("{12345}", installer.ProductCode);
-        Assert.Equal("{67890}", installer.UpgradeCode);
         Assert.Equal(2, installer.Arguments!.Count);
     }
 


### PR DESCRIPTION
## Summary
- **Producer fix**: cimiimport and makepkginfo now emit MSI `product_code`/`upgrade_code` only in `installs[]` of `type: msi` (Munki convention), not on the top-level `installer:` block. makepkginfo also stops writing the misleading `installs[]` `type: file` entry that pointed at the `.msi` artifact itself.
- **Consumer fix** (managedsoftwareupdate): `IsUninstallable()` and the self-uninstall synthesis in `InstallerService` now accept an `installs[]` `type: msi` entry with `ProductCode` as the MSI self-uninstall signal — so producer and consumer stay in sync.
- Legacy `installer.product_code` paths kept as a read-side fallback so existing pkgsinfos in the wild continue to verify and self-uninstall.

## Why
A freshly imported MSI pkginfo looked like this:

```yaml
installer:
  type: msi
  ...
  product_code: '{2c643ccc-...}'
  upgrade_code: '{229fa234-...}'
# no installs: array at all
```

Two problems:
1. `product_code`/`upgrade_code` belong in `installs[]` of `type: msi`, not on the installer block — the installer block describes the artifact (hash/size/location), `installs[]` describes the install identity used to verify Windows Installer registration.
2. Without an `installs[]` MSI entry, `managedsoftwareupdate`'s `VerifyInstallationBeforeRegistry` had nothing to check against and fell through to "No installs array — cannot verify, assuming success" for every MSI it installed. (The `installs[]` emission was added in #18 the same day the user's binary was built but at a later timestamp, so the running binary missed it.)

## What changed where

**Producer**
- `cli/cimiimport/Services/ImportService.cs` — drop `ProductCode`/`UpgradeCode` from the `Installer` construction and from the installer-block YAML emitter.
- `cli/makepkginfo/Services/PkgInfoBuilder.cs` — for `.msi`, emit an `installs[]` `type: msi` entry instead of `type: file`; drop the `Installer.ProductCode`/`UpgradeCode` assignment.
- `cli/makepkginfo/Models/PkgsInfo.cs` — remove `ProductCode`/`UpgradeCode` from the `Installer` model (they belong on `InstallItem`).

**Consumer**
- `cli/managedsoftwareupdate/Services/InstallerService.cs` — self-uninstall synthesis prefers `installs[]` `type: msi` `ProductCode`, falls back to legacy `installer.product_code`.
- `cli/managedsoftwareupdate/Models/UpdateModels.cs` — `IsUninstallable()` accepts either the canonical `installs[]` MSI entry or the legacy installer-block GUID.
- `cli/managedsoftwareupdate/Services/StatusService.cs` — Priority 6.5 comment re-labelled as legacy fallback; new pkgsinfos hit Priority 2 (`CheckInstallsArray` → MSI case) which uses the same `CheckMsiWithUpgradeCode` registry lookup.

**Tests**
- `tests/Makepkginfo/PkgInfoBuilderTests.cs` — updated `SerializePkgsInfo_IncludesInstallerDetails` and `Installer_CanSetAllProperties` to match the new shape. Full suite: **629/629 passing**.

## Test plan
- [x] `dotnet build CimianTools.sln` — green
- [x] `dotnet test CimianTools.sln` — 629 passed, 0 failed
- [ ] Rebuild signed binaries: `.\build.ps1 -Sign -Binary cimiimport`, `... makepkginfo`, `... managedsoftwareupdate`
- [ ] Re-import an MSI (e.g. ReportMate) and verify the YAML has `installs[]` of `type: msi` with the GUIDs and the `installer:` block has only `type/size/location/hash`
- [ ] `sudo .\release\arm64\managedsoftwareupdate.exe -v --checkonly` against a freshly-imported MSI pkginfo — expect MSI verification via installs[] (Priority 2)
- [ ] Verify legacy pkgsinfo with `installer.product_code` still verifies (Priority 6.5 fallback) and is still considered uninstallable