### PR TITLE
Add model_version fact from Win32_ComputerSystemProduct.Version

### DIFF
--- a/shared/core/Models/SystemFacts.cs
+++ b/shared/core/Models/SystemFacts.cs
@@ -85,6 +85,16 @@ public class SystemFacts
     public string MachineModel { get; set; } = string.Empty;
 
     /// <summary>
+    /// Friendly model name from Win32_ComputerSystemProduct.Version
+    /// (e.g., "ThinkCentre M75q Gen 2", "ThinkPad X1 Carbon Gen 11").
+    /// On Lenovo hardware, Win32_ComputerSystem.Model returns the raw MTM code
+    /// (e.g., "11JQS6CH00") and the human-readable model lives here. May be
+    /// empty on vendors that don't populate this field (e.g., Dell).
+    /// Maps to 'model_version' fact key.
+    /// </summary>
+    public string ModelVersion { get; set; } = string.Empty;
+
+    /// <summary>
     /// Domain join type: workgroup, domain, entra, hybrid
     /// Maps to 'joined_type' fact key
     /// </summary>
@@ -271,6 +281,7 @@ public class SystemFacts
             "username" => Username,
             "machine_type" => MachineType,
             "machine_model" => MachineModel,
+            "model_version" => ModelVersion,
             "joined_type" => JoinedType,
             "battery_state" => BatteryState,
             "date" => Date,

--- a/shared/infrastructure/System/SystemFactsCollector.cs
+++ b/shared/infrastructure/System/SystemFactsCollector.cs
@@ -191,6 +191,26 @@ public class SystemFactsCollector : ISystemFactsCollector
                 }
             }
 
+            // Friendly model name lives on Win32_ComputerSystemProduct.Version on Lenovo
+            // (Win32_ComputerSystem.Model returns the MTM code there).
+            try
+            {
+                using var productSearcher = new ManagementObjectSearcher("SELECT Version FROM Win32_ComputerSystemProduct");
+                foreach (ManagementObject mo in productSearcher.Get())
+                {
+                    var version = mo["Version"]?.ToString()?.Trim() ?? "";
+                    if (!string.IsNullOrEmpty(version))
+                    {
+                        facts.ModelVersion = version;
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to read Win32_ComputerSystemProduct.Version");
+            }
+
             // Determine machine type (laptop, desktop, virtual, server)
             facts.MachineType = DetermineMachineType();
             facts.BatteryState = GetBatteryState();

--- a/tests/PredicateEngineTests.cs
+++ b/tests/PredicateEngineTests.cs
@@ -502,12 +502,39 @@ public class PredicateEngineTests
     public async Task EvaluateCondition_QuotedValueWithSpaces_ShouldMatch()
     {
         var facts = CreateFacts(machineModel: "Dell OptiPlex 7090");
-        
+
         var result = await _engine.EvaluateConditionAsync(
-            "machine_model == 'Dell OptiPlex 7090'", 
+            "machine_model == 'Dell OptiPlex 7090'",
             facts);
-        
+
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EvaluateCondition_ModelVersion_ContainsLenovoFriendlyName()
+    {
+        // Lenovo Win32_ComputerSystem.Model is the MTM code; the friendly name
+        // lives on Win32_ComputerSystemProduct.Version → exposed as model_version.
+        var facts = CreateFacts(
+            machineModel: "LENOVO 11JQS6CH00",
+            modelVersion: "ThinkCentre M75q Gen 2");
+
+        (await _engine.EvaluateConditionAsync("model_version CONTAINS 'M75q'", facts))
+            .Should().BeTrue();
+        (await _engine.EvaluateConditionAsync("machine_model CONTAINS 'M75q'", facts))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateCondition_ModelVersion_EmptyOnVendorsThatDontPopulateIt()
+    {
+        // Dell leaves Win32_ComputerSystemProduct.Version empty.
+        var facts = CreateFacts(
+            machineModel: "Dell Inc. Precision 3660",
+            modelVersion: "");
+
+        (await _engine.EvaluateConditionAsync("model_version == ''", facts))
+            .Should().BeTrue();
     }
 
     [Theory]
@@ -809,6 +836,7 @@ public class PredicateEngineTests
         string machineType = "desktop",
         string joinedType = "workgroup",
         string machineModel = "Generic PC",
+        string modelVersion = "",
         string[]? catalogs = null,
         string[]? gpuNames = null,
         string gpuDriverVersion = "",
@@ -833,6 +861,7 @@ public class PredicateEngineTests
             MachineType = machineType,
             JoinedType = joinedType,
             MachineModel = machineModel,
+            ModelVersion = modelVersion,
             Catalogs = catalogs?.ToList() ?? new List<string>(),
             GpuNames = gpuNames?.ToList() ?? new List<string>(),
             GpuDriverVersion = gpuDriverVersion,


### PR DESCRIPTION
## Summary
- New `model_version` predicate fact populated from `Win32_ComputerSystemProduct.Version`.
- On Lenovo hardware, `Win32_ComputerSystem.Model` returns the raw MTM (e.g. `11JQS6CH00`) â€” the human-readable name (e.g. `ThinkCentre M75q Gen 2`) lives on `ComputerSystemProduct.Version`. This lets manifest authors write `model_version CONTAINS "M75q"` instead of enumerating MTM prefixes.
- Empty on vendors that don't populate that field (e.g. Dell). Existing `machine_model` is unchanged.

## Motivation
Targeting MaxCPUthrottle to a Lenovo M75q subset in `Classroom.yaml` â€” `machine_model CONTAINS "M75q"` would not match because the MTM hides the friendly name. Verified live on `COMD-RG-01` (M75q Gen 2 â†’ `Version = "ThinkCentre M75q Gen 2"`) and `LAB-HOST-01` (Dell Precision 3660 â†’ empty Version).

## Changes
- `shared/core/Models/SystemFacts.cs`: add `ModelVersion` property + `model_version` mapping in `GetFactValue`.
- `shared/infrastructure/System/SystemFactsCollector.cs`: read `Win32_ComputerSystemProduct.Version` in `CollectMachineInfo`, with isolated try/catch so a failure doesn't break the rest of machine-info collection.
- `tests/PredicateEngineTests.cs`: extend `CreateFacts` helper and add two tests covering the Lenovo / Dell cases.

## Test plan
- [x] `dotnet test tests --filter PredicateEngineTests` â€” 108/108 passing locally
- [ ] CI green
- [ ] After merge + client rollout, validate on a real M75q that `managedsoftwareupdate --checkonly` evaluates `model_version CONTAINS "M75q"` true

[](https://dev.azure.com/example-org/f6d33719-4062-45ea-af9e-4e4f881c1409/_workitems/edit/259)
