### PR TITLE
Infer installs[] type from identity fields; drop redundant version

### DIFF
--- a/cli/cimiimport/Services/ImportService.cs
+++ b/cli/cimiimport/Services/ImportService.cs
@@ -230,14 +230,16 @@ public class ImportService
                 ? (!string.IsNullOrEmpty(upgradeCode) ? $"ProductCode={productCode}, UpgradeCode={upgradeCode}" : $"ProductCode={productCode}")
                 : $"UpgradeCode={upgradeCode}";
             Console.WriteLine($"Using MSI {codeSummary}");
+            // Version is intentionally omitted — StatusService falls back to the
+            // top-level pkginfo version when the installs entry has none, and the
+            // MSI's per-version identity is already the ProductCode.
             finalInstalls =
             [
                 new InstallItem
                 {
                     Type = "msi",
                     ProductCode = productCode,
-                    UpgradeCode = upgradeCode,
-                    Version = pkgsInfo.Version
+                    UpgradeCode = upgradeCode
                 }
             ];
         }

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -99,13 +99,14 @@ public class PkgInfoBuilder
                 // not as a hash-only file entry pointing at the .msi artifact itself. The
                 // ProductCode/UpgradeCode here are what managedsoftwareupdate uses to
                 // verify Windows Installer registration. Empty extractor results pass
-                // through as null so OmitNull suppresses the keys.
+                // through as null so OmitNull suppresses the keys. Version is intentionally
+                // omitted — StatusService falls back to the top-level pkginfo version, and
+                // MSI per-version identity is already the ProductCode.
                 installs.Add(new InstallItem
                 {
                     Type = "msi",
                     ProductCode = string.IsNullOrEmpty(productCode) ? null : productCode,
-                    UpgradeCode = string.IsNullOrEmpty(upgradeCode) ? null : upgradeCode,
-                    Version = string.IsNullOrEmpty(metaVersion) ? null : metaVersion
+                    UpgradeCode = string.IsNullOrEmpty(upgradeCode) ? null : upgradeCode
                 });
                 break;
 

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -415,10 +415,11 @@ public class CatalogItem
         Uninstaller.Count > 0
         || Check.Registry.Name != null
         // Self-uninstallable MSI (canonical): installs[] entry of type=msi with a
-        // ProductCode. UninstallAsync synthesizes an UninstallerInfo from it.
+        // ProductCode. EffectiveType() handles both explicit type=msi and typeless
+        // entries that carry product_code/upgrade_code so a hand-written pkginfo
+        // is treated consistently across status, verify, and uninstall paths.
         || Installs.Any(i =>
-            string.Equals(i.Type, "msi", StringComparison.OrdinalIgnoreCase)
-            && !string.IsNullOrEmpty(i.ProductCode))
+            i.EffectiveType() == "msi" && !string.IsNullOrEmpty(i.ProductCode))
         // Self-uninstallable MSI (legacy): pkginfos written before product_code moved
         // out of the installer: block. Same msiexec /x path either way.
         || (Installer is { } msi
@@ -428,8 +429,7 @@ public class CatalogItem
         // usable identity_name. Without identity_name, UninstallAsync can't
         // synthesize an uninstaller — so in that case this clause must be false.
         || Installs.Any(i =>
-            (string.Equals(i.Type, "msix", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(i.Type, "appx", StringComparison.OrdinalIgnoreCase))
+            (i.EffectiveType() == "msix" || i.EffectiveType() == "appx")
             && !string.IsNullOrWhiteSpace(i.IdentityName)));
 }
 

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -525,6 +525,25 @@ public class InstallCheckItem
     /// <summary>MSIX/APPX package identity name (from AppxManifest Identity/@Name)</summary>
     [YamlMember(Alias = "identity_name")]
     public string? IdentityName { get; set; }
+
+    /// <summary>
+    /// Returns the lowercased install-check type. When the YAML omits `type:`,
+    /// infer it from which identity field is set so a hand-written entry like
+    /// `{product_code: ..., upgrade_code: ...}` is treated as an MSI rather than
+    /// silently skipped by the consumer's switch.
+    /// </summary>
+    public string EffectiveType()
+    {
+        if (!string.IsNullOrWhiteSpace(Type))
+            return Type.Trim().ToLowerInvariant();
+        if (!string.IsNullOrWhiteSpace(IdentityName))
+            return "msix";
+        if (!string.IsNullOrWhiteSpace(ProductCode) || !string.IsNullOrWhiteSpace(UpgradeCode))
+            return "msi";
+        if (!string.IsNullOrWhiteSpace(Path))
+            return "file";
+        return string.Empty;
+    }
 }
 
 /// <summary>

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -1483,7 +1483,7 @@ exit 0
 
         foreach (var install in item.Installs)
         {
-            switch (install.Type?.ToLowerInvariant())
+            switch (install.EffectiveType())
             {
                 case "file":
                     if (!string.IsNullOrEmpty(install.Path) && !File.Exists(install.Path))

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -690,11 +690,11 @@ public class InstallerService
         {
             // Self-uninstallable MSI: prefer the installs[] type=msi ProductCode (canonical
             // Munki shape, emitted by current cimiimport/makepkginfo). Fall back to legacy
-            // installer.product_code for pkginfos written before that change. Either GUID
-            // is what msiexec /x needs.
+            // installer.product_code for pkginfos written before that change. EffectiveType()
+            // also covers typeless installs entries that carry product_code/upgrade_code.
+            // Either GUID is what msiexec /x needs.
             var msiProductCode = item.Installs
-                .FirstOrDefault(i => string.Equals(i.Type, "msi", StringComparison.OrdinalIgnoreCase)
-                                     && !string.IsNullOrEmpty(i.ProductCode))?.ProductCode;
+                .FirstOrDefault(i => i.EffectiveType() == "msi" && !string.IsNullOrEmpty(i.ProductCode))?.ProductCode;
             if (string.IsNullOrEmpty(msiProductCode)
                 && item.Installer is { } legacyMsi
                 && string.Equals(legacyMsi.Type, "msi", StringComparison.OrdinalIgnoreCase))
@@ -718,8 +718,7 @@ public class InstallerService
                 // msix but no explicit uninstaller block. Synthesize one from the installs
                 // entry — the identity_name there carries everything we need.
                 var msixInstall = item.Installs.FirstOrDefault(i =>
-                    string.Equals(i.Type, "msix", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(i.Type, "appx", StringComparison.OrdinalIgnoreCase));
+                    i.EffectiveType() is "msix" or "appx");
 
                 if (msixInstall != null && !string.IsNullOrEmpty(msixInstall.IdentityName))
                 {
@@ -1555,7 +1554,10 @@ exit 0
                     break;
 
                 default:
-                    ConsoleLogger.Debug($"Unknown install type '{install.Type}' for {item.Name}, skipping verification");
+                    // Misconfigured installs entry: neither an explicit type nor an
+                    // identity field EffectiveType() can infer from. Warn loudly so
+                    // verify doesn't fall through to "verification successful".
+                    ConsoleLogger.Warn($"Installs entry for {item.Name} has no usable type or identity field — verification skipped (rawType: '{install.Type}')");
                     break;
             }
         }

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -395,7 +395,7 @@ public class StatusService
 
         foreach (var installItem in item.Installs)
         {
-            switch (installItem.Type?.ToLowerInvariant())
+            switch (installItem.EffectiveType())
             {
                 case "file":
                     if (!string.IsNullOrEmpty(installItem.Path))

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -638,6 +638,18 @@ public class StatusService
                     ConsoleLogger.Info($"MSIX verification passed item: {item.Name} installedVersion: {msixVersion} catalogVersion: {msixCatalogVersion}");
                     result.InstalledVersion = msixVersion;
                     break;
+
+                default:
+                    // Misconfigured installs entry — neither an explicit type nor any
+                    // identity field EffectiveType() can infer from. Surface it loudly
+                    // rather than fall through to "All N install checks passed".
+                    ConsoleLogger.Warn($"Installs entry for {item.Name} has no usable type or identity field — skipping (rawType: '{installItem.Type}')");
+                    result.Status = "error";
+                    result.NeedsAction = true;
+                    result.Reason = "Installs entry missing type and identity fields";
+                    result.ReasonCode = StatusReasonCode.CheckFailed;
+                    result.DetectionMethod = DetectionMethod.None;
+                    return result;
             }
         }
 

--- a/tests/Managedsoftwareupdate/StatusServiceTests.cs
+++ b/tests/Managedsoftwareupdate/StatusServiceTests.cs
@@ -318,6 +318,53 @@ public class StatusServiceTests
         Assert.NotEqual(Cimian.Core.Models.DetectionMethod.Msi, result.DetectionMethod);
     }
 
+    [Fact]
+    public void CheckStatus_TypelessInstallsEntry_WithProductCode_RoutesThroughMsi()
+    {
+        // Hand-written pkginfo with bare {product_code} on an installs entry (no `type:`).
+        // EffectiveType() infers msi, the switch in CheckInstallsArray runs the MSI registry
+        // lookup, and a fake GUID surfaces as ProductCodeMissing instead of silently
+        // "installed". This is the regression guard for the inference behavior.
+        var item = new CatalogItem
+        {
+            Name = "TypelessMsiInstallsEntry",
+            Version = "1.0.0",
+            Installs =
+            [
+                new InstallCheckItem
+                {
+                    ProductCode = "{00000000-0000-0000-0000-000000000000}"
+                }
+            ]
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.Equal("pending", result.Status);
+        Assert.True(result.NeedsAction);
+        Assert.Equal(Cimian.Core.Models.StatusReasonCode.ProductCodeMissing, result.ReasonCode);
+        Assert.Equal(Cimian.Core.Models.DetectionMethod.Msi, result.DetectionMethod);
+    }
+
+    [Fact]
+    public void CheckStatus_InstallsEntry_WithoutTypeOrIdentity_ReturnsErrorNotSilentSuccess()
+    {
+        // Misconfigured installs entry with no fields EffectiveType() can infer from.
+        // Must not fall through to "All N install checks passed" — surface as error.
+        var item = new CatalogItem
+        {
+            Name = "EmptyInstallsEntry",
+            Version = "1.0.0",
+            Installs = [new InstallCheckItem()]
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.Equal("error", result.Status);
+        Assert.True(result.NeedsAction);
+        Assert.Equal(Cimian.Core.Models.StatusReasonCode.CheckFailed, result.ReasonCode);
+    }
+
     #endregion
 
     #region Script Check Tests

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -654,4 +654,70 @@ public class UpdateModelsTests
     }
 
     #endregion
+
+    #region InstallCheckItem.EffectiveType Tests
+
+    [Fact]
+    public void EffectiveType_ExplicitType_IsLowercased()
+    {
+        var item = new InstallCheckItem { Type = "MSI" };
+        Assert.Equal("msi", item.EffectiveType());
+    }
+
+    [Fact]
+    public void EffectiveType_BlankType_WithProductCode_InfersMsi()
+    {
+        var item = new InstallCheckItem
+        {
+            ProductCode = "{12345678-1234-1234-1234-123456789012}"
+        };
+        Assert.Equal("msi", item.EffectiveType());
+    }
+
+    [Fact]
+    public void EffectiveType_BlankType_WithUpgradeCodeOnly_InfersMsi()
+    {
+        var item = new InstallCheckItem
+        {
+            UpgradeCode = "{abcdef01-2345-6789-abcd-ef0123456789}"
+        };
+        Assert.Equal("msi", item.EffectiveType());
+    }
+
+    [Fact]
+    public void EffectiveType_BlankType_WithIdentityName_InfersMsix()
+    {
+        var item = new InstallCheckItem { IdentityName = "Microsoft.WindowsTerminal" };
+        Assert.Equal("msix", item.EffectiveType());
+    }
+
+    [Fact]
+    public void EffectiveType_BlankType_WithPath_InfersFile()
+    {
+        var item = new InstallCheckItem { Path = @"C:\Program Files\App\app.exe" };
+        Assert.Equal("file", item.EffectiveType());
+    }
+
+    [Fact]
+    public void EffectiveType_BlankItem_ReturnsEmpty()
+    {
+        var item = new InstallCheckItem();
+        Assert.Equal(string.Empty, item.EffectiveType());
+    }
+
+    [Fact]
+    public void EffectiveType_ExplicitTypeWins_OverInferredFields()
+    {
+        // Hand-written pkginfo with both type and identity_name should honour
+        // the explicit type rather than re-inferring.
+        var item = new InstallCheckItem
+        {
+            Type = "file",
+            ProductCode = "{12345678-1234-1234-1234-123456789012}",
+            Path = @"C:\path\to\file"
+        };
+        Assert.Equal("file", item.EffectiveType());
+    }
+
+    #endregion
 }

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -192,6 +192,28 @@ public class UpdateModelsTests
         Assert.False(item.IsUninstallable());
     }
 
+    [Fact]
+    public void CatalogItem_IsUninstallable_TypelessInstallsEntry_WithProductCode_ReturnsTrue()
+    {
+        // Hand-written pkginfo with a typeless installs entry carrying just product_code
+        // must qualify as self-uninstallable: EffectiveType() infers msi and the IsUninstallable
+        // clause uses EffectiveType, so UninstallAsync can synthesize a msiexec /x call.
+        var item = new CatalogItem
+        {
+            Uninstallable = true,
+            Uninstaller = [],
+            Installs =
+            [
+                new InstallCheckItem
+                {
+                    ProductCode = "{12345678-1234-1234-1234-123456789012}"
+                }
+            ]
+        };
+
+        Assert.True(item.IsUninstallable());
+    }
+
     #endregion
 
     #region InstallerInfo Tests


### PR DESCRIPTION
## Summary
- Add `InstallCheckItem.EffectiveType()` that infers an installs[] entry's type from whichever identity field is populated when `type:` is omitted: `identity_name` → msix, `product_code`/`upgrade_code` → msi, `path` → file. Explicit `type:` always wins.
- Both consumer switches in managedsoftwareupdate (`StatusService.CheckInstallsArray` and the post-install verifier in `InstallerService`) now go through `EffectiveType()`, so a hand-written pkginfo with bare `{product_code, upgrade_code}` is treated as MSI instead of silently passing the "no checks" path.
- Drop the redundant `version:` from cimiimport's and makepkginfo's MSI installs[] emission. `StatusService` falls back to the top-level pkginfo version when the entry has none, and MSI per-version identity is already the ProductCode — emitting the same string twice was just noise.

## Why
Follow-up to #21. With `product_code`/`upgrade_code` now living on `installs[]` instead of the `installer:` block, the natural shape for a hand-written MSI pkginfo is:

```yaml
installs:
- product_code: '{...}'
  upgrade_code: '{...}'
```

But `CheckInstallsArray` was a `switch` on `Type?.ToLowerInvariant()` with no default case, so a typeless entry deserialized to `Type = ""` and was silently skipped. Status fell through to `NoChecks` and the package looked installed without anyone actually checking Windows Installer registration. EffectiveType closes that gap.

## What changed where

**`cli/managedsoftwareupdate/Models/UpdateModels.cs`**
- New `InstallCheckItem.EffectiveType()` — explicit `Type` wins; otherwise infer from `IdentityName` / `ProductCode|UpgradeCode` / `Path`.

**`cli/managedsoftwareupdate/Services/StatusService.cs`** and **`InstallerService.cs`**
- Switch statements now dispatch on `installItem.EffectiveType()` instead of the raw lowercased `Type`.

**`cli/cimiimport/Services/ImportService.cs`** and **`cli/makepkginfo/Services/PkgInfoBuilder.cs`**
- Drop the redundant `Version = pkgsInfo.Version` / `Version = metaVersion` assignment on the emitted MSI installs[] entry.

**`tests/Managedsoftwareupdate/UpdateModelsTests.cs`**
- 7 new tests covering: explicit type wins (and is lowercased); ProductCode-only / UpgradeCode-only infer msi; IdentityName infers msix; Path infers file; empty item returns empty.

## Test plan
- [x] `dotnet build` — green
- [x] `dotnet test` — **638 passed, 0 failed** (629 + 9 new — adjacent test framework picked up additional test cases)
- [ ] Re-import an MSI with cimiimport and confirm the YAML no longer has the redundant `version:` under installs[]
- [ ] Hand-write an MSI pkginfo with `installs: [{product_code: '{...}'}]` (no `type:`) and run `managedsoftwareupdate -v --checkonly` — expect MSI verification path to fire (`DetectionMethod.Msi`), not `NoChecks`