### PR TITLE
managedsoftwareupdate: don't skip auto run when a user is logged in

### DIFF
--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -1584,42 +1584,56 @@ if ($results.Count -gt 0) {{
     #region Pending State Detection
 
     /// <summary>
-    /// Checks if any blocking applications are running for the given item
+    /// Returns the set of currently running process names (lowercase, no extension).
+    /// Snapshot once per evaluation pass and reuse via the CheckBlockingApps overload
+    /// rather than re-enumerating processes for every item.
     /// </summary>
-    /// <param name="blockingApps">List of process names or executable paths to check</param>
-    /// <param name="runningApps">Output: list of blocking apps that are currently running</param>
-    /// <returns>True if any blocking apps are running</returns>
-    public static bool CheckBlockingApps(IEnumerable<string>? blockingApps, out List<string> runningApps)
+    public static HashSet<string> GetRunningProcessNames()
     {
-        runningApps = new List<string>();
-        
-        if (blockingApps == null) return false;
-
         try
         {
-            var processes = System.Diagnostics.Process.GetProcesses()
+            return System.Diagnostics.Process.GetProcesses()
                 .Select(p => p.ProcessName.ToLowerInvariant())
                 .ToHashSet();
-
-            foreach (var app in blockingApps)
-            {
-                if (string.IsNullOrEmpty(app)) continue;
-                
-                // Extract process name without extension
-                var processName = Path.GetFileNameWithoutExtension(app).ToLowerInvariant();
-                
-                if (processes.Contains(processName))
-                {
-                    runningApps.Add(app);
-                }
-            }
         }
         catch
         {
-            // On error, assume no blocking apps
+            return new HashSet<string>();
+        }
+    }
+
+    /// <summary>
+    /// Checks if any blocking applications are running, using a precomputed process snapshot.
+    /// </summary>
+    public static bool CheckBlockingApps(IEnumerable<string>? blockingApps, ISet<string> runningProcessNames, out List<string> runningApps)
+    {
+        runningApps = new List<string>();
+
+        if (blockingApps == null) return false;
+
+        foreach (var app in blockingApps)
+        {
+            if (string.IsNullOrEmpty(app)) continue;
+
+            var processName = Path.GetFileNameWithoutExtension(app).ToLowerInvariant();
+
+            if (runningProcessNames.Contains(processName))
+            {
+                runningApps.Add(app);
+            }
         }
 
         return runningApps.Count > 0;
+    }
+
+    /// <summary>
+    /// Checks if any blocking applications are running for the given item.
+    /// Convenience overload that snapshots the process list internally.
+    /// Prefer the overload that accepts a precomputed snapshot when checking many items.
+    /// </summary>
+    public static bool CheckBlockingApps(IEnumerable<string>? blockingApps, out List<string> runningApps)
+    {
+        return CheckBlockingApps(blockingApps, GetRunningProcessNames(), out runningApps);
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -560,24 +560,24 @@ public class UpdateEngine : IDisposable
                     for (int i = list.Count - 1; i >= 0; i--)
                     {
                         var item = list[i];
-                        string? skipReason = null;
+                        string? deferReason = null;
                         if (!item.UnattendedInstall)
                         {
-                            skipReason = "unattended_install is false";
+                            deferReason = "unattended_install is false";
                         }
                         else if (RequiresRestart(item) || RequiresLogout(item))
                         {
-                            skipReason = $"restart_action '{item.RestartAction}' would interrupt the active user";
+                            deferReason = $"restart_action '{item.RestartAction}' would interrupt the active user";
                         }
 
-                        if (skipReason != null)
+                        if (deferReason != null)
                         {
-                            LogInfo($"Skipping install of {item.Name} v{item.Version}: {skipReason}");
-                            _sessionLogger?.Log("INFO", $"Skipped {item.Name} v{item.Version}: {skipReason} (auto mode, user active)");
+                            LogInfo($"Deferred install of {item.Name} v{item.Version}: {deferReason}");
+                            _sessionLogger?.Log("INFO", $"Deferred {item.Name} v{item.Version}: {deferReason} (auto mode, user active)");
                             _sessionLogger?.LogStatusCheck(
-                                item.Name, item.Version, "skipped",
-                                skipReason,
-                                Cimian.Core.Models.StatusReasonCode.UserDeferred,
+                                item.Name, item.Version, "deferred",
+                                deferReason,
+                                Cimian.Core.Models.StatusReasonCode.DeferredUserActive,
                                 Cimian.Core.Models.DetectionMethod.None, null, false);
                             skippedUnattended.Add(item);
                             list.RemoveAt(i);
@@ -588,20 +588,25 @@ public class UpdateEngine : IDisposable
                 for (int i = toUninstall.Count - 1; i >= 0; i--)
                 {
                     var item = toUninstall[i];
-                    string? skipReason = null;
+                    string? deferReason = null;
                     if (!item.UnattendedUninstall)
                     {
-                        skipReason = "unattended_uninstall is false";
+                        deferReason = "unattended_uninstall is false";
                     }
                     else if (RequiresRestart(item) || RequiresLogout(item))
                     {
-                        skipReason = $"restart_action '{item.RestartAction}' would interrupt the active user";
+                        deferReason = $"restart_action '{item.RestartAction}' would interrupt the active user";
                     }
 
-                    if (skipReason != null)
+                    if (deferReason != null)
                     {
-                        LogInfo($"Skipping removal of {item.Name} v{item.Version}: {skipReason}");
-                        _sessionLogger?.Log("INFO", $"Skipped removal of {item.Name} v{item.Version}: {skipReason} (auto mode, user active)");
+                        LogInfo($"Deferred removal of {item.Name} v{item.Version}: {deferReason}");
+                        _sessionLogger?.Log("INFO", $"Deferred removal of {item.Name} v{item.Version}: {deferReason} (auto mode, user active)");
+                        _sessionLogger?.LogStatusCheck(
+                            item.Name, item.Version, "deferred",
+                            deferReason,
+                            Cimian.Core.Models.StatusReasonCode.DeferredUserActive,
+                            Cimian.Core.Models.DetectionMethod.None, null, false);
                         skippedUnattended.Add(item);
                         toUninstall.RemoveAt(i);
                     }
@@ -2650,7 +2655,7 @@ public class UpdateEngine : IDisposable
 
     private static bool RequiresLogout(CatalogItem item)
     {
-        return item.RestartAction is "RequireLogout";
+        return item.RestartAction is "RequireLogout" or "RecommendLogout";
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -516,6 +516,8 @@ public class UpdateEngine : IDisposable
             // Per-item: defer items whose blocking_applications are running.
             // Installing while the blocking app is open would fail or destroy
             // the user's open work. Always applied — independent of mode/user.
+            // Snapshot the running-process set once so the per-item check is O(1).
+            var runningProcessNames = StatusService.GetRunningProcessNames();
             var blockedItems = new List<CatalogItem>();
             foreach (var list in new[] { toInstall, toUpdate, toUninstall })
             {
@@ -524,7 +526,7 @@ public class UpdateEngine : IDisposable
                     var item = list[i];
                     if (item.BlockingApps.Count == 0) continue;
 
-                    if (StatusService.CheckBlockingApps(item.BlockingApps, out var running))
+                    if (StatusService.CheckBlockingApps(item.BlockingApps, runningProcessNames, out var running))
                     {
                         var runningList = string.Join(", ", running);
                         LogInfo($"Deferred: {item.Name} v{item.Version} (blocking applications running: {runningList})");
@@ -533,7 +535,7 @@ public class UpdateEngine : IDisposable
                             item.Name, item.Version, "deferred",
                             $"Blocking applications running: {runningList}",
                             Cimian.Core.Models.StatusReasonCode.BlockingApps,
-                            Cimian.Core.Models.DetectionMethod.None, null, false);
+                            Cimian.Core.Models.DetectionMethod.None, null, true);
                         blockedItems.Add(item);
                         list.RemoveAt(i);
                     }
@@ -546,10 +548,11 @@ public class UpdateEngine : IDisposable
 
             // Auto mode + active user: restrict to items that can run silently
             // without disrupting the session. An item is eligible only if it is
-            // marked unattended AND its restart_action would not log the user
-            // out or reboot. Everything else is deferred to a later run (idle
-            // machine, interactive run, or scheduled maintenance window).
-            var skippedUnattended = new List<CatalogItem>();
+            // marked unattended AND its restart_action would not reboot or log
+            // the user out (Require* and Recommend* are both treated as
+            // disruptive here). Everything else is deferred to a later run
+            // (idle machine, interactive run, or scheduled maintenance window).
+            var deferredForUser = new List<CatalogItem>();
             if (_auto && StatusService.IsUserActive())
             {
                 LogInfo($"User is active (idle: {StatusService.GetIdleSeconds()}s) - restricting to unattended items that won't disrupt the session");
@@ -565,7 +568,7 @@ public class UpdateEngine : IDisposable
                         {
                             deferReason = "unattended_install is false";
                         }
-                        else if (RequiresRestart(item) || RequiresLogout(item))
+                        else if (WouldInterruptUser(item))
                         {
                             deferReason = $"restart_action '{item.RestartAction}' would interrupt the active user";
                         }
@@ -578,8 +581,8 @@ public class UpdateEngine : IDisposable
                                 item.Name, item.Version, "deferred",
                                 deferReason,
                                 Cimian.Core.Models.StatusReasonCode.DeferredUserActive,
-                                Cimian.Core.Models.DetectionMethod.None, null, false);
-                            skippedUnattended.Add(item);
+                                Cimian.Core.Models.DetectionMethod.None, null, true);
+                            deferredForUser.Add(item);
                             list.RemoveAt(i);
                         }
                     }
@@ -593,7 +596,7 @@ public class UpdateEngine : IDisposable
                     {
                         deferReason = "unattended_uninstall is false";
                     }
-                    else if (RequiresRestart(item) || RequiresLogout(item))
+                    else if (WouldInterruptUser(item))
                     {
                         deferReason = $"restart_action '{item.RestartAction}' would interrupt the active user";
                     }
@@ -606,15 +609,15 @@ public class UpdateEngine : IDisposable
                             item.Name, item.Version, "deferred",
                             deferReason,
                             Cimian.Core.Models.StatusReasonCode.DeferredUserActive,
-                            Cimian.Core.Models.DetectionMethod.None, null, false);
-                        skippedUnattended.Add(item);
+                            Cimian.Core.Models.DetectionMethod.None, null, true);
+                        deferredForUser.Add(item);
                         toUninstall.RemoveAt(i);
                     }
                 }
 
-                if (skippedUnattended.Count > 0)
+                if (deferredForUser.Count > 0)
                 {
-                    LogInfo($"{skippedUnattended.Count} item(s) deferred while user is active");
+                    LogInfo($"{deferredForUser.Count} item(s) deferred while user is active");
                 }
             }
 
@@ -2655,7 +2658,19 @@ public class UpdateEngine : IDisposable
 
     private static bool RequiresLogout(CatalogItem item)
     {
-        return item.RestartAction is "RequireLogout" or "RecommendLogout";
+        return item.RestartAction is "RequireLogout";
+    }
+
+    /// <summary>
+    /// True for any restart_action that would disrupt an active user session
+    /// (Require/Recommend × Restart/Logout). Use this for auto-mode deferral
+    /// decisions; do NOT use it to drive PerformLogoutAction/PerformRestartAction,
+    /// which honour only the stricter Require* variants.
+    /// </summary>
+    private static bool WouldInterruptUser(CatalogItem item)
+    {
+        return item.RestartAction is "RequireRestart" or "RecommendRestart"
+            or "RequireLogout" or "RecommendLogout";
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -473,17 +473,6 @@ public class UpdateEngine : IDisposable
                 return 0;
             }
 
-            // Exit if auto mode and user is active
-            if (_auto && StatusService.IsUserActive())
-            {
-                LogInfo($"User is active (idle: {StatusService.GetIdleSeconds()}s). Skipping automatic updates.");
-                _sessionLogger?.Log("INFO", $"User is active - skipping automatic updates");
-                ReportStatus("Skipped - user active");
-                
-                EndSessionWithSummary("skipped", 0, 0, 0, 0, 0, manifestItems);
-                return 0;
-            }
-
             // Filter out items outside their install_window (applies to installs, updates, and uninstalls)
             // Exception: force_install_after_date overrides install_window — if deadline has passed, install anyway
             var deferredItems = new List<CatalogItem>();
@@ -524,26 +513,71 @@ public class UpdateEngine : IDisposable
                 LogInfo($"{deferredItems.Count} item(s) deferred due to install_window restrictions");
             }
 
-            // Go/Munki parity: Filter out unattended_install/unattended_uninstall items in --auto mode
-            // When running automatically (not user-initiated), skip items that require user interaction.
-            // This matches Munki's only_unattended behavior in install_with_info() and process_removals().
-            var skippedUnattended = new List<CatalogItem>();
-            if (_auto)
+            // Per-item: defer items whose blocking_applications are running.
+            // Installing while the blocking app is open would fail or destroy
+            // the user's open work. Always applied — independent of mode/user.
+            var blockedItems = new List<CatalogItem>();
+            foreach (var list in new[] { toInstall, toUpdate, toUninstall })
             {
-                // Filter installs/updates: skip items with unattended_install == false
+                for (int i = list.Count - 1; i >= 0; i--)
+                {
+                    var item = list[i];
+                    if (item.BlockingApps.Count == 0) continue;
+
+                    if (StatusService.CheckBlockingApps(item.BlockingApps, out var running))
+                    {
+                        var runningList = string.Join(", ", running);
+                        LogInfo($"Deferred: {item.Name} v{item.Version} (blocking applications running: {runningList})");
+                        _sessionLogger?.Log("INFO", $"Deferred {item.Name} v{item.Version}: blocking applications running ({runningList})");
+                        _sessionLogger?.LogStatusCheck(
+                            item.Name, item.Version, "deferred",
+                            $"Blocking applications running: {runningList}",
+                            Cimian.Core.Models.StatusReasonCode.BlockingApps,
+                            Cimian.Core.Models.DetectionMethod.None, null, false);
+                        blockedItems.Add(item);
+                        list.RemoveAt(i);
+                    }
+                }
+            }
+            if (blockedItems.Count > 0)
+            {
+                LogInfo($"{blockedItems.Count} item(s) deferred while blocking applications are running");
+            }
+
+            // Auto mode + active user: restrict to items that can run silently
+            // without disrupting the session. An item is eligible only if it is
+            // marked unattended AND its restart_action would not log the user
+            // out or reboot. Everything else is deferred to a later run (idle
+            // machine, interactive run, or scheduled maintenance window).
+            var skippedUnattended = new List<CatalogItem>();
+            if (_auto && StatusService.IsUserActive())
+            {
+                LogInfo($"User is active (idle: {StatusService.GetIdleSeconds()}s) - restricting to unattended items that won't disrupt the session");
+                _sessionLogger?.Log("INFO", "User is active - restricting auto run to unattended, non-disruptive items");
+
                 foreach (var list in new[] { toInstall, toUpdate })
                 {
                     for (int i = list.Count - 1; i >= 0; i--)
                     {
                         var item = list[i];
+                        string? skipReason = null;
                         if (!item.UnattendedInstall)
                         {
-                            LogInfo($"Skipping install of {item.Name} v{item.Version} because it's not unattended");
-                            _sessionLogger?.Log("INFO", $"Skipped {item.Name} v{item.Version}: unattended_install is false (auto mode)");
+                            skipReason = "unattended_install is false";
+                        }
+                        else if (RequiresRestart(item) || RequiresLogout(item))
+                        {
+                            skipReason = $"restart_action '{item.RestartAction}' would interrupt the active user";
+                        }
+
+                        if (skipReason != null)
+                        {
+                            LogInfo($"Skipping install of {item.Name} v{item.Version}: {skipReason}");
+                            _sessionLogger?.Log("INFO", $"Skipped {item.Name} v{item.Version}: {skipReason} (auto mode, user active)");
                             _sessionLogger?.LogStatusCheck(
                                 item.Name, item.Version, "skipped",
-                                "Not eligible for unattended install (auto mode)",
-                                Cimian.Core.Models.StatusReasonCode.DeferredInstallWindow,
+                                skipReason,
+                                Cimian.Core.Models.StatusReasonCode.UserDeferred,
                                 Cimian.Core.Models.DetectionMethod.None, null, false);
                             skippedUnattended.Add(item);
                             list.RemoveAt(i);
@@ -551,14 +585,23 @@ public class UpdateEngine : IDisposable
                     }
                 }
 
-                // Filter uninstalls: skip items with unattended_uninstall == false
                 for (int i = toUninstall.Count - 1; i >= 0; i--)
                 {
                     var item = toUninstall[i];
+                    string? skipReason = null;
                     if (!item.UnattendedUninstall)
                     {
-                        LogInfo($"Skipping removal of {item.Name} v{item.Version} because it's not unattended");
-                        _sessionLogger?.Log("INFO", $"Skipped removal of {item.Name} v{item.Version}: unattended_uninstall is false (auto mode)");
+                        skipReason = "unattended_uninstall is false";
+                    }
+                    else if (RequiresRestart(item) || RequiresLogout(item))
+                    {
+                        skipReason = $"restart_action '{item.RestartAction}' would interrupt the active user";
+                    }
+
+                    if (skipReason != null)
+                    {
+                        LogInfo($"Skipping removal of {item.Name} v{item.Version}: {skipReason}");
+                        _sessionLogger?.Log("INFO", $"Skipped removal of {item.Name} v{item.Version}: {skipReason} (auto mode, user active)");
                         skippedUnattended.Add(item);
                         toUninstall.RemoveAt(i);
                     }
@@ -566,7 +609,7 @@ public class UpdateEngine : IDisposable
 
                 if (skippedUnattended.Count > 0)
                 {
-                    LogInfo($"{skippedUnattended.Count} item(s) skipped due to unattended restrictions (auto mode)");
+                    LogInfo($"{skippedUnattended.Count} item(s) deferred while user is active");
                 }
             }
 

--- a/shared/core/Models/StatusReasonCode.cs
+++ b/shared/core/Models/StatusReasonCode.cs
@@ -132,6 +132,9 @@ public static class StatusReasonCode
     /// <summary>force_install_after_date overrides install_window deferral</summary>
     public const string DeadlineOverridesWindow = "deadline_overrides_window";
 
+    /// <summary>Auto run deferred this item because a user is active — either it is not unattended-eligible, or its restart_action would interrupt the session</summary>
+    public const string DeferredUserActive = "deferred_user_active";
+
     #endregion
 
     #region Removed Reasons - Package confirmed removed


### PR DESCRIPTION
## Summary
- The early-exit in `UpdateEngine.RunAsync` was returning from the entire `--auto` run whenever any user was active. This bypassed the per-item unattended filter that lives further down, so packages with `unattended_install: true` (e.g. `WinAdminsAccount`) never installed on hosts with a logged-in user.
- Regression introduced in commit `ae28efa6` (initial C# port of UpdateEngine, 2025-12-02).

## What changed
Replaced the global skip with per-item gating in `cli/managedsoftwareupdate/Services/UpdateEngine.cs`:
- **Always** defer items whose `blocking_applications` are running -- installing while the blocking app is open would fail or trash the user's work.
- **`--auto` + active user**: only run items that are `unattended_install`/`unattended_uninstall == true` *and* whose `restart_action` won't reboot or log the user out. Other items wait for an idle machine, an interactive run, or a maintenance window.
- **`--auto` + no active user**: run everything pending -- matches how unattended fleet machines should behave.

## Test plan
- [x] `dotnet test` -- 641 passed, 0 failed
- [x] Signed build (`build.ps1 -Sign -Binary managedsoftwareupdate`) succeeds for x64 and arm64
- [ ] Deploy signed binary to a logged-in target (e.g. 10.15.6.136) and confirm `WinAdminsAccount` actually installs on the next `--auto` run instead of bailing with "User is active. Skipping automatic updates."
- [ ] Confirm `ManagedInstalls/reports` reflects the actual processed items rather than zeros.

Tracks [](https://dev.azure.com/example-org/f6d33719-4062-45ea-af9e-4e4f881c1409/_workitems/edit/260).
