### PR TITLE
items.json: per-run finalization + LoopGuard suppression surfacing

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -395,7 +395,14 @@ public class UpdateEngine : IDisposable
             LogInfo("----------------------------------------------------------------------");
             LogInfo("STATUS CHECKING");
             LogInfo("----------------------------------------------------------------------");
-            var (toInstall, toUpdate, toUninstall) = IdentifyActions(manifestItems, catalogMap);
+            var (toInstall, toUpdate, toUninstall, loopSuppressed) = IdentifyActions(manifestItems, catalogMap);
+
+            // Dictionary of items LoopGuard refused this run, keyed by lower-invariant
+            // name. Surfaces in items.json as Warning + last_warning + status_reason_code,
+            // and in a sibling reports/loop_suppressed.json for dashboards.
+            var loopSuppressedByName = loopSuppressed.ToDictionary(
+                x => x.Item.Name.ToLowerInvariant(),
+                x => (x.Reason, x.InstalledVersion, x.WasUpdate));
 
             // AutoRemove: queue uninstall for packages installed by Cimian but no longer in any manifest
             if (_config.AutoRemove)
@@ -464,7 +471,9 @@ public class UpdateEngine : IDisposable
                 
                 // Collect items data for items.json report (Go parity: SetCurrentSessionPackagesInfo)
                 // Check-only mode never runs installs/uninstalls, so no outcomes exist.
-                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, new Dictionary<string, ItemOutcome>());
+                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap,
+                    new Dictionary<string, ItemOutcome>(),
+                    loopSuppressedByName);
 
                 // Write InstallInfo.yaml for MSC GUI
                 WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
@@ -772,7 +781,7 @@ public class UpdateEngine : IDisposable
                 ReportPercent(100);
                 
                 // Collect items data for items.json report
-                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName);
+                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName, loopSuppressedByName);
 
                 // Write InstallInfo.yaml for MSC GUI (post-install: actions completed)
                 WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
@@ -799,7 +808,7 @@ public class UpdateEngine : IDisposable
                 ReportError("Some operations failed");
 
                 // Collect items data for items.json report
-                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName);
+                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName, loopSuppressedByName);
 
                 // Write InstallInfo.yaml for MSC GUI (post-install: reflects final state)
                 WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
@@ -849,12 +858,16 @@ public class UpdateEngine : IDisposable
         }
     }
 
-    private (List<CatalogItem> ToInstall, List<CatalogItem> ToUpdate, List<CatalogItem> ToUninstall) 
+    private (List<CatalogItem> ToInstall, List<CatalogItem> ToUpdate, List<CatalogItem> ToUninstall,
+             List<(CatalogItem Item, string Reason, string? InstalledVersion, bool WasUpdate)> LoopSuppressed)
         IdentifyActions(List<ManifestItem> manifestItems, Dictionary<string, CatalogItem> catalogMap)
     {
         var toInstall = new List<CatalogItem>();
         var toUpdate = new List<CatalogItem>();
         var toUninstall = new List<CatalogItem>();
+        // Items LoopGuard refused this run. Tracked separately so CollectSessionItems
+        // can stamp them as Warning instead of letting them fall through to "Installed".
+        var loopSuppressed = new List<(CatalogItem, string, string?, bool)>();
 
         var sysArch = StatusService.GetSystemArchitecture();
 
@@ -955,6 +968,7 @@ public class UpdateEngine : IDisposable
                                     Cimian.Core.Models.DetectionMethod.None,
                                     status.InstalledVersion,
                                     false);
+                                loopSuppressed.Add((catalogItem, loopReason, status.InstalledVersion, status.IsUpdate));
                                 break; // Skip this item
                             }
                         }
@@ -1050,7 +1064,7 @@ public class UpdateEngine : IDisposable
             }
         }
 
-        return (toInstall, toUpdate, toUninstall);
+        return (toInstall, toUpdate, toUninstall, loopSuppressed);
     }
 
     /// <summary>
@@ -2377,7 +2391,8 @@ public class UpdateEngine : IDisposable
         List<CatalogItem> toUpdate,
         List<CatalogItem> toUninstall,
         Dictionary<string, CatalogItem> catalogMap,
-        IReadOnlyDictionary<string, ItemOutcome> outcomesByName)
+        IReadOnlyDictionary<string, ItemOutcome> outcomesByName,
+        IReadOnlyDictionary<string, (string Reason, string? InstalledVersion, bool WasUpdate)> loopSuppressedByName)
     {
         if (_sessionLogger == null) return;
 
@@ -2416,6 +2431,32 @@ public class UpdateEngine : IDisposable
                     displayName = catItem.DisplayName;
             }
 
+            // LoopGuard suppression takes precedence: the item was deliberately not
+            // acted on, but it is broken — surface as Warning so dashboards flag it.
+            // Keep the conditional short-circuited so suppressed items don't fall
+            // through to outcome/plan logic below.
+            if (loopSuppressedByName.TryGetValue(key, out var suppression))
+            {
+                items.Add(new SessionPackageInfo
+                {
+                    Name = mi.Name,
+                    Version = version,
+                    Status = "Warning",
+                    ItemType = itemType,
+                    DisplayName = displayName,
+                    InstalledVersion = suppression.InstalledVersion,
+                    WarningMessage = suppression.Reason,
+                    StatusReason = suppression.Reason,
+                    StatusReasonCode = Cimian.Core.Models.StatusReasonCode.LoopSuppressed,
+                    DetectionMethod = Cimian.Core.Models.DetectionMethod.None,
+                    // Mark as touched this run so DataExporter stamps last_seen_in_session.
+                    // Distinct from install/update/remove so consumers can filter on it.
+                    ActionPerformed = "loop_suppressed",
+                    OutcomeTimestamp = DateTime.UtcNow
+                });
+                continue;
+            }
+
             // Determine status — prefer the actual install/uninstall outcome over the
             // pre-install plan. Only fall back to "Pending …" when nothing was attempted.
             var hadOutcome = outcomesByName.TryGetValue(key, out var outcome) && outcome is not null;
@@ -2440,6 +2481,14 @@ public class UpdateEngine : IDisposable
         }
 
         _sessionLogger.SetCurrentSessionItems(items);
+
+        // Surface LoopGuard suppressions for reports/loop_suppressed.json. Pulled from
+        // LoopGuard rather than this run's list so packages suppressed in earlier runs
+        // (still active backoff) also appear.
+        if (_loopGuard != null)
+        {
+            _sessionLogger.SetCurrentLoopSuppressed(_loopGuard.GetSuppressedReport());
+        }
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -463,11 +463,12 @@ public class UpdateEngine : IDisposable
                 ReportPercent(100);
                 
                 // Collect items data for items.json report (Go parity: SetCurrentSessionPackagesInfo)
-                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
-                
+                // Check-only mode never runs installs/uninstalls, so no outcomes exist.
+                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, new Dictionary<string, ItemOutcome>());
+
                 // Write InstallInfo.yaml for MSC GUI
                 WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
-                
+
                 // End session for check-only
                 EndSessionWithSummary("completed", toInstall.Count, toUpdate.Count, toUninstall.Count, 0, 0, manifestItems);
                 return 0;
@@ -629,6 +630,8 @@ public class UpdateEngine : IDisposable
             var installSuccess = true;
             var successCount = 0;
             var failCount = 0;
+            var installOutcomes = new List<ItemOutcome>();
+            var uninstallOutcomes = new List<ItemOutcome>();
             if (toInstall.Count > 0 || toUpdate.Count > 0)
             {
                 var allToInstall = toInstall.Concat(toUpdate).ToList();
@@ -703,11 +706,12 @@ public class UpdateEngine : IDisposable
                 {
                     ReportStatus("Installing updates...");
                     _sessionLogger?.Log("INFO", $"Installing {allToInstall.Count} items...");
-                    installSuccess = await PerformInstallationsAsync(allToInstall, cancellationToken);
-                    
-                    // Count successes/failures based on result
-                    successCount = installSuccess ? allToInstall.Count : 0;
-                    failCount = installSuccess ? 0 : allToInstall.Count;
+                    installOutcomes = await PerformInstallationsAsync(allToInstall, cancellationToken);
+
+                    // Per-item outcome counts (includes dependencies + update_for items)
+                    successCount = installOutcomes.Count(o => o.Success);
+                    failCount = installOutcomes.Count(o => !o.Success);
+                    installSuccess = failCount == 0;
                 }
                 else if (selfUpdateItems.Count > 0)
                 {
@@ -723,8 +727,15 @@ public class UpdateEngine : IDisposable
             if (toUninstall.Count > 0)
             {
                 _sessionLogger?.Log("INFO", $"Removing {toUninstall.Count} items...");
-                uninstallSuccess = await PerformUninstallsAsync(toUninstall, cancellationToken);
+                uninstallOutcomes = await PerformUninstallsAsync(toUninstall, cancellationToken);
+                uninstallSuccess = uninstallOutcomes.All(o => o.Success);
             }
+
+            // Combine install + uninstall outcomes keyed by lower-invariant name so
+            // CollectSessionItems can stamp each manifest item with its real result.
+            var outcomesByName = new Dictionary<string, ItemOutcome>(StringComparer.OrdinalIgnoreCase);
+            foreach (var o in installOutcomes) outcomesByName[o.Name.ToLowerInvariant()] = o;
+            foreach (var o in uninstallOutcomes) outcomesByName[o.Name.ToLowerInvariant()] = o;
 
             // Run postflight unless skipped
             if (!skipPostflight && !_config.NoPostflight)
@@ -761,12 +772,12 @@ public class UpdateEngine : IDisposable
                 ReportPercent(100);
                 
                 // Collect items data for items.json report
-                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
-                
+                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName);
+
                 // Write InstallInfo.yaml for MSC GUI (post-install: actions completed)
                 WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
-                
-                EndSessionWithSummary("completed", toInstall.Count, toUpdate.Count, toUninstall.Count, 
+
+                EndSessionWithSummary("completed", toInstall.Count, toUpdate.Count, toUninstall.Count,
                     toInstall.Count + toUpdate.Count + toUninstall.Count, 0, manifestItems);
                 
                 // Handle restart_action: restart takes precedence over logout (Munki parity)
@@ -788,7 +799,7 @@ public class UpdateEngine : IDisposable
                 ReportError("Some operations failed");
 
                 // Collect items data for items.json report
-                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
+                CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName);
 
                 // Write InstallInfo.yaml for MSC GUI (post-install: reflects final state)
                 WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
@@ -1216,12 +1227,13 @@ public class UpdateEngine : IDisposable
         Log();
     }
 
-    private async Task<bool> PerformInstallationsAsync(
+    private async Task<List<ItemOutcome>> PerformInstallationsAsync(
         List<CatalogItem> items,
         CancellationToken cancellationToken)
     {
         LogInfo($"Installing/updating {items.Count} items with dependency processing...");
 
+        var outcomes = new List<ItemOutcome>();
         var successCount = 0;
         var failCount = 0;
         var totalItems = items.Count;
@@ -1287,6 +1299,7 @@ public class UpdateEngine : IDisposable
                 installedItems,
                 scheduledItems,
                 downloadedPaths,
+                outcomes,
                 cancellationToken);
 
             if (success)
@@ -1300,7 +1313,7 @@ public class UpdateEngine : IDisposable
         }
 
         LogInfo($"Installation summary: {successCount} succeeded, {failCount} failed");
-        return failCount == 0;
+        return outcomes;
     }
 
     /// <summary>
@@ -1380,6 +1393,7 @@ public class UpdateEngine : IDisposable
         List<string> installedItems,
         List<string> scheduledItems,
         Dictionary<string, string> downloadedPaths,
+        List<ItemOutcome> outcomes,
         CancellationToken cancellationToken)
     {
         LogDetail($"ProcessInstallWithDependencies: {itemName}");
@@ -1488,7 +1502,7 @@ public class UpdateEngine : IDisposable
 
                 // Recursively process the dependency
                 var newScheduled = new List<string>(scheduledItems) { dep };
-                if (!await ProcessInstallWithDependenciesAsync(dep, installedItems, newScheduled, downloadedPaths, cancellationToken))
+                if (!await ProcessInstallWithDependenciesAsync(dep, installedItems, newScheduled, downloadedPaths, outcomes, cancellationToken))
                 {
                     ConsoleLogger.Error($"Failed to install required dependency: {dep}");
                     return false;
@@ -1539,10 +1553,12 @@ public class UpdateEngine : IDisposable
             ConsoleLogger.Error(msg);
             _sessionLogger?.Log("ERROR", msg);
             _sessionLogger?.LogInstall(item.Name, item.Version, "install", "failed", msg);
+            outcomes.Add(new ItemOutcome(item.Name, item.Version, "install", false, msg, DateTime.UtcNow));
             return false;
         }
 
         var (success, output) = await _installerService.InstallAsync(item, localFile ?? "", cancellationToken);
+        outcomes.Add(new ItemOutcome(item.Name, item.Version, "install", success, success ? null : output, DateTime.UtcNow));
 
         if (success)
         {
@@ -1634,7 +1650,7 @@ public class UpdateEngine : IDisposable
                     }
 
                     // Process the update item (which may have its own dependencies)
-                    if (!await ProcessInstallWithDependenciesAsync(updateItemName, installedItems, scheduledItems, downloadedPaths, cancellationToken))
+                    if (!await ProcessInstallWithDependenciesAsync(updateItemName, installedItems, scheduledItems, downloadedPaths, outcomes, cancellationToken))
                     {
                         LogInfo($"[WARNING] Failed to install update item: {updateItemName} (continuing)");
                         // Don't fail the main install just because an update_for item failed
@@ -1658,6 +1674,7 @@ public class UpdateEngine : IDisposable
     private async Task<bool> ProcessUninstallWithDependenciesAsync(
         string itemName,
         List<string> installedItems,
+        List<ItemOutcome> outcomes,
         CancellationToken cancellationToken)
     {
         LogDetail($"ProcessUninstallWithDependencies: {itemName}");
@@ -1672,7 +1689,7 @@ public class UpdateEngine : IDisposable
             if (CatalogService.IsItemInstalled(depItem.Name, installedItems))
             {
                 LogInfo($"Removing dependent item first: {depItem.Name} (requires {itemName})");
-                if (!await ProcessUninstallWithDependenciesAsync(depItem.Name, installedItems, cancellationToken))
+                if (!await ProcessUninstallWithDependenciesAsync(depItem.Name, installedItems, outcomes, cancellationToken))
                 {
                     ConsoleLogger.Error($"Failed to remove dependent item: {depItem.Name}");
                     return false;
@@ -1697,6 +1714,7 @@ public class UpdateEngine : IDisposable
 
         LogInfo($"Removing: {item.Name}");
         var (success, output) = await _installerService.UninstallAsync(item, cancellationToken);
+        outcomes.Add(new ItemOutcome(item.Name, item.Version, "remove", success, success ? null : output, DateTime.UtcNow));
 
         if (success)
         {
@@ -1728,12 +1746,13 @@ public class UpdateEngine : IDisposable
 
     #endregion
 
-    private async Task<bool> PerformUninstallsAsync(
+    private async Task<List<ItemOutcome>> PerformUninstallsAsync(
         List<CatalogItem> items,
         CancellationToken cancellationToken)
     {
         LogInfo($"Removing {items.Count} items with dependency processing...");
 
+        var outcomes = new List<ItemOutcome>();
         var successCount = 0;
         var failCount = 0;
 
@@ -1758,6 +1777,7 @@ public class UpdateEngine : IDisposable
             var success = await ProcessUninstallWithDependenciesAsync(
                 item.Name,
                 installedItems,
+                outcomes,
                 cancellationToken);
 
             if (success)
@@ -1771,7 +1791,7 @@ public class UpdateEngine : IDisposable
         }
 
         LogInfo($"Uninstall summary: {successCount} succeeded, {failCount} failed");
-        return failCount == 0;
+        return outcomes;
     }
 
     private void CleanManifestsAndCatalogsPreRun()
@@ -2356,7 +2376,8 @@ public class UpdateEngine : IDisposable
         List<CatalogItem> toInstall,
         List<CatalogItem> toUpdate,
         List<CatalogItem> toUninstall,
-        Dictionary<string, CatalogItem> catalogMap)
+        Dictionary<string, CatalogItem> catalogMap,
+        IReadOnlyDictionary<string, ItemOutcome> outcomesByName)
     {
         if (_sessionLogger == null) return;
 
@@ -2395,26 +2416,26 @@ public class UpdateEngine : IDisposable
                     displayName = catItem.DisplayName;
             }
 
-            // Determine status
-            string status;
-            if (toInstallNames.Contains(key))
-                status = "Pending Install";
-            else if (toUpdateNames.Contains(key))
-                status = "Pending Update";
-            else if (toUninstallNames.Contains(key))
-                status = "Pending Removal";
-            else if (action == "uninstall")
-                status = "Removed";
-            else
-                status = "Installed";
+            // Determine status — prefer the actual install/uninstall outcome over the
+            // pre-install plan. Only fall back to "Pending …" when nothing was attempted.
+            var hadOutcome = outcomesByName.TryGetValue(key, out var outcome) && outcome is not null;
+            var status = SessionItemStatusResolver.Resolve(
+                hadOutcome ? outcome : null,
+                isPendingInstall:   toInstallNames.Contains(key),
+                isPendingUpdate:    toUpdateNames.Contains(key),
+                isPendingUninstall: toUninstallNames.Contains(key),
+                manifestAction:     action);
 
             items.Add(new SessionPackageInfo
             {
                 Name = mi.Name,
-                Version = version,
+                Version = hadOutcome && !string.IsNullOrEmpty(outcome!.Version) ? outcome.Version : version,
                 Status = status,
                 ItemType = itemType,
-                DisplayName = displayName
+                DisplayName = displayName,
+                ErrorMessage = hadOutcome && !outcome!.Success ? outcome.ErrorMessage : null,
+                ActionPerformed = hadOutcome ? outcome!.Action : null,
+                OutcomeTimestamp = hadOutcome ? outcome!.Timestamp : null
             });
         }
 

--- a/shared/core/Models/Reporting.cs
+++ b/shared/core/Models/Reporting.cs
@@ -673,6 +673,68 @@ public class SessionPackageInfo
     public string? DetectionMethod { get; set; }
 
     #endregion
+
+    /// <summary>
+    /// Action actually performed on this item during the run
+    /// ("install", "update", "remove"). Null when the item was only status-checked.
+    /// Used by DataExporter to decide whether to stamp last_seen_in_session.
+    /// </summary>
+    [JsonPropertyName("action_performed")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ActionPerformed { get; set; }
+
+    /// <summary>
+    /// UTC timestamp when the install/uninstall outcome was recorded.
+    /// </summary>
+    [JsonPropertyName("outcome_timestamp")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? OutcomeTimestamp { get; set; }
+}
+
+/// <summary>
+/// Per-item outcome captured during an install or uninstall pass.
+/// Used to bridge the gap between the pre-install plan and the post-install
+/// truth that <see cref="SessionPackageInfo"/> needs to surface in items.json.
+/// </summary>
+public record ItemOutcome(
+    string Name,
+    string Version,
+    string Action,         // "install" | "update" | "remove"
+    bool Success,
+    string? ErrorMessage,
+    DateTime Timestamp);
+
+/// <summary>
+/// Pure helper that resolves the per-item session status reported in items.json.
+/// Prefers the actual install/uninstall outcome over the pre-install plan so a
+/// successful install does not stay stamped as "Pending Install".
+/// </summary>
+public static class SessionItemStatusResolver
+{
+    public static string Resolve(
+        ItemOutcome? outcome,
+        bool isPendingInstall,
+        bool isPendingUpdate,
+        bool isPendingUninstall,
+        string manifestAction)
+    {
+        if (outcome is not null)
+        {
+            return outcome.Action switch
+            {
+                "install" or "update" => outcome.Success ? "Installed" : "Failed",
+                "remove"              => outcome.Success ? "Removed"   : "Failed",
+                _                     => outcome.Success ? "Installed" : "Failed"
+            };
+        }
+
+        if (isPendingInstall) return "Pending Install";
+        if (isPendingUpdate)  return "Pending Update";
+        if (isPendingUninstall) return "Pending Removal";
+        if (string.Equals(manifestAction, "uninstall", StringComparison.OrdinalIgnoreCase))
+            return "Removed";
+        return "Installed";
+    }
 }
 
 /// <summary>

--- a/shared/core/Models/Reporting.cs
+++ b/shared/core/Models/Reporting.cs
@@ -705,6 +705,32 @@ public record ItemOutcome(
     DateTime Timestamp);
 
 /// <summary>
+/// Reports a single loop-suppressed package for reports/loop_suppressed.json.
+/// Surfaces broken packages so operators can see them even when items.json
+/// reports them as Warning rather than Pending Install.
+/// </summary>
+public class LoopSuppressedReportItem
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = string.Empty;
+
+    [JsonPropertyName("reason")]
+    public string Reason { get; set; } = string.Empty;
+
+    /// <summary>UTC time at which suppression expires; null when suppressed indefinitely.</summary>
+    [JsonPropertyName("suppressed_until")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? SuppressedUntil { get; set; }
+
+    /// <summary>Operator-actionable command string (matches LoopGuard's WARN log line).</summary>
+    [JsonPropertyName("clear_command")]
+    public string ClearCommand { get; set; } = string.Empty;
+}
+
+/// <summary>
 /// Pure helper that resolves the per-item session status reported in items.json.
 /// Prefers the actual install/uninstall outcome over the pre-install plan so a
 /// successful install does not stay stamped as "Pending Install".

--- a/shared/core/Services/DataExporter.cs
+++ b/shared/core/Services/DataExporter.cs
@@ -358,10 +358,25 @@ public class DataExporter
                     record.Message = msg.GetString() ?? "";
                 if (eventData.TryGetValue("event_type", out var eventType))
                     record.EventType = eventType.GetString() ?? "";
-                if (eventData.TryGetValue("package", out var pkg))
-                    record.Package = pkg.GetString();
-                if (eventData.TryGetValue("version", out var ver))
-                    record.Version = ver.GetString();
+                // Read canonical package_name/package_version with legacy fallback.
+                // Populate both new and legacy fields so downstream consumers that
+                // still read either spelling continue to work.
+                var pkgName =
+                    (eventData.TryGetValue("package_name", out var pn) ? pn.GetString() : null) ??
+                    (eventData.TryGetValue("package",      out var pkg) ? pkg.GetString() : null);
+                if (!string.IsNullOrEmpty(pkgName))
+                {
+                    record.PackageName = pkgName;
+                    record.Package = pkgName;
+                }
+                var pkgVersion =
+                    (eventData.TryGetValue("package_version", out var pv) ? pv.GetString() : null) ??
+                    (eventData.TryGetValue("version",         out var ver) ? ver.GetString() : null);
+                if (!string.IsNullOrEmpty(pkgVersion))
+                {
+                    record.PackageVersion = pkgVersion;
+                    record.Version = pkgVersion;
+                }
                 if (eventData.TryGetValue("action", out var action))
                     record.Action = action.GetString() ?? "";
                 if (eventData.TryGetValue("status", out var status))
@@ -420,7 +435,13 @@ public class DataExporter
     /// Generates item records from current session packages info, enriched with historical
     /// event data for accurate install loop detection.
     /// </summary>
-    public List<ItemRecord> GenerateCurrentItemsFromPackagesInfo(List<SessionPackageInfo> packagesInfo)
+    /// <param name="packagesInfo">Current session package info collected by the engine.</param>
+    /// <param name="currentSessionId">Session id (yyyy-MM-dd-HHmm). Stamped onto items the
+    /// run actually acted on; left empty for items only status-checked. Pass null in
+    /// contexts where no current session exists (e.g., one-off exports).</param>
+    public List<ItemRecord> GenerateCurrentItemsFromPackagesInfo(
+        List<SessionPackageInfo> packagesInfo,
+        string? currentSessionId = null)
     {
         var records = new List<ItemRecord>();
         var now = DateTime.UtcNow.ToString("o");
@@ -450,14 +471,20 @@ public class DataExporter
                         if (eventData == null)
                             continue;
 
-                        var packageName = eventData.TryGetValue("package", out var p) ? p.GetString() : null;
+                        // Read canonical package_name; fall back to legacy "package" for
+                        // events.jsonl files written before the schema rename.
+                        var packageName =
+                            (eventData.TryGetValue("package_name", out var pn) ? pn.GetString() : null) ??
+                            (eventData.TryGetValue("package",      out var p)  ? p.GetString()  : null);
                         if (string.IsNullOrEmpty(packageName))
                             continue;
 
                         var action = eventData.TryGetValue("action", out var a) ? a.GetString() : "";
                         var status = eventData.TryGetValue("status", out var s) ? s.GetString() : "";
                         var timestamp = eventData.TryGetValue("timestamp", out var ts) ? ts.GetString() : "";
-                        var version = eventData.TryGetValue("version", out var v) ? v.GetString() : "";
+                        var version =
+                            (eventData.TryGetValue("package_version", out var pv) ? pv.GetString() : null) ??
+                            (eventData.TryGetValue("version",         out var v)  ? v.GetString()  : "");
 
                         if (!packageHistory.ContainsKey(packageName))
                             packageHistory[packageName] = new List<ItemAttempt>();
@@ -496,6 +523,7 @@ public class DataExporter
         {
             // Normalize status: convert session statuses (completed/success) to item statuses (Installed)
             var normalizedStatus = NormalizeItemStatus(pkg.Status);
+            var actedOnThisRun = !string.IsNullOrEmpty(pkg.ActionPerformed);
 
             var record = new ItemRecord
             {
@@ -503,13 +531,26 @@ public class DataExporter
                 ItemName = pkg.Name,
                 DisplayName = pkg.DisplayName,
                 ItemType = pkg.ItemType,
-                CurrentStatus = normalizedStatus,  // NORMALIZED STATUS - maps completed/success to Installed
+                CurrentStatus = normalizedStatus,
                 LatestVersion = pkg.Version,
                 InstalledVersion = pkg.InstalledVersion,
                 LastUpdate = now,
                 LastAttemptTime = now,
-                LastAttemptStatus = normalizedStatus,  // NORMALIZED attempt status
-                Type = "cimian"
+                LastAttemptStatus = normalizedStatus,
+                Type = "cimian",
+
+                // Stamp the session id only when this run actually touched the item;
+                // status-checked items get an empty string so consumers can filter to
+                // "what the last run actually did" rather than catalog membership.
+                LastSeenInSession = actedOnThisRun ? (currentSessionId ?? "") : "",
+
+                // Always populate counts — GetValueOrDefault returns 0 cleanly when
+                // there is no event history for the package.
+                InstallCount = packageInstallCounts.GetValueOrDefault(pkg.Name),
+                FailureCount = packageFailureCounts.GetValueOrDefault(pkg.Name),
+                RecentAttempts = packageHistory.TryGetValue(pkg.Name, out var hist)
+                                    ? hist.TakeLast(5).ToList()
+                                    : new List<ItemAttempt>()
             };
 
             if (!string.IsNullOrEmpty(pkg.ErrorMessage))
@@ -523,14 +564,9 @@ public class DataExporter
                 record.WarningCount = 1;
             }
 
-            // Enrich with historical data for loop detection
-            if (packageHistory.TryGetValue(pkg.Name, out var history) && history.Count > 0)
+            if (record.RecentAttempts.Count > 0)
             {
-                record.InstallCount = packageInstallCounts.GetValueOrDefault(pkg.Name);
-                record.FailureCount = packageFailureCounts.GetValueOrDefault(pkg.Name);
-                record.RecentAttempts = history.TakeLast(5).ToList();
-
-                var (loopDetected, loopDetails) = DetectInstallLoopEnhanced(history, pkg.Name);
+                var (loopDetected, loopDetails) = DetectInstallLoopEnhanced(record.RecentAttempts, pkg.Name);
                 record.InstallLoopDetected = loopDetected;
                 record.LoopDetails = loopDetails;
             }
@@ -991,7 +1027,9 @@ public class DataExporter
                 if (status?.ToLowerInvariant() != "failed")
                     continue;
 
-                var packageName = eventData.TryGetValue("package", out var p) ? p.GetString() : null;
+                var packageName =
+                    (eventData.TryGetValue("package_name", out var pn) ? pn.GetString() : null) ??
+                    (eventData.TryGetValue("package",      out var p)  ? p.GetString()  : null);
                 if (string.IsNullOrEmpty(packageName))
                     continue;
 
@@ -1117,7 +1155,9 @@ public class DataExporter
                 if (eventData == null)
                     continue;
 
-                var packageName = eventData.TryGetValue("package", out var p) ? p.GetString() : null;
+                var packageName =
+                    (eventData.TryGetValue("package_name", out var pn) ? pn.GetString() : null) ??
+                    (eventData.TryGetValue("package",      out var p)  ? p.GetString()  : null);
                 if (string.IsNullOrEmpty(packageName))
                     continue;
 
@@ -1137,7 +1177,9 @@ public class DataExporter
                 var action = eventData.TryGetValue("action", out var a) ? a.GetString() : "";
                 var status = eventData.TryGetValue("status", out var s) ? s.GetString() : "";
                 var timestamp = eventData.TryGetValue("timestamp", out var ts) ? ts.GetString() : "";
-                var version = eventData.TryGetValue("version", out var v) ? v.GetString() : "";
+                var version =
+                    (eventData.TryGetValue("package_version", out var pv) ? pv.GetString() : null) ??
+                    (eventData.TryGetValue("version",         out var v)  ? v.GetString()  : "");
                 var error = eventData.TryGetValue("error", out var e) ? e.GetString() : "";
 
                 // Update statistics

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -288,11 +288,38 @@ public class LoopGuard
         var result = new List<(string, string, DateTime?)>();
         foreach (var (key, pkgState) in _state.Packages)
         {
-            if (pkgState.SuppressedUntil.HasValue && 
+            if (pkgState.SuppressedUntil.HasValue &&
                 (pkgState.SuppressedUntil.Value == DateTime.MaxValue || DateTime.UtcNow < pkgState.SuppressedUntil.Value))
             {
                 result.Add((pkgState.PackageName, pkgState.SuppressionReason ?? "Unknown", pkgState.SuppressedUntil));
             }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Returns a report-ready list of currently suppressed packages, suitable for
+    /// serialization into reports/loop_suppressed.json. Includes the last-attempted
+    /// version and the operator-facing clear command for each entry.
+    /// </summary>
+    public List<LoopSuppressedReportItem> GetSuppressedReport()
+    {
+        var result = new List<LoopSuppressedReportItem>();
+        foreach (var (_, pkgState) in _state.Packages)
+        {
+            if (!pkgState.SuppressedUntil.HasValue) continue;
+            var until = pkgState.SuppressedUntil.Value;
+            // Indefinite (DateTime.MaxValue) and not-yet-expired entries both qualify.
+            if (until != DateTime.MaxValue && DateTime.UtcNow >= until) continue;
+
+            result.Add(new LoopSuppressedReportItem
+            {
+                Name            = pkgState.PackageName,
+                Version         = pkgState.LastVersion ?? "",
+                Reason          = pkgState.SuppressionReason ?? "Unknown",
+                SuppressedUntil = until == DateTime.MaxValue ? null : until,
+                ClearCommand    = $"managedsoftwareupdate --clear-loop {pkgState.PackageName}"
+            });
         }
         return result;
     }

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -483,12 +483,16 @@ public class LoopGuard
                     if (!string.Equals(action, "install", StringComparison.OrdinalIgnoreCase))
                         continue;
 
-                    var packageName = eventData.TryGetValue("package", out var p) ? p.GetString() : null;
+                    var packageName =
+                        (eventData.TryGetValue("package_name", out var pn) ? pn.GetString() : null) ??
+                        (eventData.TryGetValue("package",      out var p)  ? p.GetString()  : null);
                     if (string.IsNullOrEmpty(packageName))
                         continue;
 
                     var status = eventData.TryGetValue("status", out var s) ? s.GetString() : "";
-                    var version = eventData.TryGetValue("version", out var v) ? v.GetString() : "";
+                    var version =
+                        (eventData.TryGetValue("package_version", out var pv) ? pv.GetString() : null) ??
+                        (eventData.TryGetValue("version",         out var v)  ? v.GetString()  : "");
                     var timestamp = eventData.TryGetValue("timestamp", out var ts) ? ts.GetString() : null;
 
                     var key = packageName.ToLowerInvariant();

--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -503,11 +503,33 @@ public class SessionLogger : IDisposable
 
             // Generate items.json - current managed items snapshot
             GenerateItemsReport();
+
+            // Generate loop_suppressed.json - LoopGuard suppressions surfaced for
+            // dashboards. Skipped silently if no suppressions were registered.
+            GenerateLoopSuppressedReport();
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"[ERROR] Failed to generate reports: {ex.Message}");
         }
+    }
+
+    private List<LoopSuppressedReportItem> _currentLoopSuppressed = new();
+
+    /// <summary>
+    /// Sets the current run's loop-suppressed package list. Pass an empty list (or
+    /// don't call) when LoopGuard isn't active. UpdateEngine populates this from
+    /// <see cref="LoopGuard.GetSuppressedReport"/> before EndSession.
+    /// </summary>
+    public void SetCurrentLoopSuppressed(List<LoopSuppressedReportItem> items)
+    {
+        _currentLoopSuppressed = items ?? new List<LoopSuppressedReportItem>();
+    }
+
+    private void GenerateLoopSuppressedReport()
+    {
+        var path = Path.Combine(ReportsDir, "loop_suppressed.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(_currentLoopSuppressed, JsonOptions));
     }
 
     /// <summary>

--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -627,7 +627,7 @@ public class SessionLogger : IDisposable
         {
             // Use DataExporter for historical enrichment + loop detection
             var exporter = new DataExporter();
-            var items = exporter.GenerateCurrentItemsFromPackagesInfo(cimianItems);
+            var items = exporter.GenerateCurrentItemsFromPackagesInfo(cimianItems, _sessionId);
 
             var itemsPath = Path.Combine(ReportsDir, "items.json");
             File.WriteAllText(itemsPath, JsonSerializer.Serialize(items, JsonOptions));
@@ -652,6 +652,7 @@ public class SessionLogger : IDisposable
         {
             var displayName = !string.IsNullOrEmpty(pkg.DisplayName) ? pkg.DisplayName : pkg.Name;
             var normalizedStatus = NormalizeItemStatus(pkg.Status);
+            var actedOnThisRun = !string.IsNullOrEmpty(pkg.ActionPerformed);
 
             records.Add(new Cimian.Core.Models.ItemRecord
             {
@@ -662,7 +663,10 @@ public class SessionLogger : IDisposable
                 CurrentStatus = normalizedStatus,
                 LatestVersion = pkg.Version,
                 InstalledVersion = pkg.InstalledVersion,
-                LastSeenInSession = now,
+                // Stamp session id (yyyy-MM-dd-HHmm) only when this run touched the
+                // item; status-checked items get an empty string so consumers can
+                // filter to "what the last run actually did."
+                LastSeenInSession = actedOnThisRun ? _sessionId : "",
                 LastAttemptTime = now,
                 LastAttemptStatus = normalizedStatus,
                 LastUpdate = now,

--- a/tests/ItemsJsonFinalizationTests.cs
+++ b/tests/ItemsJsonFinalizationTests.cs
@@ -192,6 +192,82 @@ public class ItemsJsonFinalizationTests
         Assert.Empty(fresh.RecentAttempts);
     }
 
+    // ── LoopGuard suppression surfacing ─────────────────────────────────────
+
+    [Fact]
+    public void DataExporter_LoopSuppressedSessionItem_PopulatesWarningFields()
+    {
+        // Given a loop-suppressed item produced by CollectSessionItems, DataExporter
+        // must propagate WarningMessage into LastWarning + WarningCount and stamp
+        // last_seen_in_session because ActionPerformed is set.
+        using var fixture = new SessionsFixture();
+        var exporter = new DataExporter(fixture.BaseDir);
+
+        const string reason = "LOOP SUPPRESSED: WinAdminsAccount — suppressed for 6h 0m " +
+                              "(Rapid-fire loop). Clear with: managedsoftwareupdate --clear-loop WinAdminsAccount";
+
+        var items = exporter.GenerateCurrentItemsFromPackagesInfo(
+            new List<SessionPackageInfo>
+            {
+                new()
+                {
+                    Name = "WinAdminsAccount",
+                    Version = "1.0",
+                    Status = "Warning",
+                    ItemType = "managed_installs",
+                    DisplayName = "WinAdminsAccount",
+                    WarningMessage = reason,
+                    StatusReason = reason,
+                    StatusReasonCode = StatusReasonCode.LoopSuppressed,
+                    DetectionMethod = Cimian.Core.Models.DetectionMethod.None,
+                    ActionPerformed = "loop_suppressed",
+                    OutcomeTimestamp = DateTime.UtcNow
+                }
+            },
+            currentSessionId: "2026-05-06-1532");
+
+        var record = items.Single();
+        Assert.Equal("Warning", record.CurrentStatus);
+        Assert.Equal(reason, record.LastWarning);
+        Assert.Equal(1, record.WarningCount);
+        Assert.Equal("2026-05-06-1532", record.LastSeenInSession);
+    }
+
+    [Fact]
+    public void LoopGuard_GetSuppressedReport_ReturnsActiveSuppressionsWithClearCommand()
+    {
+        var stateDir = Path.Combine(Path.GetTempPath(), "CimianTests", "LoopGuard", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(stateDir);
+        var statePath = Path.Combine(stateDir, "state.json");
+        var logsDir   = Path.Combine(stateDir, "logs");
+        Directory.CreateDirectory(logsDir);
+
+        try
+        {
+            var guard = new LoopGuard(statePath, logsDir);
+
+            // Three rapid attempts within 2h trigger the rapid-fire loop policy.
+            for (var i = 0; i < 3; i++)
+            {
+                guard.RecordAttempt("WinAdminsAccount", "1.0", success: false, catalogFingerprint: "fp1");
+            }
+
+            var report = guard.GetSuppressedReport();
+            var entry = Assert.Single(report);
+            Assert.Equal("WinAdminsAccount", entry.Name);
+            Assert.Equal("1.0", entry.Version);
+            // Stored reason is the policy-level cause (LoopGuard composes the
+            // operator-facing "LOOP SUPPRESSED: <name> ..." string at ShouldSuppress
+            // time, not at storage time).
+            Assert.Contains("Rapid-fire", entry.Reason);
+            Assert.Equal("managedsoftwareupdate --clear-loop WinAdminsAccount", entry.ClearCommand);
+        }
+        finally
+        {
+            try { Directory.Delete(stateDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────
 
     private static string EventLine(string action, string status, string packageName, string packageVersion) =>

--- a/tests/ItemsJsonFinalizationTests.cs
+++ b/tests/ItemsJsonFinalizationTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cimian.Core.Models;
+using Cimian.Core.Services;
+using Xunit;
+
+namespace Cimian.Tests;
+
+/// <summary>
+/// Acceptance tests for items.json per-run finalization.
+///
+/// Three invariants under test:
+///   1. last_seen_in_session == sessionId iff the run produced a terminal
+///      install/update/remove outcome for the item.
+///   2. current_status reflects the actual outcome, not the pre-install plan.
+///   3. install_count / failure_count accumulate from events.jsonl rather than
+///      defaulting to 0 because of the package vs package_name field-name bug.
+/// </summary>
+public class ItemsJsonFinalizationTests
+{
+    // ── SessionItemStatusResolver: outcome vs pending plan ──────────────────
+
+    [Fact]
+    public void Resolve_SuccessfulInstallOutcome_OverridesPendingInstall()
+    {
+        var outcome = new ItemOutcome("Foo", "1.0", "install", true, null, DateTime.UtcNow);
+
+        var status = SessionItemStatusResolver.Resolve(
+            outcome,
+            isPendingInstall: true,   // plan said it was pending
+            isPendingUpdate: false,
+            isPendingUninstall: false,
+            manifestAction: "install");
+
+        Assert.Equal("Installed", status);
+    }
+
+    [Fact]
+    public void Resolve_FailedInstallOutcome_ReturnsFailed()
+    {
+        var outcome = new ItemOutcome("Bar", "1.0", "install", false, "boom", DateTime.UtcNow);
+
+        var status = SessionItemStatusResolver.Resolve(
+            outcome,
+            isPendingInstall: true,
+            isPendingUpdate: false,
+            isPendingUninstall: false,
+            manifestAction: "install");
+
+        Assert.Equal("Failed", status);
+    }
+
+    [Fact]
+    public void Resolve_SuccessfulRemoveOutcome_ReturnsRemoved()
+    {
+        var outcome = new ItemOutcome("Baz", "1.0", "remove", true, null, DateTime.UtcNow);
+
+        var status = SessionItemStatusResolver.Resolve(
+            outcome,
+            isPendingInstall: false,
+            isPendingUpdate: false,
+            isPendingUninstall: true,
+            manifestAction: "uninstall");
+
+        Assert.Equal("Removed", status);
+    }
+
+    [Fact]
+    public void Resolve_NoOutcome_FallsBackToPendingInstallPlan()
+    {
+        var status = SessionItemStatusResolver.Resolve(
+            outcome: null,
+            isPendingInstall: true,
+            isPendingUpdate: false,
+            isPendingUninstall: false,
+            manifestAction: "install");
+
+        Assert.Equal("Pending Install", status);
+    }
+
+    [Fact]
+    public void Resolve_NoOutcome_AlreadyInstalledItem_ReturnsInstalled()
+    {
+        var status = SessionItemStatusResolver.Resolve(
+            outcome: null,
+            isPendingInstall: false,
+            isPendingUpdate: false,
+            isPendingUninstall: false,
+            manifestAction: "install");
+
+        Assert.Equal("Installed", status);
+    }
+
+    // ── DataExporter: events.jsonl reads + LastSeenInSession stamp ──────────
+
+    [Fact]
+    public void GenerateCurrentItems_PackageNameKey_CountsInstallsAndFailures()
+    {
+        using var fixture = new SessionsFixture();
+        fixture.WriteSession("2026-04-27-1000",
+            EventLine(action: "install", status: "completed", packageName: "Foo", packageVersion: "1.0"),
+            EventLine(action: "install", status: "failed",    packageName: "Foo", packageVersion: "1.0"),
+            EventLine(action: "install", status: "completed", packageName: "Foo", packageVersion: "1.1"));
+
+        var exporter = new DataExporter(fixture.BaseDir);
+        var items = exporter.GenerateCurrentItemsFromPackagesInfo(
+            new List<SessionPackageInfo>
+            {
+                new() { Name = "Foo", Version = "1.1", Status = "Installed", ItemType = "managed_installs", DisplayName = "Foo" }
+            },
+            currentSessionId: "2026-04-27-1000");
+
+        var foo = items.Single();
+        Assert.Equal(3, foo.InstallCount);
+        Assert.Equal(1, foo.FailureCount);
+    }
+
+    [Fact]
+    public void GenerateCurrentItems_LegacyPackageKey_StillCountsForBackwardCompat()
+    {
+        using var fixture = new SessionsFixture();
+        // Pre-rename events.jsonl format with `package` / `version` instead of
+        // `package_name` / `package_version`.
+        fixture.WriteSession("2026-04-26-0900",
+            "{\"action\":\"install\",\"status\":\"completed\",\"package\":\"Bar\",\"version\":\"2.0\"}",
+            "{\"action\":\"install\",\"status\":\"failed\",\"package\":\"Bar\",\"version\":\"2.0\"}");
+
+        var exporter = new DataExporter(fixture.BaseDir);
+        var items = exporter.GenerateCurrentItemsFromPackagesInfo(
+            new List<SessionPackageInfo>
+            {
+                new() { Name = "Bar", Version = "2.0", Status = "Installed", ItemType = "managed_installs", DisplayName = "Bar" }
+            },
+            currentSessionId: "2026-04-26-0900");
+
+        var bar = items.Single();
+        Assert.Equal(2, bar.InstallCount);
+        Assert.Equal(1, bar.FailureCount);
+    }
+
+    [Fact]
+    public void GenerateCurrentItems_ActedOn_StampsLastSeenInSession()
+    {
+        using var fixture = new SessionsFixture();
+        var exporter = new DataExporter(fixture.BaseDir);
+
+        var items = exporter.GenerateCurrentItemsFromPackagesInfo(
+            new List<SessionPackageInfo>
+            {
+                new()
+                {
+                    Name = "Touched", Version = "1.0", Status = "Installed",
+                    ItemType = "managed_installs", DisplayName = "Touched",
+                    ActionPerformed = "install",
+                    OutcomeTimestamp = DateTime.UtcNow
+                },
+                new()
+                {
+                    Name = "OnlyChecked", Version = "1.0", Status = "Installed",
+                    ItemType = "managed_installs", DisplayName = "OnlyChecked"
+                    // ActionPerformed left null — only status-checked
+                }
+            },
+            currentSessionId: "2026-04-28-1545");
+
+        var touched = items.Single(i => i.ItemName == "Touched");
+        var onlyChecked = items.Single(i => i.ItemName == "OnlyChecked");
+
+        Assert.Equal("2026-04-28-1545", touched.LastSeenInSession);
+        Assert.Equal("", onlyChecked.LastSeenInSession);
+    }
+
+    [Fact]
+    public void GenerateCurrentItems_NoEventHistory_StillReportsZeroCountsNotMissing()
+    {
+        using var fixture = new SessionsFixture();
+        var exporter = new DataExporter(fixture.BaseDir);
+
+        var items = exporter.GenerateCurrentItemsFromPackagesInfo(
+            new List<SessionPackageInfo>
+            {
+                new() { Name = "Fresh", Version = "1.0", Status = "Pending", ItemType = "managed_installs", DisplayName = "Fresh" }
+            },
+            currentSessionId: "2026-04-28-1545");
+
+        var fresh = items.Single();
+        Assert.Equal(0, fresh.InstallCount);
+        Assert.Equal(0, fresh.FailureCount);
+        Assert.NotNull(fresh.RecentAttempts);
+        Assert.Empty(fresh.RecentAttempts);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private static string EventLine(string action, string status, string packageName, string packageVersion) =>
+        "{\"action\":\"" + action + "\"," +
+        "\"status\":\"" + status + "\"," +
+        "\"package_name\":\"" + packageName + "\"," +
+        "\"package_version\":\"" + packageVersion + "\"," +
+        "\"timestamp\":\"" + DateTime.UtcNow.ToString("o") + "\"}";
+
+    private sealed class SessionsFixture : IDisposable
+    {
+        public string BaseDir { get; }
+
+        public SessionsFixture()
+        {
+            BaseDir = Path.Combine(Path.GetTempPath(), "CimianTests", "ItemsJson", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(BaseDir);
+        }
+
+        public void WriteSession(string sessionId, params string[] eventLines)
+        {
+            var dir = Path.Combine(BaseDir, sessionId);
+            Directory.CreateDirectory(dir);
+            File.WriteAllLines(Path.Combine(dir, "events.jsonl"), eventLines);
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(BaseDir)) Directory.Delete(BaseDir, recursive: true); }
+            catch { /* cleanup best-effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two related fixes to `reports/items.json` so it reflects what the run actually did, and so LoopGuard suppressions stop hiding behind a `current_status="Installed"` lie.

### Fix 1 — Per-run finalization (real install outcomes)

`reports/items.json` was a pre-run snapshot, not a per-run report. Items that just installed successfully kept `"Pending Install"`; every record shipped with `last_seen_in_session=""` and `install_count=failure_count=0`. Consumers (e.g. ReportMate) had no way to filter on "what did the last run do."

**Bugs fixed**

1. `CollectSessionItems` derived status from the pre-install plan, never the actual outcome.
2. `DataExporter.GenerateCurrentItemsFromPackagesInfo` read `package` from `events.jsonl`, but `SessionLogger` writes `package_name` — `install_count`/`failure_count` were always 0.
3. `LastSeenInSession` was never assigned in the primary path and was unconditionally stamped (with a UTC timestamp instead of session id) in the simple fallback.

**Changes**

- `managedsoftwareupdate` — `PerformInstallationsAsync` / `PerformUninstallsAsync` now return per-item `ItemOutcome` lists; threaded through dependency and `update_for` recursion. `CollectSessionItems` resolves status via `SessionItemStatusResolver.Resolve` (outcome > pre-install plan).
- `SessionPackageInfo` — adds optional `ActionPerformed` and `OutcomeTimestamp` fields so `DataExporter` decides session stamping without re-parsing events.
- `DataExporter` — reads `package_name`/`package_version` with a one-release legacy fallback to `package`/`version` (across all four event-read sites in the file). `LastSeenInSession` only set when the run touched the item. Counts always populate.
- `LoopGuard` — same `package_name` fallback in its events reader.
- `SessionLogger` — passes the current session id to `DataExporter`; simple fallback also stamps the session id conditionally.

### Fix 2 — Surface LoopGuard suppressions in items.json

LoopGuard correctly suppresses packages stuck in install loops, but the suppression was invisible to consumers. `installcheck_script` would say "install needed", LoopGuard would refuse, and `items.json` would still report `current_status="Installed"`. Operators had no signal that a package was broken.

**Changes**

- `managedsoftwareupdate` — `IdentifyActions` returns the list of LoopGuard-suppressed items as a fourth tuple element. `CollectSessionItems` stamps each as `Status="Warning"` with the LoopGuard reason in `WarningMessage` / `StatusReason`, plus `StatusReasonCode="loop_suppressed"` and `DetectionMethod="none"` so frontends can branch on the machine-readable code rather than string-matching warning text. `ActionPerformed="loop_suppressed"` so `DataExporter` stamps `last_seen_in_session` — suppressed items appear under "what did the last run do" filters.
- `LoopGuard` — adds `GetSuppressedReport()` returning report-ready `LoopSuppressedReportItem` entries (name, last-attempted version, policy reason, suppression deadline, operator clear-command).
- `SessionLogger` — writes `reports/loop_suppressed.json` alongside `items.json` so dashboards get a sibling file listing every active suppression (including prior-run suppressions still in backoff).

The existing `LogStatusCheck("suppressed")` event in `events.jsonl` is preserved — that's still the per-action source of truth.

## Acceptance criteria

After a session that installs `Foo` successfully, fails `Bar`, has `Qux` loop-suppressed, and merely status-checks `Baz`:

- `Foo`: `current_status=Installed`, `last_seen_in_session=<sessionId>`, `install_count >= 1`.
- `Bar`: `current_status=Failed` (or `Error` after `NormalizeItemStatus`), `last_seen_in_session=<sessionId>`, `failure_count >= 1`.
- `Qux`: `current_status=Warning`, `last_warning=<full LoopGuard reason>`, `status_reason_code=loop_suppressed`, `last_seen_in_session=<sessionId>`.
- `Baz`: `current_status=Installed`, `last_seen_in_session=""`.

Plus `reports/loop_suppressed.json` listing `Qux` (and any other active suppressions across runs) with name, version, reason, `suppressed_until`, and `clear_command`.

## Migration window

Old `events.jsonl` files written before the schema rename used `package`/`version`. Both readers (DataExporter, LoopGuard) accept either spelling for one transition window before legacy keys can be dropped.

## Test plan

- [x] `dotnet build` — clean Release build.
- [x] `dotnet test tests/Cimian.Tests.csproj -c Release` — 652 passed, 0 failed, 0 warnings.
- [ ] Signed binary smoke for finalization: `.\build.ps1 -Sign -Binary managedsoftwareupdate`, then `sudo .\release\arm64\managedsoftwareupdate.exe -v --checkonly` against a manifest with one needs-install item; verify `C:\ProgramData\ManagedInstalls\reports\items.json` shows that one item with a non-empty `last_seen_in_session` and the rest empty.
- [ ] Signed binary smoke for LoopGuard surfacing: trigger a loop on a test item (three rapid installs of a package whose `installcheck_script` always returns 0), let LoopGuard kick in, then `--checkonly`. Verify the suppressed item shows `current_status="Warning"` + matching `last_warning`, and `reports/loop_suppressed.json` lists the package.

## Out of scope (separate tickets)

- ReportMate Windows collector workaround at `clients/windows/src/Services/Modules/InstallsModuleProcessor.cs` can be removed once this lands.
- ReportMate frontend pill labels not recomputing under `last_run` filter — separate UX issue.