### PR TITLE
managedsoftwareupdate: --item bypasses LoopGuard for the named item

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -395,7 +395,7 @@ public class UpdateEngine : IDisposable
             LogInfo("----------------------------------------------------------------------");
             LogInfo("STATUS CHECKING");
             LogInfo("----------------------------------------------------------------------");
-            var (toInstall, toUpdate, toUninstall, loopSuppressed) = IdentifyActions(manifestItems, catalogMap);
+            var (toInstall, toUpdate, toUninstall, loopSuppressed) = IdentifyActions(manifestItems, catalogMap, itemFilterService);
 
             // Dictionary of items LoopGuard refused this run, keyed by lower-invariant
             // name. Surfaces in items.json as Warning + last_warning + status_reason_code,
@@ -860,7 +860,8 @@ public class UpdateEngine : IDisposable
 
     private (List<CatalogItem> ToInstall, List<CatalogItem> ToUpdate, List<CatalogItem> ToUninstall,
              List<(CatalogItem Item, string Reason, string? InstalledVersion, bool WasUpdate)> LoopSuppressed)
-        IdentifyActions(List<ManifestItem> manifestItems, Dictionary<string, CatalogItem> catalogMap)
+        IdentifyActions(List<ManifestItem> manifestItems, Dictionary<string, CatalogItem> catalogMap,
+                        ItemFilterService? itemFilterService = null)
     {
         var toInstall = new List<CatalogItem>();
         var toUpdate = new List<CatalogItem>();
@@ -950,8 +951,22 @@ public class UpdateEngine : IDisposable
                     
                     if (status.NeedsAction)
                     {
+                        // --item targets specific packages by name; bypass LoopGuard for those
+                        // (run-scoped only — persistent suppression state is left intact so
+                        // future runs without --item still honor it).
+                        var bypassLoopGuard = itemFilterService != null
+                            && itemFilterService.HasFilter
+                            && itemFilterService.Items.Contains(catalogItem.Name);
+
+                        if (bypassLoopGuard)
+                        {
+                            var msg = $"--item: bypassing LoopGuard for '{catalogItem.Name}'";
+                            ConsoleLogger.Info(msg);
+                            _sessionLogger?.Log("INFO", msg);
+                        }
+
                         // Check LoopGuard before adding to install list
-                        if (_loopGuard != null)
+                        if (_loopGuard != null && !bypassLoopGuard)
                         {
                             var fingerprint = ComputeCatalogFingerprint(catalogItem);
                             var (suppress, loopReason) = _loopGuard.ShouldSuppress(catalogItem.Name, catalogItem.Version, fingerprint);


### PR DESCRIPTION
## Summary
- When `--item <name>` is passed to `managedsoftwareupdate`, LoopGuard is bypassed for the matching item(s) so an operator-targeted run can proceed even if the item was previously suppressed.
- Run-scoped only: persistent suppression state in `cimian.state.json` is left intact, so the next run *without* `--item` still honors it.
- All other gates (CheckStatus, OS/agent eligibility, install_window, force deadlines, dependencies, installcheck_script) continue to apply normally.

## Test plan
- [ ] Verify `--checkonly --item <name>` on a previously LoopGuard-suppressed item logs the bypass message and queues the install action.
- [ ] Verify a subsequent run *without* `--item` still respects the existing LoopGuard suppression.
- [ ] Confirm non-matching items in the same run are unaffected by the bypass.
- [ ] Confirm other eligibility gates (install_window, dependencies, installcheck_script) still block when applicable.