### PR TITLE
pkginfo: round-trip _metadata block via PkgsInfo.Metadata

### DIFF
--- a/shared/core/Services/YamlUtils.cs
+++ b/shared/core/Services/YamlUtils.cs
@@ -70,11 +70,37 @@ public static class YamlUtils
         NormalizeMultilineStrings(pkgInfo);
 
         var raw = Serializer.Serialize(pkgInfo);
+
+        // If the model carries a `Metadata : Dictionary<string, object?>`
+        // property (any of our pkginfo models — PkgsInfo, CimianStudio's
+        // Package — can opt in by declaring one with [YamlIgnore]), splice
+        // its contents in as a `_metadata:` block. Workaround for YamlDotNet
+        // 16.3's leading-underscore alias regression. ReorderTopLevelKeys
+        // moves the block to its canonical EOF position.
+        var metadata = ExtractMetadataFromModel(pkgInfo);
+        if (metadata is { Count: > 0 } md)
+        {
+            var metaYaml = Serializer.Serialize(new Dictionary<string, object?> { [MetadataKey] = md });
+            raw = raw.TrimEnd('\n') + "\n" + metaYaml;
+        }
+
         return ReorderTopLevelKeys(raw, PkgInfoPriorityKeys, MetadataKey);
     }
 
     public static T? DeserializePkgInfo<T>(string yaml) where T : class
-        => Deserializer.Deserialize<T>(yaml);
+    {
+        var pkg = Deserializer.Deserialize<T>(yaml);
+        if (pkg is null) return null;
+
+        // Round-trip the _metadata block into the model's Metadata property
+        // when it has one. Symmetric with SerializePkgInfo's emit path.
+        var metadata = ExtractMetadataBlock(yaml);
+        if (metadata is { Count: > 0 })
+        {
+            AssignMetadataToModel(pkg, metadata);
+        }
+        return pkg;
+    }
 
     /// <summary>
     /// Serializes a manifest, normalizing `included_manifests` entries from
@@ -286,6 +312,27 @@ public static class YamlUtils
                 }
             }
         }
+    }
+
+    // Reflection-based read of a `Metadata : Dictionary<string, object?>`
+    // property, if present. Returns null when the model doesn't declare one
+    // (most upstream models don't; PkgsInfo is the seed, CimianStudio's
+    // Package follows). Same marker-less convention as
+    // NormalizeIncludedManifestPaths below.
+    private static Dictionary<string, object?>? ExtractMetadataFromModel(object obj)
+    {
+        var prop = obj.GetType().GetProperty("Metadata", BindingFlags.Public | BindingFlags.Instance);
+        if (prop?.PropertyType != typeof(Dictionary<string, object?>)) return null;
+        return prop.GetValue(obj) as Dictionary<string, object?>;
+    }
+
+    // Symmetric setter for the round-trip path. No-op when the model has no
+    // writable Metadata property.
+    private static void AssignMetadataToModel(object obj, Dictionary<string, object?> metadata)
+    {
+        var prop = obj.GetType().GetProperty("Metadata", BindingFlags.Public | BindingFlags.Instance);
+        if (prop?.PropertyType != typeof(Dictionary<string, object?>) || !prop.CanWrite) return;
+        prop.SetValue(obj, metadata);
     }
 
     // Reflection-based normalization for any model with an

--- a/shared/import/Models/ImportModels.cs
+++ b/shared/import/Models/ImportModels.cs
@@ -89,6 +89,21 @@ public class PkgsInfo
 
     [YamlMember(Alias = "uninstallcheck_script")]
     public string? UninstallCheckScript { get; set; }
+
+    /// <summary>
+    /// Free-form trailing dictionary used by tools like cimian-promoter and
+    /// autopkg (e.g. <c>created_by</c>, <c>creation_date</c>,
+    /// <c>cimian-promoter_edit_date</c>). Always emitted last.
+    /// <see cref="YamlIgnoreAttribute"/> because YamlDotNet 16.3 silently drops
+    /// any <c>[YamlMember(Alias = "_metadata")]</c> binding (leading-underscore
+    /// alias regression). <see cref="Cimian.Core.Services.YamlUtils"/> picks
+    /// this up via reflection: <c>SerializePkgInfo</c> appends a
+    /// <c>_metadata:</c> block when the value is non-empty, and
+    /// <c>DeserializePkgInfo</c> populates it from the source YAML via
+    /// <c>ExtractMetadataBlock</c>. Round-trip is automatic.
+    /// </summary>
+    [YamlIgnore]
+    public Dictionary<string, object?>? Metadata { get; set; }
 }
 
 /// <summary>

--- a/shared/import/Services/ImportService.cs
+++ b/shared/import/Services/ImportService.cs
@@ -299,6 +299,16 @@ public class ImportService
         var pkginfoFilename = $"{sanitizedName}{archTag}{pkgsInfo.Version}.yaml";
         var pkginfoPath = Path.Combine(pkginfoFolderPath, pkginfoFilename);
 
+        // Preserve any existing _metadata block (cimian-promoter / autopkg
+        // stamps like created_by / creation_date / cimian-promoter_edit_date).
+        // Without this an in-place re-import would silently strip them, since
+        // we're about to overwrite the file from a freshly-built PkgsInfo.
+        if (File.Exists(pkginfoPath))
+        {
+            var existing = await File.ReadAllTextAsync(pkginfoPath).ConfigureAwait(false);
+            pkgsInfo.Metadata = YamlUtils.ExtractMetadataBlock(existing);
+        }
+
         var yaml = YamlUtils.SerializePkgInfo(pkgsInfo);
         await File.WriteAllTextAsync(pkginfoPath, yaml);
 

--- a/shared/import/Services/ImportService.cs
+++ b/shared/import/Services/ImportService.cs
@@ -305,12 +305,12 @@ public class ImportService
         // we're about to overwrite the file from a freshly-built PkgsInfo.
         if (File.Exists(pkginfoPath))
         {
-            var existing = await File.ReadAllTextAsync(pkginfoPath).ConfigureAwait(false);
+            var existing = await File.ReadAllTextAsync(pkginfoPath, cancellationToken).ConfigureAwait(false);
             pkgsInfo.Metadata = YamlUtils.ExtractMetadataBlock(existing);
         }
 
         var yaml = YamlUtils.SerializePkgInfo(pkgsInfo);
-        await File.WriteAllTextAsync(pkginfoPath, yaml);
+        await File.WriteAllTextAsync(pkginfoPath, yaml, cancellationToken).ConfigureAwait(false);
 
         prompter.ReportInfo($"Pkginfo created at: {pkginfoPath}");
 

--- a/tests/Shared/YamlUtilsTests.cs
+++ b/tests/Shared/YamlUtilsTests.cs
@@ -62,15 +62,17 @@ public class YamlUtilsTests
         Assert.StartsWith("catalogs:", lines[3]);
     }
 
-    // ─── _metadata at EOF ──────────────────────────────────────────────────
+    // ─── _metadata round-trip via the strongly-typed PkgsInfo.Metadata ─────
 
     [Fact]
-    public void SerializePkgInfo_PreservesMetadataAtEof_WhenRoundTrippedAsDictionary()
+    public void PkgsInfo_RoundTrips_MetadataBlock_AtEof()
     {
-        // The strongly-typed PkgsInfo model can't carry _metadata (YamlDotNet
-        // 16.3 silently drops underscore-prefix aliases). The post-processing
-        // reorder logic does keep it last if the input mapping had it though,
-        // so this exercises the reorder layer directly via the raw Serializer.
+        // PkgsInfo gained a `Metadata : Dictionary<string, object?>` property
+        // (with [YamlIgnore] because YamlDotNet 16.3 silently drops underscore-
+        // prefix aliases). YamlUtils.SerializePkgInfo / DeserializePkgInfo
+        // splice the block in/out via reflection, so the round-trip is
+        // automatic for any model that opts in by declaring a Metadata
+        // property of that exact type.
         const string source = """
             name: Test
             version: '1.0'
@@ -80,13 +82,31 @@ public class YamlUtilsTests
             _metadata:
               created_by: autopkg
               creation_date: '2026-04-21T14:04:12Z'
+
             """;
 
-        var meta = YamlUtils.ExtractMetadataBlock(source);
+        var pkg = YamlUtils.DeserializePkgInfo<PkgsInfo>(source);
+        Assert.NotNull(pkg);
+        Assert.NotNull(pkg!.Metadata);
+        Assert.Equal("autopkg", pkg.Metadata!["created_by"]);
+        Assert.Equal("2026-04-21T14:04:12Z", pkg.Metadata["creation_date"]);
 
-        Assert.NotNull(meta);
-        Assert.Equal("autopkg", meta!["created_by"]);
-        Assert.Equal("2026-04-21T14:04:12Z", meta["creation_date"]);
+        // Re-emit and verify the block is back at EOF in canonical form.
+        var emitted = YamlUtils.SerializePkgInfo(pkg);
+        Assert.Contains("_metadata:", emitted);
+        Assert.Contains("created_by: autopkg", emitted);
+        // _metadata must remain the trailing key — the reorder step's job.
+        var lastNonEmpty = emitted.Split('\n').Reverse().FirstOrDefault(l => !string.IsNullOrWhiteSpace(l));
+        Assert.NotNull(lastNonEmpty);
+        Assert.StartsWith("  ", lastNonEmpty); // last line is indented under _metadata, not a top-level key.
+    }
+
+    [Fact]
+    public void PkgsInfo_RoundTrip_OmitsMetadata_WhenNotPresent()
+    {
+        var pkg = new PkgsInfo { Name = "Test", Version = "1.0" };
+        var emitted = YamlUtils.SerializePkgInfo(pkg);
+        Assert.DoesNotContain("_metadata:", emitted);
     }
 
     // ─── OnDemand: PascalCase must survive round-trip ──────────────────────


### PR DESCRIPTION
## Summary

- Add a \`Metadata : Dictionary<string, object?>\` property to \`PkgsInfo\` (with \`[YamlIgnore]\` because YamlDotNet 16.3 silently drops underscore-prefix aliases — that's the bug \`ExtractMetadataBlock\` already worked around for parsing).
- Teach \`YamlUtils.SerializePkgInfo\` and \`YamlUtils.DeserializePkgInfo\` to splice the trailing \`_metadata:\` block in/out via reflection, so any model declaring a \`Metadata\` property of that exact type gets round-trip support automatically.
- Update \`ImportService.ImportAsync\` to read any pre-existing pkginfo before the overwrite and copy its \`_metadata\` block onto the freshly-built \`PkgsInfo\`. Re-importing on top of an autopkg- or cimian-promoter-stamped file no longer silently strips \`created_by\` / \`creation_date\` / \`cimian-promoter_edit_date\`.

## Why

In CimianStudio's import wizard we noticed that hitting Save on a pkginfo that already had a \`_metadata\` block (autopkg's \`creation_date\`, cimian-promoter's edit timestamp, etc.) would lose the block, because \`ImportService\` builds a fresh \`PkgsInfo\` and \`PkgsInfo\` had no Metadata field. CimianStudio shipped a downstream shim (\`PackageYaml.ReadExistingMetadataAsync\` / \`RestoreMetadataIfMissingAsync\`) to capture-and-reinject around the call, but the right home for that behavior is upstream — every Cimian tool that re-writes a pkginfo should preserve operator metadata.

## Design notes

The reflection-based handler is generic: any model that opts in by declaring \`Metadata : Dictionary<string, object?>\` (with \`[YamlIgnore]\`) gets the same round-trip behavior. CimianStudio's \`Package\` already declares one for its own editor flow; the same pattern extends to manifests if/when we want operator stamps there too.

CimianStudio's downstream shim becomes a no-op once this lands (its \`RestoreMetadataIfMissingAsync\` skips when the new file already has a \`_metadata:\` line), so there's no co-deploy ordering problem — merge here and CimianStudio gracefully picks up the upstream behavior on next clone.

## Test plan
- [x] \`dotnet build CimianTools.sln -c Debug\` clean (0 warnings, 0 errors)
- [x] Full test suite: 675/675 pass
- [x] New unit tests: \`PkgsInfo_RoundTrips_MetadataBlock_AtEof\` and \`PkgsInfo_RoundTrip_OmitsMetadata_WhenNotPresent\`
- [ ] Manual: re-import a pkgsinfo file in CimianStudio that already has a \`_metadata:\` block, confirm the block survives the overwrite