### PR TITLE
makepkginfo: auto-populate installs[].version from MSI ProductVersion

### DIFF
--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -62,6 +62,33 @@ public class PkgInfoBuilder
     }
 
     /// <summary>
+    /// Builds the InstallItem that represents MSI install identity in the pkgsinfo.
+    /// Internal so unit tests can verify the mapping from MsiMetadata without
+    /// needing a real MSI on disk.
+    ///
+    /// Munki convention: MSI install identity belongs in installs[] of type=msi,
+    /// not as a hash-only file entry pointing at the .msi artifact itself. The
+    /// ProductCode/UpgradeCode are what managedsoftwareupdate uses to verify
+    /// Windows Installer registration. Empty extractor results pass through as
+    /// null so OmitNull suppresses the keys.
+    ///
+    /// Version is populated from the MSI's ProductVersion (the truncated form
+    /// that lands in the uninstall registry, e.g. 26.5.612 for cimipkg-built
+    /// date-format catalogs). StatusService's installs[] check compares against
+    /// DisplayVersion, so omitting installs[].version makes it fall back to the
+    /// top-level catalog version — which for date-format builds (YYYY.MM.DD.HHMM)
+    /// will never match the registry's truncated form and loops on every cycle.
+    /// </summary>
+    public static InstallItem BuildMsiInstallItem(MetadataExtractor.MsiMetadata meta) =>
+        new()
+        {
+            Type = "msi",
+            ProductCode = string.IsNullOrEmpty(meta.ProductCode) ? null : meta.ProductCode,
+            UpgradeCode = string.IsNullOrEmpty(meta.UpgradeCode) ? null : meta.UpgradeCode,
+            Version = string.IsNullOrEmpty(meta.ProductVersion) ? null : meta.ProductVersion
+        };
+
+    /// <summary>
     /// Gathers installer information and builds a PkgsInfo object
     /// </summary>
     public PkgsInfo BuildFromInstaller(string installerPath, PkgsInfoOptions options)
@@ -90,25 +117,7 @@ public class PkgInfoBuilder
                 productCode = msiMeta.ProductCode;
                 upgradeCode = msiMeta.UpgradeCode;
 
-                // Munki convention: MSI install identity belongs in installs[] of type=msi,
-                // not as a hash-only file entry pointing at the .msi artifact itself. The
-                // ProductCode/UpgradeCode here are what managedsoftwareupdate uses to
-                // verify Windows Installer registration. Empty extractor results pass
-                // through as null so OmitNull suppresses the keys.
-                //
-                // Version is populated from the MSI's ProductVersion (the truncated form
-                // that lands in the uninstall registry, e.g. 26.5.612 for cimipkg-built
-                // date-format catalogs). StatusService's installs[] check compares against
-                // DisplayVersion, so omitting installs[].version makes it fall back to the
-                // top-level catalog version — which for date-format builds (YYYY.MM.DD.HHMM)
-                // will never match the registry's truncated form and loops on every cycle.
-                installs.Add(new InstallItem
-                {
-                    Type = "msi",
-                    ProductCode = string.IsNullOrEmpty(productCode) ? null : productCode,
-                    UpgradeCode = string.IsNullOrEmpty(upgradeCode) ? null : upgradeCode,
-                    Version = string.IsNullOrEmpty(msiMeta.ProductVersion) ? null : msiMeta.ProductVersion
-                });
+                installs.Add(BuildMsiInstallItem(msiMeta));
                 break;
 
             case ".exe":

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -94,14 +94,20 @@ public class PkgInfoBuilder
                 // not as a hash-only file entry pointing at the .msi artifact itself. The
                 // ProductCode/UpgradeCode here are what managedsoftwareupdate uses to
                 // verify Windows Installer registration. Empty extractor results pass
-                // through as null so OmitNull suppresses the keys. Version is intentionally
-                // omitted — StatusService falls back to the top-level pkginfo version, and
-                // MSI per-version identity is already the ProductCode.
+                // through as null so OmitNull suppresses the keys.
+                //
+                // Version is populated from the MSI's ProductVersion (the truncated form
+                // that lands in the uninstall registry, e.g. 26.5.612 for cimipkg-built
+                // date-format catalogs). StatusService's installs[] check compares against
+                // DisplayVersion, so omitting installs[].version makes it fall back to the
+                // top-level catalog version — which for date-format builds (YYYY.MM.DD.HHMM)
+                // will never match the registry's truncated form and loops on every cycle.
                 installs.Add(new InstallItem
                 {
                     Type = "msi",
                     ProductCode = string.IsNullOrEmpty(productCode) ? null : productCode,
-                    UpgradeCode = string.IsNullOrEmpty(upgradeCode) ? null : upgradeCode
+                    UpgradeCode = string.IsNullOrEmpty(upgradeCode) ? null : upgradeCode,
+                    Version = string.IsNullOrEmpty(msiMeta.ProductVersion) ? null : msiMeta.ProductVersion
                 });
                 break;
 

--- a/tests/Makepkginfo/PkgInfoBuilderTests.cs
+++ b/tests/Makepkginfo/PkgInfoBuilderTests.cs
@@ -239,6 +239,67 @@ public class PkgInfoBuilderTests
     }
 
     [Fact]
+    public void BuildMsiInstallItem_PopulatesVersionFromProductVersion()
+    {
+        // Cimipkg-built MSIs land DisplayVersion=26.5.612 in the registry (compressed
+        // from catalog version 2026.05.06.1248). installs[].version must match that
+        // truncated form so StatusService.CheckMsiWithUpgradeCode resolves correctly --
+        // omitting it makes Cimian fall back to the date-format catalog version, which
+        // never equals 26.5.612 and triggers a permanent reinstall loop.
+        var meta = new MetadataExtractor.MsiMetadata(
+            ProductName:    "SbinInstaller",
+            ProductVersion: "26.4.2716",
+            Developer:      "Windows Admins",
+            Description:    "",
+            ProductCode:    "{a3d0871c-e0e8-4f11-827f-6507a08dc00b}",
+            UpgradeCode:    "{eb666390-ff65-55da-aac4-8eebc7b45db0}");
+
+        var item = PkgInfoBuilder.BuildMsiInstallItem(meta);
+
+        Assert.Equal("msi", item.Type);
+        Assert.Equal("{a3d0871c-e0e8-4f11-827f-6507a08dc00b}", item.ProductCode);
+        Assert.Equal("{eb666390-ff65-55da-aac4-8eebc7b45db0}", item.UpgradeCode);
+        Assert.Equal("26.4.2716", item.Version);
+    }
+
+    [Fact]
+    public void BuildMsiInstallItem_EmptyProductVersion_LeavesVersionNull()
+    {
+        // OmitNull must suppress an absent ProductVersion (some MSIs ship without one) --
+        // emitting empty-string would serialize as `version: ''` and break version compare.
+        var meta = new MetadataExtractor.MsiMetadata(
+            ProductName:    "Blender",
+            ProductVersion: "",
+            Developer:      "Blender Foundation",
+            Description:    "",
+            ProductCode:    "{26068070-A31E-4DCD-8D17-F40B06CB413D}",
+            UpgradeCode:    "{4C6AD1CE-C11B-54CD-83AE-A801252310E4}");
+
+        var item = PkgInfoBuilder.BuildMsiInstallItem(meta);
+
+        Assert.Null(item.Version);
+        Assert.Equal("{26068070-A31E-4DCD-8D17-F40B06CB413D}", item.ProductCode);
+    }
+
+    [Fact]
+    public void BuildMsiInstallItem_EmptyCodes_LeavesCodesNull()
+    {
+        var meta = new MetadataExtractor.MsiMetadata(
+            ProductName:    "UnknownMSI",
+            ProductVersion: "1.2.3",
+            Developer:      "",
+            Description:    "",
+            ProductCode:    "",
+            UpgradeCode:    "");
+
+        var item = PkgInfoBuilder.BuildMsiInstallItem(meta);
+
+        Assert.Null(item.ProductCode);
+        Assert.Null(item.UpgradeCode);
+        Assert.Equal("1.2.3", item.Version);
+    }
+
+    [Fact]
     public void CreateNewPkgsInfo_CreatesFileWithDefaults()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());


### PR DESCRIPTION
## Summary

When `makepkginfo` builds a pkginfo from an MSI, it now populates `installs[].version` from the MSI's `ProductVersion` property instead of intentionally omitting it.

## Why

cimipkg compresses date-format catalog versions (`YYYY.MM.DD.HHMM`) into MSI's strict 3-part `ProductVersion` (`YY.M.DDxHH`, e.g. `2026.05.06.1248` â†’ `26.5.612`). The truncated form is what lands in the Windows uninstall registry's `DisplayVersion`.

At runtime, `StatusService.CheckMsiWithUpgradeCode` compares the catalog version (e.g. `2026.05.06.1248`) against `DisplayVersion` (`26.5.612`) via naive part-by-part comparison â€” `2026 > 26` â†’ catalog "newer" â†’ reinstall on every cycle.

The previous comment claimed _"MSI per-version identity is the ProductCode"_ and intentionally omitted `installs[].version`, which is exactly what triggered fleet-wide install loops for cimipkg-built MSIs (SbinInstaller, WinAdminsAccount, CimianPreflight, etc â€” 200+ loop warnings on the fleet via ReportMate, tracked under [](https://dev.azure.com/example-org/f6d33719-4062-45ea-af9e-4e4f881c1409/_workitems/edit/267)).

## What it changes

```diff
 installs.Add(new InstallItem
 {
     Type = "msi",
     ProductCode = string.IsNullOrEmpty(productCode) ? null : productCode,
-    UpgradeCode = string.IsNullOrEmpty(upgradeCode) ? null : upgradeCode
+    UpgradeCode = string.IsNullOrEmpty(upgradeCode) ? null : upgradeCode,
+    Version = string.IsNullOrEmpty(msiMeta.ProductVersion) ? null : msiMeta.ProductVersion
 });
```

The top-level pkginfo `version` still carries the human-readable full date for display/sort. The new `installs[].version` lines the catalog-side expected version up with what's actually in the registry, so the version comparison resolves correctly.

## Test plan

- [ ] Re-run `makepkginfo` against a cimipkg-built MSI (e.g. `SbinInstaller-x64-*.msi`) and verify the generated YAML has `installs[].version` matching the MSI's `ProductVersion` (e.g. `26.4.2716`).
- [ ] Re-run against a third-party MSI (Blender 4.5.x) and verify `installs[].version` matches its `ProductVersion`.
- [ ] On a previously-looping host, regenerate the pkginfo and confirm `managedsoftwareupdate -v --checkonly` reports "installed" rather than "version outdated".
