### PR TITLE
msi: verify on-disk file version after ARP check (key_path) + BOM-driven auto-detect in cimiimport

### DIFF
--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -527,6 +527,16 @@ public class InstallCheckItem
     public string? IdentityName { get; set; }
 
     /// <summary>
+    /// Optional absolute path to the primary executable installed by this MSI.
+    /// When set, MSI verification also checks that this file's FileVersion is
+    /// >= the catalog version, even after the ARP/UpgradeCode registry check
+    /// passes. Catches silent file overwrites where another installer lays
+    /// older binaries on top of a current MSI without updating the ARP entry.
+    /// </summary>
+    [YamlMember(Alias = "key_path")]
+    public string? KeyPath { get; set; }
+
+    /// <summary>
     /// Returns the lowercased install-check type. When the YAML omits `type:`,
     /// infer it from which identity field is set so a hand-written entry like
     /// `{product_code: ..., upgrade_code: ...}` is treated as an MSI rather than

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -578,6 +578,44 @@ public class StatusService
                     {
                         ConsoleLogger.Info($"MSI verification passed - version current or newer item: {item.Name} installedVersion: {msiInstalledVersion} catalogVersion: {catalogVersion}");
                         result.InstalledVersion = msiInstalledVersion;
+
+                        // Defense in depth: registry says installed at the right version, but
+                        // verify the primary executable on disk matches. Catches silent file
+                        // overwrites where another installer (e.g. a downgrade MSI with a
+                        // different ProductCode) lays older binaries on top while leaving
+                        // this product's ARP DisplayVersion intact.
+                        if (!string.IsNullOrEmpty(installItem.KeyPath))
+                        {
+                            if (!File.Exists(installItem.KeyPath))
+                            {
+                                ConsoleLogger.Info($"MSI registry OK but key_path file missing - reinstall needed item: {item.Name} keyPath: {installItem.KeyPath}");
+                                result.Status = "pending";
+                                result.NeedsAction = true;
+                                result.IsUpdate = true;
+                                result.Reason = $"key_path file missing despite MSI registry hit: {installItem.KeyPath}";
+                                result.ReasonCode = StatusReasonCode.FileMissing;
+                                result.DetectionMethod = DetectionMethod.File;
+                                return result;
+                            }
+
+                            var diskVersion = GetFileVersion(installItem.KeyPath);
+                            if (!string.IsNullOrEmpty(diskVersion) && !string.IsNullOrEmpty(catalogVersion))
+                            {
+                                var cmp = CatalogService.CompareVersions(catalogVersion, diskVersion);
+                                if (cmp > 0)
+                                {
+                                    ConsoleLogger.Info($"MSI registry reports {msiInstalledVersion} but key_path file is older - reinstall needed item: {item.Name} keyPath: {installItem.KeyPath} diskVersion: {diskVersion} catalogVersion: {catalogVersion}");
+                                    result.Status = "pending";
+                                    result.NeedsAction = true;
+                                    result.IsUpdate = true;
+                                    result.InstalledVersion = diskVersion;
+                                    result.Reason = $"key_path version mismatch: disk={diskVersion} catalog={catalogVersion} (ARP reported {msiInstalledVersion})";
+                                    result.ReasonCode = StatusReasonCode.VersionOutdated;
+                                    result.DetectionMethod = DetectionMethod.File;
+                                    return result;
+                                }
+                            }
+                        }
                     }
                     break;
 

--- a/shared/import/Models/ImportModels.cs
+++ b/shared/import/Models/ImportModels.cs
@@ -165,6 +165,15 @@ public class InstallItem
     /// <summary>MSIX/APPX package identity name (from AppxManifest Identity/@Name).</summary>
     [YamlMember(Alias = "identity_name")]
     public string? IdentityName { get; set; }
+
+    /// <summary>
+    /// Optional absolute path to the primary binary installed by this MSI.
+    /// Mirrors the runtime InstallCheckItem.KeyPath field — emitted in pkginfos
+    /// so managedsoftwareupdate can verify the on-disk FileVersion in addition
+    /// to the MSI registry check.
+    /// </summary>
+    [YamlMember(Alias = "key_path")]
+    public string? KeyPath { get; set; }
 }
 
 /// <summary>
@@ -207,6 +216,14 @@ public class InstallerMetadata
 
     /// <summary>MSIX/APPX package identity name (from AppxManifest Identity/@Name).</summary>
     public string IdentityName { get; set; } = "";
+
+    /// <summary>
+    /// Resolved absolute path of the primary installed binary for MSI packages.
+    /// Populated by ExtractMsiMetadata from either the build-info.yaml override
+    /// or the auto-detect heuristic against the MSI's File/Component/Directory
+    /// tables. Empty when unresolvable.
+    /// </summary>
+    public string KeyPath { get; set; } = "";
 }
 
 /// <summary>

--- a/shared/import/Services/ImportService.cs
+++ b/shared/import/Services/ImportService.cs
@@ -205,13 +205,20 @@ public class ImportService
             // Version is intentionally omitted — StatusService falls back to the
             // top-level pkginfo version when the installs entry has none, and the
             // MSI's per-version identity is already the ProductCode.
+            //
+            // KeyPath is populated by ExtractMsiMetadata for cimipkg-built MSIs
+            // (either an explicit build-info override or the BOM heuristic pick).
+            // Third-party MSIs leave KeyPath empty here — those packages get up
+            // to 3 companion type=file entries appended further down via
+            // metadata.Installs (see PopulateMsiBom).
             finalInstalls =
             [
                 new InstallItem
                 {
                     Type = "msi",
                     ProductCode = productCode,
-                    UpgradeCode = upgradeCode
+                    UpgradeCode = upgradeCode,
+                    KeyPath = string.IsNullOrWhiteSpace(metadata.KeyPath) ? null : metadata.KeyPath
                 }
             ];
         }

--- a/shared/import/Services/MetadataExtractor.cs
+++ b/shared/import/Services/MetadataExtractor.cs
@@ -217,7 +217,17 @@ public partial class MetadataExtractor
             // Third-party MSI — emit top-N file checks instead of a single key_path.
             // type=msi entry (registry/ProductCode check) is still emitted by
             // ImportService.cs; these stack on top as defense-in-depth file checks.
-            foreach (var f in exes.Take(ThirdPartyFileCheckCap))
+            //
+            // Filter to versioned files only. The runtime file verifier compares
+            // the catalog version against the on-disk FileVersionInfo, and when
+            // the disk file has no embedded version it marks the item pending
+            // ("File version metadata unavailable and no hash verification") —
+            // which would loop forever for unversioned vendor binaries. Better
+            // to not emit a check we can't make pass than to ship an install
+            // loop. Files with version metadata get the full file-version check;
+            // unversioned binaries fall back to ARP-only verification.
+            foreach (var f in exes.Where(f => !string.IsNullOrWhiteSpace(f.Version))
+                                  .Take(ThirdPartyFileCheckCap))
             {
                 metadata.Installs.Add(new InstallItem
                 {
@@ -234,24 +244,30 @@ public partial class MetadataExtractor
     }
 
     /// <summary>
-    /// Resolves a <c>key_path</c> value from build-info.yaml. Absolute paths
-    /// pass through; relative paths are anchored to the package's
-    /// <c>install_location</c>. Returns empty when neither yields an absolute path.
+    /// Resolves a <c>key_path</c> value from build-info.yaml. Fully-qualified
+    /// paths pass through; everything else (including drive-relative forms like
+    /// <c>C:foo\bar</c>, which <see cref="Path.IsPathRooted"/> reports as
+    /// rooted but aren't fully qualified) is treated as a relative path anchored
+    /// to the package's <c>install_location</c>. Returns empty when there's no
+    /// install_location to anchor against and the value isn't fully qualified.
     /// </summary>
     private static string ResolveBuildInfoKeyPath(string keyPath, string? installLocation)
     {
         var trimmed = keyPath.Trim();
         if (string.IsNullOrEmpty(trimmed)) return "";
 
-        // Already an absolute Windows path (e.g. starts with "C:\" or "\\").
-        if (Path.IsPathRooted(trimmed))
-            return trimmed.Replace('/', '\\');
+        var normalized = trimmed.Replace('/', '\\');
+
+        // Use IsPathFullyQualified (not IsPathRooted) so drive-relative forms like
+        // "C:foo\bar" — which resolve at the runtime CWD of drive C: — don't sneak
+        // through as if they were absolute paths.
+        if (Path.IsPathFullyQualified(normalized))
+            return normalized;
 
         if (string.IsNullOrWhiteSpace(installLocation))
             return "";
 
-        var combined = Path.Combine(installLocation.TrimEnd('\\', '/'), trimmed.Replace('/', '\\'));
-        return combined;
+        return Path.Combine(installLocation.TrimEnd('\\', '/'), normalized);
     }
 
     /// <summary>

--- a/shared/import/Services/MetadataExtractor.cs
+++ b/shared/import/Services/MetadataExtractor.cs
@@ -118,6 +118,7 @@ public partial class MetadataExtractor
             // For cimipkg-built MSI, extract rich metadata from embedded build-info.yaml.
             // cimipkg stores the YAML base64-encoded so the property value stays single-line
             // (multi-line values corrupt the MSI Property dump and PREVIOUSVERSIONSINSTALLED).
+            PkgBuildInfo? buildInfo = null;
             var buildInfoYaml = DecodeBuildInfoYaml(ReadProp("CIMIAN_PKG_BUILD_INFO"));
             if (!string.IsNullOrEmpty(buildInfoYaml))
             {
@@ -127,7 +128,7 @@ public partial class MetadataExtractor
                         .WithNamingConvention(UnderscoredNamingConvention.Instance)
                         .IgnoreUnmatchedProperties()
                         .Build();
-                    var buildInfo = deserializer.Deserialize<PkgBuildInfo>(buildInfoYaml);
+                    buildInfo = deserializer.Deserialize<PkgBuildInfo>(buildInfoYaml);
 
                     if (buildInfo?.Product != null)
                     {
@@ -157,6 +158,16 @@ public partial class MetadataExtractor
             var fullVersion = ReadProp("CIMIAN_PKG_FULL_VERSION");
             if (!string.IsNullOrEmpty(fullVersion))
                 metadata.Version = ParseVersion(fullVersion);
+
+            // Auto-populate the defense-in-depth file checks from the MSI's
+            // native bill of materials (File ⨯ Component ⨯ Directory tables).
+            // The pkginfo gets either:
+            //   - cimipkg MSI: a single resolved key_path on the type=msi
+            //     entry (explicit build-info override OR auto-detect heuristic).
+            //   - third-party MSI: up to 3 type=file entries for the largest
+            //     .exe files. Caps the array so a vendor MSI with 50 binaries
+            //     doesn't produce a 50-entry pkginfo.
+            PopulateMsiBom(db, metadata, buildInfo);
         }
         catch
         {
@@ -164,6 +175,83 @@ public partial class MetadataExtractor
             metadata.Title = ParsePackageName(Path.GetFileName(packagePath));
             metadata.ID = metadata.Title;
         }
+    }
+
+    /// <summary>
+    /// Populates <see cref="InstallerMetadata.KeyPath"/> and (for third-party MSIs)
+    /// up to three <c>type: file</c> entries in <see cref="InstallerMetadata.Installs"/>
+    /// from the MSI's native bill of materials.
+    /// </summary>
+    /// <remarks>
+    /// Decision tree:
+    ///   1. cimipkg MSI + explicit <c>key_path</c> in build-info → use it verbatim
+    ///      (resolved relative to <c>install_location</c> when not absolute).
+    ///   2. cimipkg MSI without override → run heuristic against enumerated .exe
+    ///      files: single .exe ⇒ it, name-match ⇒ it, largest ⇒ it.
+    ///   3. Third-party MSI (no build-info) → no <c>key_path</c> on the MSI entry;
+    ///      append up to 3 file entries by descending FileSize. Caps the array.
+    /// All branches fail-soft — a BOM read error leaves metadata unchanged.
+    /// </remarks>
+    private void PopulateMsiBom(Database db, InstallerMetadata metadata, PkgBuildInfo? buildInfo)
+    {
+        const int ThirdPartyFileCheckCap = 3;
+
+        try
+        {
+            var exes = MsiBomReader.EnumerateInstalledFiles(db, [".exe"]);
+
+            if (buildInfo != null && !string.IsNullOrWhiteSpace(buildInfo.KeyPath))
+            {
+                metadata.KeyPath = ResolveBuildInfoKeyPath(buildInfo.KeyPath, buildInfo.InstallLocation);
+                return;
+            }
+
+            if (buildInfo != null)
+            {
+                // cimipkg MSI, no override — pick single primary binary by heuristic.
+                var productName = buildInfo.Product?.Name ?? metadata.Title;
+                metadata.KeyPath = MsiBomReader.PickPrimaryBinary(exes, productName) ?? "";
+                return;
+            }
+
+            // Third-party MSI — emit top-N file checks instead of a single key_path.
+            // type=msi entry (registry/ProductCode check) is still emitted by
+            // ImportService.cs; these stack on top as defense-in-depth file checks.
+            foreach (var f in exes.Take(ThirdPartyFileCheckCap))
+            {
+                metadata.Installs.Add(new InstallItem
+                {
+                    Type = "file",
+                    Path = f.AbsolutePath,
+                    Version = f.Version,
+                });
+            }
+        }
+        catch
+        {
+            // BOM read failure is non-fatal; ProductCode/UpgradeCode-only verification stands.
+        }
+    }
+
+    /// <summary>
+    /// Resolves a <c>key_path</c> value from build-info.yaml. Absolute paths
+    /// pass through; relative paths are anchored to the package's
+    /// <c>install_location</c>. Returns empty when neither yields an absolute path.
+    /// </summary>
+    private static string ResolveBuildInfoKeyPath(string keyPath, string? installLocation)
+    {
+        var trimmed = keyPath.Trim();
+        if (string.IsNullOrEmpty(trimmed)) return "";
+
+        // Already an absolute Windows path (e.g. starts with "C:\" or "\\").
+        if (Path.IsPathRooted(trimmed))
+            return trimmed.Replace('/', '\\');
+
+        if (string.IsNullOrWhiteSpace(installLocation))
+            return "";
+
+        var combined = Path.Combine(installLocation.TrimEnd('\\', '/'), trimmed.Replace('/', '\\'));
+        return combined;
     }
 
     /// <summary>
@@ -614,6 +702,13 @@ internal class PkgBuildInfo
     public string? InstallLocation { get; set; }
     public string? PostinstallAction { get; set; }
     public PkgInstallerInfo? Installer { get; set; }
+
+    /// <summary>
+    /// Mirrors cimipkg's BuildInfo.KeyPath — explicit override for the
+    /// auto-detected primary binary. Value may be a path absolute to
+    /// install_location or an absolute Windows path.
+    /// </summary>
+    public string? KeyPath { get; set; }
 }
 
 /// <summary>

--- a/shared/import/Services/MsiBomReader.cs
+++ b/shared/import/Services/MsiBomReader.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using WixToolset.Dtf.WindowsInstaller;
 
 namespace Cimian.CLI.Cimiimport.Services;
@@ -27,26 +26,49 @@ public static class MsiBomReader
 {
     /// <summary>
     /// Standard Windows Installer system folder identifiers. Resolved to their
-    /// canonical absolute paths. Anything not in this map is treated as a
-    /// custom directory and resolved via Directory.DefaultDir.
+    /// canonical absolute paths from the running environment so a non-default
+    /// system drive (e.g. Windows installed on D:\) produces correct keypaths.
+    /// Anything not in this map is treated as a custom directory and resolved
+    /// via Directory.DefaultDir.
     /// See https://learn.microsoft.com/en-us/windows/win32/msi/property-reference#system-folder-properties
+    /// Caveat: cimiimport runs at packaging time, so the resolved roots reflect
+    /// the build host. In a homogeneous fleet (all machines on the same system
+    /// drive) this is correct. Mixed-drive fleets would need install-time path
+    /// resolution, which a static pkginfo can't express anyway.
     /// </summary>
-    private static readonly Dictionary<string, string> WellKnownFolders = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, string> WellKnownFolders = BuildWellKnownFolders();
+
+    private static Dictionary<string, string> BuildWellKnownFolders()
     {
-        ["TARGETDIR"]            = @"C:\",
-        ["ProgramFiles64Folder"] = @"C:\Program Files",
-        ["ProgramFilesFolder"]   = @"C:\Program Files (x86)",
-        ["CommonFiles64Folder"]  = @"C:\Program Files\Common Files",
-        ["CommonFilesFolder"]    = @"C:\Program Files (x86)\Common Files",
-        ["CommonAppDataFolder"]  = @"C:\ProgramData",
-        ["WindowsFolder"]        = @"C:\Windows",
-        ["SystemFolder"]         = @"C:\Windows\System32",
-        ["System64Folder"]       = @"C:\Windows\System32",
-        ["FontsFolder"]          = @"C:\Windows\Fonts",
-        ["TempFolder"]           = @"C:\Windows\Temp",
-        ["DesktopFolder"]        = @"C:\Users\Public\Desktop",
-        ["ProgramMenuFolder"]    = @"C:\ProgramData\Microsoft\Windows\Start Menu\Programs",
-    };
+        var sysDrive = Environment.GetEnvironmentVariable("SystemDrive") ?? "C:";
+        var programFiles    = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+        var commonFiles     = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles);
+        var commonFilesX86  = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFilesX86);
+        var commonAppData   = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        var windows         = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        var system          = Environment.GetFolderPath(Environment.SpecialFolder.System);
+        var fonts           = Environment.GetFolderPath(Environment.SpecialFolder.Fonts);
+        var commonDesktop   = Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory);
+        var commonPrograms  = Environment.GetFolderPath(Environment.SpecialFolder.CommonPrograms);
+
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["TARGETDIR"]            = sysDrive + @"\",
+            ["ProgramFiles64Folder"] = programFiles,
+            ["ProgramFilesFolder"]   = string.IsNullOrEmpty(programFilesX86) ? programFiles : programFilesX86,
+            ["CommonFiles64Folder"]  = commonFiles,
+            ["CommonFilesFolder"]    = string.IsNullOrEmpty(commonFilesX86) ? commonFiles : commonFilesX86,
+            ["CommonAppDataFolder"]  = commonAppData,
+            ["WindowsFolder"]        = windows,
+            ["SystemFolder"]         = system,
+            ["System64Folder"]       = system,
+            ["FontsFolder"]          = fonts,
+            ["TempFolder"]           = Path.Combine(windows, "Temp"),
+            ["DesktopFolder"]        = commonDesktop,
+            ["ProgramMenuFolder"]    = commonPrograms,
+        };
+    }
 
     /// <summary>
     /// Enumerates files installed by the MSI whose extension matches one of

--- a/shared/import/Services/MsiBomReader.cs
+++ b/shared/import/Services/MsiBomReader.cs
@@ -1,0 +1,245 @@
+using System.Collections;
+using WixToolset.Dtf.WindowsInstaller;
+
+namespace Cimian.CLI.Cimiimport.Services;
+
+/// <summary>
+/// One installed file row from the MSI's native bill of materials
+/// (the File ⨯ Component ⨯ Directory tables).
+/// </summary>
+public sealed record MsiInstalledFile(
+    string AbsolutePath,
+    long FileSize,
+    string? Version,
+    bool IsKeyPath);
+
+/// <summary>
+/// Queries an MSI's native bill of materials to enumerate the files it would
+/// install, with each file's absolute target path resolved by walking the
+/// Directory table to TARGETDIR.
+///
+/// Every cimipkg- and WiX-built MSI already populates these tables — there's
+/// no need for a sidecar manifest. Used by cimiimport to auto-populate the
+/// pkginfo "key_path" field and to seed top-N file checks for third-party
+/// MSIs whose payload is too large to enumerate exhaustively.
+/// </summary>
+public static class MsiBomReader
+{
+    /// <summary>
+    /// Standard Windows Installer system folder identifiers. Resolved to their
+    /// canonical absolute paths. Anything not in this map is treated as a
+    /// custom directory and resolved via Directory.DefaultDir.
+    /// See https://learn.microsoft.com/en-us/windows/win32/msi/property-reference#system-folder-properties
+    /// </summary>
+    private static readonly Dictionary<string, string> WellKnownFolders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["TARGETDIR"]            = @"C:\",
+        ["ProgramFiles64Folder"] = @"C:\Program Files",
+        ["ProgramFilesFolder"]   = @"C:\Program Files (x86)",
+        ["CommonFiles64Folder"]  = @"C:\Program Files\Common Files",
+        ["CommonFilesFolder"]    = @"C:\Program Files (x86)\Common Files",
+        ["CommonAppDataFolder"]  = @"C:\ProgramData",
+        ["WindowsFolder"]        = @"C:\Windows",
+        ["SystemFolder"]         = @"C:\Windows\System32",
+        ["System64Folder"]       = @"C:\Windows\System32",
+        ["FontsFolder"]          = @"C:\Windows\Fonts",
+        ["TempFolder"]           = @"C:\Windows\Temp",
+        ["DesktopFolder"]        = @"C:\Users\Public\Desktop",
+        ["ProgramMenuFolder"]    = @"C:\ProgramData\Microsoft\Windows\Start Menu\Programs",
+    };
+
+    /// <summary>
+    /// Enumerates files installed by the MSI whose extension matches one of
+    /// <paramref name="extensions"/> (default: <c>.exe</c>). Returns absolute
+    /// target paths sorted by FileSize descending — callers can take the top
+    /// N or apply name-match heuristics on top of the ordered list.
+    /// </summary>
+    public static List<MsiInstalledFile> EnumerateInstalledFiles(
+        Database db,
+        string[]? extensions = null)
+    {
+        var exts = extensions ?? [".exe"];
+        var result = new List<MsiInstalledFile>();
+
+        try
+        {
+            // Build the Directory → absolute path lookup once for the whole pass.
+            var dirPaths = BuildDirectoryPathMap(db);
+
+            // Join File + Component to get keypath designation per file.
+            // Component.KeyPath = File.File means this file is the keypath of
+            // its component (every cimipkg-built component has its single file
+            // as its own keypath, but third-party MSIs use this distinction).
+            using var view = db.OpenView(
+                "SELECT `File`.`File`, `File`.`FileName`, `File`.`FileSize`, `File`.`Version`, " +
+                "`Component`.`Directory_`, `Component`.`KeyPath` " +
+                "FROM `File`, `Component` WHERE `File`.`Component_` = `Component`.`Component`");
+            view.Execute();
+
+            for (var record = view.Fetch(); record != null; record = view.Fetch())
+            {
+                using (record)
+                {
+                    var fileKey = record.GetString(1);
+                    var fileName = record.GetString(2);
+                    var fileSize = record.GetInteger(3);
+                    var version = record.GetString(4);
+                    var directoryKey = record.GetString(5);
+                    var componentKeyPath = record.GetString(6);
+
+                    var targetName = ExtractLongTargetName(fileName);
+                    if (string.IsNullOrEmpty(targetName)) continue;
+
+                    if (!exts.Any(e => targetName.EndsWith(e, StringComparison.OrdinalIgnoreCase)))
+                        continue;
+
+                    if (!dirPaths.TryGetValue(directoryKey, out var dirPath))
+                        continue;
+
+                    // FileSize column type is INTEGER, returned as long; the
+                    // DTF .GetInteger() call above narrows to int, fine for
+                    // files up to 2 GB. For larger files the comparison still
+                    // works monotonically (largest wins) even if individual
+                    // sizes saturate.
+                    result.Add(new MsiInstalledFile(
+                        AbsolutePath: NormalizePath(Path.Combine(dirPath, targetName)),
+                        FileSize: fileSize,
+                        Version: string.IsNullOrEmpty(version) ? null : version,
+                        IsKeyPath: string.Equals(fileKey, componentKeyPath, StringComparison.Ordinal)));
+                }
+            }
+        }
+        catch
+        {
+            // MSI table query failed (older MSI format, missing tables, etc.).
+            // Return whatever we collected — caller treats empty as "no auto
+            // key_path", same as if the MSI had no .exe files.
+        }
+
+        return result
+            .OrderByDescending(f => f.FileSize)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Picks the best key_path candidate from an ordered (largest-first) file
+    /// list. Returns null when no candidate exists.
+    /// 1. Single .exe → it.
+    /// 2. .exe whose stem matches <paramref name="productName"/> (case-insensitive) → it.
+    /// 3. Largest .exe → it.
+    /// </summary>
+    public static string? PickPrimaryBinary(List<MsiInstalledFile> orderedFiles, string productName)
+    {
+        if (orderedFiles.Count == 0) return null;
+        if (orderedFiles.Count == 1) return orderedFiles[0].AbsolutePath;
+
+        if (!string.IsNullOrEmpty(productName))
+        {
+            var match = orderedFiles.FirstOrDefault(f =>
+                Path.GetFileNameWithoutExtension(f.AbsolutePath)
+                    .Equals(productName, StringComparison.OrdinalIgnoreCase));
+            if (match != null) return match.AbsolutePath;
+        }
+
+        return orderedFiles[0].AbsolutePath;
+    }
+
+    /// <summary>
+    /// Walks the MSI Directory table from every leaf upward to TARGETDIR,
+    /// returning a map of Directory key → resolved absolute path. Well-known
+    /// system folders are substituted with their canonical paths; everything
+    /// else uses DefaultDir's long-name component.
+    /// </summary>
+    private static Dictionary<string, string> BuildDirectoryPathMap(Database db)
+    {
+        var directories = new Dictionary<string, (string Parent, string DefaultDir)>(StringComparer.Ordinal);
+
+        using (var view = db.OpenView("SELECT `Directory`, `Directory_Parent`, `DefaultDir` FROM `Directory`"))
+        {
+            view.Execute();
+            for (var record = view.Fetch(); record != null; record = view.Fetch())
+            {
+                using (record)
+                {
+                    directories[record.GetString(1)] = (record.GetString(2) ?? "", record.GetString(3) ?? "");
+                }
+            }
+        }
+
+        var resolved = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var key in directories.Keys)
+        {
+            ResolvePath(key, directories, resolved);
+        }
+
+        return resolved;
+    }
+
+    private static string ResolvePath(
+        string directoryKey,
+        Dictionary<string, (string Parent, string DefaultDir)> directories,
+        Dictionary<string, string> resolved)
+    {
+        if (resolved.TryGetValue(directoryKey, out var cached))
+            return cached;
+
+        // Well-known system folder — use canonical absolute path.
+        if (WellKnownFolders.TryGetValue(directoryKey, out var known))
+        {
+            resolved[directoryKey] = known;
+            return known;
+        }
+
+        if (!directories.TryGetValue(directoryKey, out var entry))
+        {
+            resolved[directoryKey] = "";
+            return "";
+        }
+
+        var segment = ExtractLongTargetName(entry.DefaultDir);
+
+        // "." is the MSI shorthand for "use the parent directory directly,
+        // no extra segment" — used by cimipkg for INSTALLDIR under TempFolder
+        // and by countless WiX patterns.
+        var addSegment = !string.IsNullOrEmpty(segment) && segment != ".";
+
+        var parentPath = string.IsNullOrEmpty(entry.Parent)
+            ? ""
+            : ResolvePath(entry.Parent, directories, resolved);
+
+        var combined = addSegment
+            ? (string.IsNullOrEmpty(parentPath) ? segment : Path.Combine(parentPath, segment))
+            : parentPath;
+
+        resolved[directoryKey] = combined;
+        return combined;
+    }
+
+    /// <summary>
+    /// MSI File.FileName and Directory.DefaultDir use one of three formats:
+    ///   <c>name</c>                                  → both short and long are "name"
+    ///   <c>shortName|longName</c>                    → 8.3 short + long
+    ///   <c>sourceShortName|sourceLongName:targetShortName|targetLongName</c> (Directory only)
+    /// We want the long, target-side name for path resolution.
+    /// </summary>
+    private static string ExtractLongTargetName(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return "";
+
+        // Directory.DefaultDir can carry a "source:target" pair — keep target.
+        var colonIdx = raw.IndexOf(':');
+        var target = colonIdx >= 0 ? raw.Substring(colonIdx + 1) : raw;
+
+        // "short|long" → keep long.
+        var pipeIdx = target.IndexOf('|');
+        return pipeIdx >= 0 ? target.Substring(pipeIdx + 1) : target;
+    }
+
+    private static string NormalizePath(string path)
+    {
+        // Collapse any forward slashes from FileName (MSI tables sometimes
+        // carry mixed separators) and remove trailing whitespace.
+        return path.Replace('/', '\\').TrimEnd();
+    }
+}

--- a/tests/CLI/Cimiimport/MetadataExtractorTests.cs
+++ b/tests/CLI/Cimiimport/MetadataExtractorTests.cs
@@ -447,4 +447,46 @@ public class MetadataExtractorTests
             }
         }
     }
+
+    [Fact]
+    public void InstallItem_SerializesKeyPathAsYaml_KeyPathField()
+    {
+        // Regression guard: the YAML attribute is `key_path`, matching the
+        // runtime InstallCheckItem.KeyPath alias on the StatusService side.
+        // A rename on either side without the matching change here would
+        // break the pkginfo wire format silently.
+        var item = new InstallItem
+        {
+            Type = "msi",
+            ProductCode = "{12345678-1234-1234-1234-123456789012}",
+            UpgradeCode = "{abcdef01-2345-6789-abcd-ef0123456789}",
+            KeyPath = @"C:\Program Files\Foo\foo.exe",
+        };
+
+        var serializer = new YamlDotNet.Serialization.SerializerBuilder().Build();
+        var yaml = serializer.Serialize(item);
+
+        Assert.Contains("key_path:", yaml);
+        Assert.Contains(@"C:\Program Files\Foo\foo.exe", yaml);
+    }
+
+    [Fact]
+    public void InstallItem_KeyPathRoundtripsThroughYaml()
+    {
+        var yaml = """
+            type: msi
+            product_code: '{12345678-1234-1234-1234-123456789012}'
+            upgrade_code: '{abcdef01-2345-6789-abcd-ef0123456789}'
+            key_path: 'C:\Program Files\ReportMate\managedreportsrunner.exe'
+            """;
+
+        var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        var item = deserializer.Deserialize<InstallItem>(yaml);
+
+        Assert.Equal("msi", item.Type);
+        Assert.Equal(@"C:\Program Files\ReportMate\managedreportsrunner.exe", item.KeyPath);
+    }
 }

--- a/tests/CLI/Cimiimport/MsiBomReaderTests.cs
+++ b/tests/CLI/Cimiimport/MsiBomReaderTests.cs
@@ -1,0 +1,97 @@
+using Xunit;
+using Cimian.CLI.Cimiimport.Services;
+
+namespace Cimian.Tests.CLI.Cimiimport;
+
+/// <summary>
+/// Unit tests for the heuristic that picks a single primary binary out of the
+/// MSI BOM enumeration. The Database-backed enumeration itself is exercised
+/// end-to-end via integration with real MSIs; here we lock in the pick logic.
+/// </summary>
+public class MsiBomReaderTests
+{
+    [Fact]
+    public void PickPrimaryBinary_EmptyList_ReturnsNull()
+    {
+        var result = MsiBomReader.PickPrimaryBinary(new List<MsiInstalledFile>(), "AnyProduct");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void PickPrimaryBinary_SingleExe_ReturnsThatExe()
+    {
+        var files = new List<MsiInstalledFile>
+        {
+            new(@"C:\Program Files\AnyProduct\only.exe", 100, "1.0.0.0", IsKeyPath: true),
+        };
+
+        var result = MsiBomReader.PickPrimaryBinary(files, "AnyProduct");
+
+        Assert.Equal(@"C:\Program Files\AnyProduct\only.exe", result);
+    }
+
+    [Fact]
+    public void PickPrimaryBinary_NameMatchWinsOverLargest()
+    {
+        // The list is ordered largest-first, so "huge.exe" would be the
+        // fallback. "MyProduct" matches MyProduct.exe — that should win even
+        // though it isn't the biggest.
+        var files = new List<MsiInstalledFile>
+        {
+            new(@"C:\Program Files\MyProduct\huge.exe",      100_000_000, "1.0", IsKeyPath: true),
+            new(@"C:\Program Files\MyProduct\MyProduct.exe",  10_000_000, "1.0", IsKeyPath: true),
+            new(@"C:\Program Files\MyProduct\helper.exe",      1_000_000, "1.0", IsKeyPath: true),
+        };
+
+        var result = MsiBomReader.PickPrimaryBinary(files, "MyProduct");
+
+        Assert.Equal(@"C:\Program Files\MyProduct\MyProduct.exe", result);
+    }
+
+    [Fact]
+    public void PickPrimaryBinary_NameMatchIsCaseInsensitive()
+    {
+        var files = new List<MsiInstalledFile>
+        {
+            new(@"C:\Program Files\ReportMate\manageDREPORTSrunner.exe", 25_000_000, "1.0", IsKeyPath: true),
+            new(@"C:\Program Files\ReportMate\speedtest.exe",             2_000_000, "1.0", IsKeyPath: true),
+        };
+
+        // Note: product name "ManagedReportsRunner" matches the .exe stem
+        // case-insensitively even though casing differs in both.
+        var result = MsiBomReader.PickPrimaryBinary(files, "managedreportsrunner");
+
+        Assert.Equal(@"C:\Program Files\ReportMate\manageDREPORTSrunner.exe", result);
+    }
+
+    [Fact]
+    public void PickPrimaryBinary_NoNameMatch_ReturnsLargest()
+    {
+        // ReportMate's real scenario: product name "ReportMate" doesn't match
+        // any .exe filename, but managedreportsrunner.exe is the largest. The
+        // largest-wins fallback gives the correct keypath.
+        var files = new List<MsiInstalledFile>
+        {
+            new(@"C:\Program Files\ReportMate\managedreportsrunner.exe", 25_000_000, "2026.05.14.1242", IsKeyPath: true),
+            new(@"C:\Program Files\ReportMate\speedtest.exe",             2_000_000, "3.8.0",           IsKeyPath: true),
+        };
+
+        var result = MsiBomReader.PickPrimaryBinary(files, "ReportMate");
+
+        Assert.Equal(@"C:\Program Files\ReportMate\managedreportsrunner.exe", result);
+    }
+
+    [Fact]
+    public void PickPrimaryBinary_EmptyProductName_FallsThroughToLargest()
+    {
+        var files = new List<MsiInstalledFile>
+        {
+            new(@"C:\Program Files\Vendor\big.exe",   100, "1.0", IsKeyPath: true),
+            new(@"C:\Program Files\Vendor\small.exe",  10, "1.0", IsKeyPath: true),
+        };
+
+        var result = MsiBomReader.PickPrimaryBinary(files, "");
+
+        Assert.Equal(@"C:\Program Files\Vendor\big.exe", result);
+    }
+}

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -741,5 +741,28 @@ public class UpdateModelsTests
         Assert.Equal("file", item.EffectiveType());
     }
 
+    [Fact]
+    public void InstallCheckItem_DeserializesKeyPathFromYaml()
+    {
+        // key_path is the defense-in-depth field that pins MSI verification to a
+        // specific on-disk file version. The YAML attribute is `key_path` (snake
+        // case); regression guard so the field can't silently get renamed.
+        var yaml = """
+            type: msi
+            product_code: '{12345678-1234-1234-1234-123456789012}'
+            upgrade_code: '{abcdef01-2345-6789-abcd-ef0123456789}'
+            key_path: 'C:\Program Files\ReportMate\managedreportsrunner.exe'
+            """;
+
+        var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        var item = deserializer.Deserialize<InstallCheckItem>(yaml);
+
+        Assert.Equal("msi", item.EffectiveType());
+        Assert.Equal(@"C:\Program Files\ReportMate\managedreportsrunner.exe", item.KeyPath);
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary
- **Runtime defense-in-depth**: `managedsoftwareupdate`'s `CheckInstallsArray` now also verifies the on-disk `FileVersion` of an MSI's primary binary when the new `key_path:` field is set on an `installs[]` MSI entry. Catches silent file overwrites that don't update the Windows Installer ARP entry.
- **cimiimport BOM auto-detect**: Queries the MSI's native `File ⨯ Component ⨯ Directory` tables to populate `key_path` automatically — no new MSI properties needed. Works on every MSI (cimipkg-built or third-party).
- **Third-party MSI bounded**: Vendor MSIs without `CIMIAN_PKG_BUILD_INFO` get up to 3 companion `type: file` entries for their largest `.exe` binaries — caps the pkginfo's `installs[]` array so a 50-binary vendor package can't produce a 50-entry pkginfo.

## Why this exists
A curriculum endpoint was running `ReportMate 2026.05.05.2219` on disk while ARP DisplayVersion showed `2026.05.14.1242`. The new MSI had installed correctly, but a stale-cache BootstrapMate playback later overwrote the binaries with the old version's payload — and the parent MSI's ARP registration stayed at the new value. Cimian's existing registry-only verification ran hourly and said "installed, current" every cycle. The device never self-healed.

With `key_path` on the pkginfo:
```yaml
installs:
- type: msi
  product_code: '{ef330bf3-6d12-4b0e-b01e-2b57f8d81ad3}'
  upgrade_code: '{229fa234-439b-545b-9617-0c6a577bdb8a}'
  key_path: 'C:\Program Files\ReportMate\managedreportsrunner.exe'
```

The runtime now logs `ARP reported 2026.05.14.1242 but key_path file is older - reinstall needed item: ReportMate keyPath: ... diskVersion: 2026.05.05.2219 catalogVersion: 2026.05.14.1242` and queues a reinstall on the next cycle.

## What changed

### Runtime (managedsoftwareupdate)
- `cli/managedsoftwareupdate/Models/UpdateModels.cs` — new optional `KeyPath` (`[YamlMember(Alias = ""key_path"")]`) on `InstallCheckItem`.
- `cli/managedsoftwareupdate/Services/StatusService.cs` — `CheckInstallsArray` MSI case (lines ~577-619 in new code): after the existing ARP/UpgradeCode check passes, if `installItem.KeyPath` is set, verifies the file exists and its `FileVersion` is `>= catalogVersion`. A mismatch flips status to `pending`/`IsUpdate=true` with reason `VersionOutdated` and reports the on-disk version in `result.InstalledVersion`.

### cimiimport (auto-populate on import)
- `shared/import/Models/ImportModels.cs` — `KeyPath` on `InstallItem` (emitted in pkginfo) and on `InstallerMetadata` (in-flight state).
- `shared/import/Services/MsiBomReader.cs` (new, ~245 lines) — queries `File ⨯ Component` joined; walks `Directory_Parent` to TARGETDIR with a well-known-folders map (`ProgramFiles64Folder`, `CommonAppDataFolder`, etc.) to resolve absolute target paths; parses MSI `DefaultDir` semantics (short|long, source:target). Exposes `EnumerateInstalledFiles` (sorted FileSize-descending) and the `PickPrimaryBinary` heuristic.
- `shared/import/Services/MetadataExtractor.cs` — adds `PkgBuildInfo.KeyPath` field (mirrors cimipkg's `BuildInfo.KeyPath` from windowsadmins/cimian-pkg#21). New `PopulateMsiBom` method orchestrates three branches:
  1. cimipkg MSI + explicit override in build-info → resolved & used.
  2. cimipkg MSI without override → heuristic pick.
  3. Third-party MSI → top-3 by-size `type: file` entries appended to `metadata.Installs`.
  Plus `ResolveBuildInfoKeyPath` (handles absolute vs. relative paths against `install_location`).
- `shared/import/Services/ImportService.cs` — MSI branch (line ~213) now sets `InstallItem.KeyPath = metadata.KeyPath`.

### Tests (full suite stays green, 684/684)
- `tests/CLI/Cimiimport/MsiBomReaderTests.cs` (new) — 6 unit tests covering the heuristic decision tree (empty/single/name-match-over-largest/case-insensitive name match/no-name-match-largest-wins/empty-product-name).
- `tests/CLI/Cimiimport/MetadataExtractorTests.cs` — 2 new tests: `InstallItem.KeyPath` YAML serialization and deserialization roundtrip.
- `tests/Managedsoftwareupdate/UpdateModelsTests.cs` — `InstallCheckItem_DeserializesKeyPathFromYaml` regression guard for the runtime-side YAML attribute name.

## Overlap with PR #30
Checked. PR #30 touches `cli/makepkginfo/Services/PkgInfoBuilder.cs` and `tests/Makepkginfo/PkgInfoBuilderTests.cs` — different cmd, different test dir, no file overlap. Thematically complementary: PR #30 populates `installs[].version` for MSIs; this PR adds `installs[].key_path`. Both make pkginfos more enforceable.

## Pairs with
windowsadmins/cimian-pkg#21 — adds the `key_path:` override field on the cimipkg side. The two PRs are independent — the runtime enforcement and BOM auto-detect in this PR work against any MSI. The cimipkg PR is just the explicit-override escape hatch for packages where the heuristic guesses wrong.

## Test plan
- [x] `dotnet test tests/Cimian.Tests.csproj` — 684/684 pass on this branch off origin/main.
- [x] Manually verified on Cintiq 27 (10.15.2.220): osquery's `bitlocker_info` returns `protection_status=0, conversion_status=0, encryption_method=None` while ReportMate's dashboard reported BitLocker ON because the May 5 binary's old code path didn't gate on protection/conversion status. The root-cause fix landed earlier (commit c400b45 in ReportMate); this PR is the defense in depth so the bad state can't sit forever again.
- [ ] After merge: build & sign new `managedsoftwareupdate.exe` + `cimiimport.exe`. Roll out via normal Cimian release flow. Existing pkginfos without `key_path:` retain today's behaviour — change is purely additive.
- [ ] After merge: re-import key Cimian-built MSIs (`cimiimport ReportMate-*.msi`, `cimiimport Cimian-*.msi`, etc.) to pick up the auto-detected `key_path` in their pkginfos. Manually-edited `key_path` in `deployment/pkgsinfo/mgmt/ReportMate-2026.05.14.1242.yaml` (in the parent Cimian repo) already in place.