### PR TITLE
Expand cimian:// deep links

### DIFF
--- a/gui/ManagedSoftwareCenter/App.xaml.cs
+++ b/gui/ManagedSoftwareCenter/App.xaml.cs
@@ -117,30 +117,53 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Handles cimian:// protocol URIs.
-    /// Supported: cimian://showitem?name=AppName, cimian://updates, cimian://history, cimian://categories
+    /// Handles cimian:// protocol URIs. Accepts both host-based and path-based shapes:
+    ///   cimian://item/Firefox            (path form, preferred)
+    ///   cimian://showitem?name=Firefox   (legacy query form)
+    ///   cimian://category/Browsers
+    ///   cimian://updatedetail/Firefox
+    ///   cimian://updates | history | categories | myitems | software
     /// </summary>
     public static void HandleProtocolActivation(Uri uri)
     {
         if (s_mainWindow is not MainWindow mainWindow) return;
 
-        var host = uri.Host.ToLowerInvariant();
-        switch (host)
+        var verb = uri.Host.ToLowerInvariant();
+        var pathSegments = (uri.AbsolutePath ?? string.Empty)
+            .Trim('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        var argument = pathSegments.Length > 0
+            ? Uri.UnescapeDataString(pathSegments[0])
+            : query["name"];
+
+        switch (verb)
         {
+            case "item":
             case "showitem":
-                var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
-                var itemName = query["name"];
-                if (!string.IsNullOrEmpty(itemName))
-                    mainWindow.NavigateToItemDetail(itemName);
+                if (!string.IsNullOrEmpty(argument))
+                    mainWindow.NavigateToItemDetail(argument);
+                else
+                    mainWindow.NavigateToPage("software");
+                break;
+            case "updatedetail":
+                if (!string.IsNullOrEmpty(argument))
+                    mainWindow.NavigateToUpdateDetail(argument);
+                else
+                    mainWindow.NavigateToPage("updates");
+                break;
+            case "category":
+                if (!string.IsNullOrEmpty(argument))
+                    mainWindow.NavigateToCategory(argument);
+                else
+                    mainWindow.NavigateToPage("categories");
                 break;
             case "updates":
-                mainWindow.NavigateToPage("updates");
-                break;
             case "history":
-                mainWindow.NavigateToPage("history");
-                break;
             case "categories":
-                mainWindow.NavigateToPage("categories");
+            case "myitems":
+            case "software":
+                mainWindow.NavigateToPage(verb);
                 break;
             default:
                 mainWindow.NavigateToPage("software");

--- a/gui/ManagedSoftwareCenter/MainWindow.xaml.cs
+++ b/gui/ManagedSoftwareCenter/MainWindow.xaml.cs
@@ -225,6 +225,31 @@ public partial class MainWindow : Window
             new SlideNavigationTransitionInfo { Effect = SlideNavigationTransitionEffect.FromRight });
     }
 
+    // Navigates to the updates page first so a Back gesture returns there, then drills into the
+    // item detail. Mirrors Munki's `updatedetail-` deep link semantics.
+    public void NavigateToUpdateDetail(string itemName)
+    {
+        NavigateToPage("updates");
+        NavigateToItemDetail(itemName);
+    }
+
+    // Navigates to the software browser with a category pre-selected.
+    public void NavigateToCategory(string category)
+    {
+        ViewModel.NavigationParameter = category;
+        ContentFrame.Navigate(typeof(SoftwarePage), category,
+            new EntranceNavigationTransitionInfo());
+
+        foreach (var item in NavView.MenuItems)
+        {
+            if (item is NavigationViewItem navItem && navItem.Tag?.ToString() == "software")
+            {
+                NavView.SelectedItem = navItem;
+                break;
+            }
+        }
+    }
+
     /// <summary>
     /// Navigate back to previous page
     /// </summary>

--- a/gui/ManagedSoftwareCenter/MainWindow.xaml.cs
+++ b/gui/ManagedSoftwareCenter/MainWindow.xaml.cs
@@ -12,6 +12,10 @@ using Cimian.GUI.ManagedSoftwareCenter.Views;
 
 namespace Cimian.GUI.ManagedSoftwareCenter;
 
+// Typed marker so SoftwarePage can distinguish a category deep-link from the
+// generic ShellViewModel.NavigationParameter (which carries item names).
+public sealed record CategoryNavigationRequest(string CategoryName);
+
 /// <summary>
 /// Main application window with NavigationView shell
 /// </summary>
@@ -233,11 +237,13 @@ public partial class MainWindow : Window
         NavigateToItemDetail(itemName);
     }
 
-    // Navigates to the software browser with a category pre-selected.
+    // Navigates to the software browser with a category pre-selected. The request is passed
+    // as a typed CategoryNavigationRequest directly via ContentFrame.Navigate so it does not
+    // leak into ShellViewModel.NavigationParameter (which is reused by other pages).
     public void NavigateToCategory(string category)
     {
-        ViewModel.NavigationParameter = category;
-        ContentFrame.Navigate(typeof(SoftwarePage), category,
+        ContentFrame.Navigate(typeof(SoftwarePage),
+            new CategoryNavigationRequest(category),
             new EntranceNavigationTransitionInfo());
 
         foreach (var item in NavView.MenuItems)

--- a/gui/ManagedSoftwareCenter/Views/CategoriesPage.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Views/CategoriesPage.xaml.cs
@@ -53,10 +53,9 @@ public partial class CategoriesPage : Page
     {
         if (CategoriesList.SelectedItem is CategoryGroup category)
         {
-            // Navigate to Software page with category filter via MainWindow
             if (App.MainWindow is MainWindow mainWindow)
             {
-                mainWindow.NavigateToPage("software");
+                mainWindow.NavigateToCategory(category.Name);
             }
             CategoriesList.SelectedItem = null; // Reset selection
         }

--- a/gui/ManagedSoftwareCenter/Views/SoftwarePage.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Views/SoftwarePage.xaml.cs
@@ -77,11 +77,29 @@ public partial class SoftwarePage : Page
                 // Load data - bindings will auto-update
                 await ViewModel.LoadAsync();
 
-                // Apply category passed via navigation (e.g. cimian://category/Browsers)
-                if (!string.IsNullOrEmpty(_selectedCategory) && _selectedCategory != "All")
+                // Apply category passed via navigation (e.g. cimian://category/Browsers).
+                // Canonicalize against the loaded category list so pill highlighting and
+                // filtering work regardless of the casing used in the deep link.
+                if (!string.IsNullOrEmpty(_selectedCategory) &&
+                    !string.Equals(_selectedCategory, "All", StringComparison.OrdinalIgnoreCase))
                 {
-                    ViewModel.SelectedCategory = _selectedCategory;
-                    SectionHeader.Text = _selectedCategory;
+                    var canonical = ViewModel.Categories?.FirstOrDefault(c =>
+                        string.Equals(c, _selectedCategory, StringComparison.OrdinalIgnoreCase));
+                    if (canonical != null)
+                    {
+                        _selectedCategory = canonical;
+                        ViewModel.SelectedCategory = canonical;
+                        SectionHeader.Text = canonical;
+                    }
+                    else
+                    {
+                        // Unknown category name -- fall back to showing everything.
+                        _selectedCategory = "All";
+                    }
+                }
+                else
+                {
+                    _selectedCategory = "All";
                 }
 
                 // Build category pills after data loaded
@@ -106,9 +124,13 @@ public partial class SoftwarePage : Page
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
         base.OnNavigatedTo(e);
-        if (e.Parameter is string category && !string.IsNullOrWhiteSpace(category))
+        // Only honor a typed CategoryNavigationRequest. ShellViewModel.NavigationParameter
+        // also flows through here as a raw string (it can carry an item name set by
+        // NavigateToItemDetail), so plain strings must not be treated as categories.
+        if (e.Parameter is CategoryNavigationRequest request &&
+            !string.IsNullOrWhiteSpace(request.CategoryName))
         {
-            _selectedCategory = category;
+            _selectedCategory = request.CategoryName;
         }
     }
 

--- a/gui/ManagedSoftwareCenter/Views/SoftwarePage.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Views/SoftwarePage.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Navigation;
 using Microsoft.UI.Xaml.Shapes;
 using Cimian.GUI.ManagedSoftwareCenter.Models;
 using Cimian.GUI.ManagedSoftwareCenter.ViewModels;
@@ -75,7 +76,14 @@ public partial class SoftwarePage : Page
                 
                 // Load data - bindings will auto-update
                 await ViewModel.LoadAsync();
-                
+
+                // Apply category passed via navigation (e.g. cimian://category/Browsers)
+                if (!string.IsNullOrEmpty(_selectedCategory) && _selectedCategory != "All")
+                {
+                    ViewModel.SelectedCategory = _selectedCategory;
+                    SectionHeader.Text = _selectedCategory;
+                }
+
                 // Build category pills after data loaded
                 BuildCategoryPills();
                 
@@ -93,6 +101,15 @@ public partial class SoftwarePage : Page
         {
             _carouselTimer.Stop();
         };
+    }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+        if (e.Parameter is string category && !string.IsNullOrWhiteSpace(category))
+        {
+            _selectedCategory = category;
+        }
     }
 
     #region Branding Images & Carousel


### PR DESCRIPTION
## Summary
- Adds path-based URL form (`cimian://item/Firefox`) alongside the legacy `?name=` query form
- New verbs: `category/<Name>`, `updatedetail/<Name>`, `myitems`, `software`
- `updatedetail` chains via the Updates page so Back returns to the update list
- Fixes the in-app Categories tile, which previously navigated to Software with no filter applied

## URL surface
| URL | Action |
|---|---|
| `cimian://item/Firefox` | Item detail (preferred) |
| `cimian://showitem?name=Firefox` | Item detail (legacy alias) |
| `cimian://updatedetail/Firefox` | Item detail; Back -> Updates |
| `cimian://category/Browsers` | Software filtered to category |
| `cimian://myitems` | My Items page |
| `cimian://updates` / `history` / `categories` / `software` | Direct nav |

## Test plan
- [ ] Build MSC signed and install the MSIX
- [ ] `start cimian://item/Firefox` opens the item detail page
- [ ] `start cimian://category/Browsers` opens Software with the Browsers pill selected and filtered
- [ ] `start cimian://updatedetail/<pending-update>` opens detail; Back returns to Updates
- [ ] `start cimian://myitems` opens the My Items page
- [ ] Clicking a category tile from inside the app now filters Software (previously dead-end)