### PR TITLE
managedsoftwareupdate: stop fuzzy registry match swallowing MSI patches

### DIFF
--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -525,9 +525,15 @@ public class StatusService
                     var (msiInstalled, msiVersionMatch, msiInstalledVersion) = CheckMsiWithUpgradeCode(
                         installItem.ProductCode, installItem.UpgradeCode, catalogVersion, item.Name);
 
-                    // If MSI detection failed, try registry lookup using item's display_name or name as fallback
-                    // This handles cases where app was installed via EXE instead of MSI (e.g., Chrome auto-update)
-                    if (!msiInstalled)
+                    // If MSI detection failed, try registry lookup using item's display_name or name as fallback.
+                    // This handles cases where app was installed via EXE instead of MSI (e.g., Chrome auto-update).
+                    // Only run when pkginfo did NOT declare a ProductCode/UpgradeCode -- when codes are
+                    // declared they are authoritative, and their absence means the item is genuinely
+                    // not installed. Fuzzy name matching against unrelated apps (e.g. "OculusPatch"
+                    // collapsing onto "Oculus") would otherwise mark patches as already current.
+                    if (!msiInstalled
+                        && string.IsNullOrEmpty(installItem.ProductCode)
+                        && string.IsNullOrEmpty(installItem.UpgradeCode))
                     {
                         var displayNameToSearch = !string.IsNullOrEmpty(item.DisplayName) ? item.DisplayName : item.Name;
                         var fallbackVersion = FindVersionByDisplayName(displayNameToSearch);
@@ -1068,9 +1074,11 @@ if ($results.Count -gt 0) {{
                     if (string.IsNullOrEmpty(regDisplayName) || string.IsNullOrEmpty(regVersion))
                         continue;
 
-                    // Partial match - either contains the other
-                    if (regDisplayName.Contains(displayName, StringComparison.OrdinalIgnoreCase) ||
-                        displayName.Contains(regDisplayName, StringComparison.OrdinalIgnoreCase))
+                    // Partial match: only accept registry entries whose name CONTAINS our search
+                    // string (e.g. "Google Chrome" -> "Google Chrome 142.x"). The reverse direction
+                    // (our string contains the registry name) is unsafe -- "OculusPatch" would match
+                    // the unrelated "Oculus" app and adopt its version.
+                    if (regDisplayName.Contains(displayName, StringComparison.OrdinalIgnoreCase))
                     {
                         ConsoleLogger.Debug($"Found partial display name match in registry displayName: {displayName} registryName: {regDisplayName} version: {regVersion}");
                         return regVersion;


### PR DESCRIPTION
## Summary
Fixes a false-positive in `StatusService.CheckStatus` where a managed item with a declared MSI `product_code`/`upgrade_code` could be marked already installed by adopting the version of an unrelated app whose registry display name was a substring of the catalog item's display name.

Repro on IXD-Lab-01: `OculusPatch` v1.0.1 (catalog) was reported installed at `1.103.0` because the display-name fallback partial-matched the unrelated `Oculus` desktop app. `1.103.0 > 1.0.1`, so the patch never ran.

## Changes (`cli/managedsoftwareupdate/Services/StatusService.cs`)
1. Display-name fallback (`~line 530`) now only runs when the install entry declares **no** `ProductCode` **and** no `UpgradeCode`. When pkginfo provides those codes they are authoritative — their absence in the registry means "not installed", not "go look for something with a similar name".
2. `FindVersionByDisplayName` partial match (`~line 1093`) now only accepts the direction where the **registry name contains the search string** (e.g. `Google Chrome` → `Google Chrome 142.x`). The reverse direction — search string contains registry name — is what caused `OculusPatch` to collapse onto `Oculus`, and is removed.

The fallback's original use case (EXE installers like Chrome auto-update with no MSI codes in pkginfo) is preserved.

## Test plan
- [x] `dotnet build -c Release` clean on managedsoftwareupdate
- [ ] Sign + deploy to IXD-Lab-01, run `managedsoftwareupdate -vvv --checkonly`, confirm `OculusPatch` is reported pending (not "current") with the real `Oculus` app still installed at 1.103.0
- [ ] Confirm a normal EXE-installer-only item (e.g. Chrome with no `product_code` in pkginfo) still resolves via display-name fallback