### PR TITLE
ci/build: drop NuGet cache; skip compression when not self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,10 @@ jobs:
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: preview
-          # Built-in NuGet cache — shipped with setup-dotnet, no separate
-          # actions/cache step. Avoids the Node 24 / DEP0169 url.parse() crash
-          # that took down actions/cache@v4 once FORCE_JAVASCRIPT_ACTIONS_TO_NODE24
-          # was enabled.
-          cache: true
-          cache-dependency-path: |
-            **/*.csproj
-            Directory.Build.props
 
+      # No NuGet caching: actions/cache@v4 throws on Node 24 runners (DEP0169
+      # url.parse) and setup-dotnet's built-in cache crashes on its tar/zstd
+      # post-step write on Windows. Cold restore adds ~60s and is reliable.
       - name: Restore
         shell: pwsh
         run: dotnet restore CimianTools.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,8 @@ jobs:
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: preview
-          # Built-in NuGet cache — shipped with setup-dotnet, no separate
-          # actions/cache step. Avoids the Node 24 / DEP0169 url.parse() crash
-          # that took down actions/cache@v4 once FORCE_JAVASCRIPT_ACTIONS_TO_NODE24
-          # was enabled.
-          cache: true
-          cache-dependency-path: |
-            **/*.csproj
-            Directory.Build.props
 
+      # No NuGet caching — see ci.yml for rationale.
       - name: Build (unsigned)
         shell: pwsh
         run: .\build.ps1 -NoSign

--- a/build.ps1
+++ b/build.ps1
@@ -631,10 +631,15 @@ function Publish-Binary {
         '--verbosity', 'minimal'
     )
     
-    # WinUI 3 does not support PublishSingleFile without MSIX packaging
+    # WinUI 3 does not support PublishSingleFile without MSIX packaging.
+    # EnableCompressionInSingleFile is only valid with --self-contained true
+    # (NETSDK1176 since .NET SDK 10.0.300); framework-dependent CLIs ship
+    # without compression, which is fine -- their bundle stays small.
     if (-not $IsWinUI) {
         $publishArgs += '-p:PublishSingleFile=true'
-        $publishArgs += '-p:EnableCompressionInSingleFile=true'
+        if ($IsSelfContained) {
+            $publishArgs += '-p:EnableCompressionInSingleFile=true'
+        }
     }
     
     if ($BuildVersion) {


### PR DESCRIPTION
Two CI-blocking issues:

1. **NuGet cache** — actions/cache@v4 throws on Node 24 Windows runners, and setup-dotnet 'cache: true' crashes in its tar/zstd post-step. Drop both; ~60s extra cold restore is acceptable.
2. **build.ps1 NETSDK1176** — .NET SDK 10.0.300 enforces that 'EnableCompressionInSingleFile' requires '--self-contained true'. Framework-dependent CLIs (Type=CLI) were failing publish. Only add the compression flag when SelfContained=true.

Result: ci.yml and release.yml both green; v0.0.4 release can be re-tagged or this branch tagged once merged.