### PR TITLE
build: override EnableCompressionInSingleFile=false for framework-dependent CLIs

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -633,12 +633,14 @@ function Publish-Binary {
     
     # WinUI 3 does not support PublishSingleFile without MSIX packaging.
     # EnableCompressionInSingleFile is only valid with --self-contained true
-    # (NETSDK1176 since .NET SDK 10.0.300); framework-dependent CLIs ship
-    # without compression, which is fine -- their bundle stays small.
+    # (NETSDK1176 since .NET SDK 10.0.300); Directory.Build.props sets it
+    # globally, so framework-dependent CLIs must override to false here.
     if (-not $IsWinUI) {
         $publishArgs += '-p:PublishSingleFile=true'
         if ($IsSelfContained) {
             $publishArgs += '-p:EnableCompressionInSingleFile=true'
+        } else {
+            $publishArgs += '-p:EnableCompressionInSingleFile=false'
         }
     }
     


### PR DESCRIPTION
PR #36 dropped the explicit -p:EnableCompressionInSingleFile=true CLI arg when not self-contained, but Directory.Build.props sets the same property globally, so framework-dependent CLI publishes still hit NETSDK1176. Override the property to false explicitly for the non-self-contained case.