### PR TITLE
build: make all CLIs self-contained (revert framework-dependent CLI behavior)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -735,7 +735,11 @@ function Build-AllBinaries {
             }
             
             $csproj = $csprojFiles[0].FullName
-            $isSelfContained = ($toolInfo.Type -eq 'GUI')
+            # All tools publish self-contained. CLIs are invoked at build time
+            # by build.ps1 itself (e.g. cimipkg.exe to build MSIs); framework-
+            # dependent publishes break when the runner SDK is preview but the
+            # published runtimeconfig wants a matching stable framework.
+            $isSelfContained = $true
             
             Publish-Binary -ToolName $tool -ProjectPath $csproj -RuntimeIdentifier $runtime -OutputPath $outputPath -IsSelfContained $isSelfContained -BuildVersion $BuildVersion
         }


### PR DESCRIPTION
PR #38 dropped trim/compress for framework-dependent CLIs to dodge NETSDK1102/1176, but cimipkg.exe is then invoked by build.ps1 itself at MSI-creation time — and Microsoft.NETCore.App 10.0.0 isn't on the runner (setup-dotnet 10.0.x preview ships 10.0.0-preview.X), so cimipkg fails to launch with HRESULT 0x80131516.

Fix: make all CLIs self-contained=true (same as GUI). Restores v0.0.3 behavior, removes the need for the trim/compression override block from PR #37+#38.