### PR TITLE
release: emit SHA256SUMS.txt + opt-in signtool verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,9 +79,44 @@ jobs:
               Write-Host "  $zipPath ($sizeMB MB)"
           }
 
+      - name: Emit SHA256SUMS.txt
+        shell: pwsh
+        run: |
+          $artifacts = Get-ChildItem -Path release -Recurse -Include '*.msi','*.nupkg','*.pkg','*.intunewin','*.zip' | Sort-Object FullName
+          if ($artifacts.Count -eq 0) { throw 'No artifacts to hash' }
+          $lines = foreach ($a in $artifacts) {
+              $h = (Get-FileHash -Algorithm SHA256 -Path $a.FullName).Hash.ToLower()
+              "$h  $($a.Name)"
+          }
+          $sumsPath = 'release/SHA256SUMS.txt'
+          $lines | Out-File -FilePath $sumsPath -Encoding ascii
+          Write-Host "Wrote $sumsPath:"
+          Get-Content $sumsPath | Write-Host
+
+      - name: Verify signatures (opt-in)
+        if: env.SIGN_VERIFY == '1'
+        shell: pwsh
+        env:
+          SIGN_VERIFY: ${{ vars.SIGN_VERIFY }}
+        run: |
+          # Opt-in gate. Set repo/org variable SIGN_VERIFY=1 to enforce.
+          # By default, GH releases ship unsigned (downstream re-signs); this
+          # step is for orgs that pre-sign before the workflow runs.
+          $msis = Get-ChildItem -Path release -Filter 'Cimian-*.msi'
+          if ($msis.Count -eq 0) { throw 'No MSIs to verify' }
+          $failed = @()
+          foreach ($m in $msis) {
+              & signtool.exe verify /pa /v $m.FullName
+              if ($LASTEXITCODE -ne 0) { $failed += $m.Name }
+          }
+          if ($failed.Count -gt 0) {
+              throw "signtool verify failed for: $($failed -join ', ')"
+          }
+          Write-Host "All $($msis.Count) MSI(s) passed signtool verify /pa"
+
       - name: List release artifacts
         shell: pwsh
-        run: Get-ChildItem -Path release -Recurse -Include '*.msi','*.nupkg','*.pkg','*.intunewin','*.zip' | Select-Object FullName, @{N='SizeMB';E={[math]::Round($_.Length/1MB,1)}}
+        run: Get-ChildItem -Path release -Recurse -Include '*.msi','*.nupkg','*.pkg','*.intunewin','*.zip','SHA256SUMS.txt' | Select-Object FullName, @{N='SizeMB';E={[math]::Round($_.Length/1MB,1)}}
 
       - name: Create GitHub Release
         shell: pwsh
@@ -96,10 +131,22 @@ jobs:
           $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
           $title = "Cimian $tag"
 
+          $sumsContent = ''
+          if (Test-Path 'release/SHA256SUMS.txt') {
+              $sumsContent = (Get-Content 'release/SHA256SUMS.txt' -Raw).Trim()
+          }
           $buildInfo = @"
           ## Build info
 
           This release was built with .NET SDK $dotnet on $os, using cimian-pkg $cimipkg, via a GitHub Actions workflow here: $runUrl. It is provided **unsigned** — see signing instructions at the bottom.
+
+          ## SHA256
+
+          ``````
+          $sumsContent
+          ``````
+
+          Verify downloads with ``sha256sum -c SHA256SUMS.txt`` (Linux/macOS) or ``Get-FileHash -Algorithm SHA256`` (PowerShell). Downstream tooling should reject MSIs whose hash does not match this manifest.
           "@
 
           $signing = @"
@@ -128,6 +175,6 @@ jobs:
           $autoNotes = (gh api -X POST "repos/$env:GITHUB_REPOSITORY/releases/generate-notes" -f tag_name=$tag --jq .body) -join "`n"
           $notes = "$buildInfo`n`n$autoNotes`n`n$signing"
 
-          $artifacts = Get-ChildItem -Path release -Recurse -Include '*.msi','*.nupkg','*.pkg','*.intunewin','*.zip' | ForEach-Object { $_.FullName }
+          $artifacts = Get-ChildItem -Path release -Recurse -Include '*.msi','*.nupkg','*.pkg','*.intunewin','*.zip','SHA256SUMS.txt' | ForEach-Object { $_.FullName }
           if ($artifacts.Count -eq 0) { throw 'No artifacts to upload' }
           gh release create $tag @artifacts --title $title --notes $notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,11 @@ jobs:
           Get-Content $sumsPath | Write-Host
 
       - name: Verify signatures (opt-in)
-        if: env.SIGN_VERIFY == '1'
+        # Gate on vars.SIGN_VERIFY directly: step-scoped env is not visible to
+        # the step's own `if:` expression (GitHub evaluates the condition
+        # before the step's env block is materialized).
+        if: vars.SIGN_VERIFY == '1'
         shell: pwsh
-        env:
-          SIGN_VERIFY: ${{ vars.SIGN_VERIFY }}
         run: |
           # Opt-in gate. Set repo/org variable SIGN_VERIFY=1 to enforce.
           # By default, GH releases ship unsigned (downstream re-signs); this

--- a/MSI_PIPELINE_LEARNINGS.md
+++ b/MSI_PIPELINE_LEARNINGS.md
@@ -1,0 +1,98 @@
+# CimianTools MSI / GH Actions Release Pipeline — Learnings from 2026-06-05 Fleet Sweep
+
+Context: pushed CimianTools 2026.06.05.0221 to ~365 Windows devices via the new `cimian-bootstrap-mgmt` pipeline. SSH-swept the fleet, ran a fallback manual install on the 35 stale-but-reachable devices. 27/35 installed cleanly first try; 8 failed; root-cause analysis revealed gaps the MSI itself + the release pipeline should address.
+
+## Failure breakdown observed in the wild
+
+| Failure mode | Count | Root cause |
+|---|---|---|
+| SCP fail — disk full | 3 | Workstations with C:\ at 0 bytes free |
+| SCP fail — network/host instability | 1 | Slow / dropping links, also partial MSI in Temp |
+| msiexec `1618` | 3 | Another msiexec session held the global mutex; ours bailed instantly |
+| msiexec `112` | 1 | Insufficient disk space mid-install |
+| `1402` registry rollback noise | 2 | Transient — concurrent install had locked `HKLM\...\Installer\Rollback`. Cleared on retry. |
+
+## Concrete MSI / pipeline upgrades
+
+### 1. Pre-install launch conditions (in WiX)
+The MSI silently proceeds and burns ~290 MB of bandwidth + SCP time before failing if disk is full. Bake hard guards into WiX:
+
+```xml
+<!-- Require >= 1.5 GB free on system drive before allowing install -->
+<Condition Message="Insufficient disk space on [WindowsVolume]. CimianTools requires at least 1.5 GB free.">
+  <![CDATA[Installed OR (WindowsVolume_FreeSpace >= 1500)]]>
+</Condition>
+
+<!-- Block if reboot is pending -->
+<Property Id="REBOOTPENDING">
+  <RegistrySearch Id="RebootRequired" Root="HKLM"
+    Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending"
+    Type="raw" />
+</Property>
+<Condition Message="A pending reboot is required before installing CimianTools. Please reboot first.">
+  <![CDATA[Installed OR NOT REBOOTPENDING]]>
+</Condition>
+```
+
+### 2. Mutex backoff inside Cimian (not WiX)
+1618 = `ERROR_INSTALL_ALREADY_RUNNING`. WiX can't fix this — but `managedsoftwareupdate` invoking msiexec **can** retry with backoff:
+
+- Detect 1618 explicitly. Sleep 30–60s. Retry up to 3 times.
+- After final 1618, log which other msiexec is holding the mutex (`tasklist /fi "imagename eq msiexec.exe"`) so we can correlate with other Cimian-triggered installs.
+- Bonus: Cimian itself should serialise its own msiexec calls so two Cimian-managed packages installed in the same cycle don't collide.
+
+### 3. Cimian hourly task should self-heal — not return result=1 every hour
+Several devices showed `TaskResult=1` hour after hour without recovery. The task should:
+
+- Capture msiexec exit code, log it, and surface in ReportMate hardware/status.
+- On 1618: schedule itself again in 10–15 min instead of waiting a full hour.
+- On 112/1603/1622: trigger a disk-space + permissions probe and emit a ReportMate event so we see it.
+- On 1402: attempt a targeted ACL reset of `HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\Rollback` *before* retrying, using a signed helper in the Cimian SYSTEM context (privileges available, unlike admin SSH).
+
+### 4. MSI verbose log retention + upload
+`/L*v C:\Windows\Temp\CimianTools-install.log` is good. Make it:
+- **Rotate** (keep last 3 attempts, not overwrite each time).
+- **Auto-include in ReportMate event** on non-zero exit. Right now this exercise required SSH to fetch the tail — that should be a ReportMate field.
+
+### 5. Detect & recover partial MSI deliveries
+Partial MSI files (e.g. 284 MB out of 302 MB after SCP timeout, or in the wild: Cimian's own download interrupted) were left in `C:\Windows\Temp\CimianTools-update.msi`. Downstream installs then fail strangely.
+- The pipeline should ship a known-good `SHA256SUMS.txt` alongside the MSI artifacts.
+- Cimian's downloader should verify the digest before calling msiexec. On mismatch, delete & redownload.
+- GH Actions release step: add `sha256sum *.msi > SHA256SUMS.txt` and upload it as part of the release.
+
+### 6. GH Actions release: dual-arch + signing verification
+We saw `2026.06.05.0221` on both `x64` and `arm64` SKUs and the runtime arch detection (`$env:PROCESSOR_ARCHITECTURE`) drove which MSI to install. Pipeline should:
+- Emit both `CimianTools-x64-<ver>.msi` and `CimianTools-arm64-<ver>.msi` as separate release assets (already happening — good).
+- Run `signtool verify /pa /v <msi>` in the workflow and fail the build if either MSI is unsigned. Per our project rule: this system cannot run unsigned binaries.
+- Output a release-notes block with the SHA256 of each MSI for audit.
+
+### 7. WiX: shrink the MSI
+At 302 MB (x64) and 290 MB (arm64), SCP to a slow link takes 30–60s and is the #1 driver of "TIMEOUT" results when sweeping the fleet. Audit what's inside:
+- Are there `.pdb` symbol files shipping in release? Strip them.
+- Are we bundling the Go toolchain or vendor deps inadvertently?
+- If unavoidable, consider a `.cab`-stripped MSI + side-by-side compressed payload that Cimian's downloader unpacks.
+
+### 8. Better launch-condition messages for ReportMate to surface
+WiX `Condition Message` strings go to the MSI log and Event Viewer but not to a structured channel. Wrap msiexec invocation in a Cimian helper that:
+- Parses the log for `Condition '...' evaluated to FALSE`.
+- Sends the human-readable message to ReportMate as a structured event.
+
+### 9. Pipeline-level: gate the bootstrap-mgmt rollout on a smoke test
+Currently the pipeline pushes the new `management.json` and the new MSI catalog reference to the fleet in one shot. Add a smoke stage:
+- Pick 2–3 representative test devices (lab + render + staff).
+- After publishing the MSI to the blob, run the Cimian hourly on those devices, wait, and confirm version bump + zero `1618/112/1402/1603`.
+- Only then promote to full fleet.
+
+This is the same `Native-Full` cutover pattern already in the pipeline but with an explicit gate.
+
+### 10. Catch the `RENDER-NODE-02` class of failure (no Cimian at all)
+One device had Cimian uninstalled entirely. The bootstrap should:
+- On every Cimian hourly run, check if `C:\Program Files\Cimian\managedsoftwareupdate.exe` exists.
+- If missing, ReportMate emit a `cimian_missing` event so we see it in the fleet view.
+- Optionally trigger CimianBootstrap-driven reinstall.
+
+## Quick wins (do these first)
+1. **SHA256SUMS.txt in the release** — trivial GH Actions step, biggest robustness gain.
+2. **Disk-space launch condition in WiX** — one-line addition, prevents msi=112.
+3. **1618 retry-with-backoff in Cimian** — eliminates ~half the failures we saw.
+4. **Self-heal task on result=1** — devices that fail at hour H currently fail at H+1, H+2, ... forever.

--- a/MSI_PIPELINE_LEARNINGS.md
+++ b/MSI_PIPELINE_LEARNINGS.md
@@ -62,8 +62,8 @@ Partial MSI files (e.g. 284 MB out of 302 MB after SCP timeout, or in the wild: 
 
 ### 6. GH Actions release: dual-arch + signing verification
 We saw `2026.06.05.0221` on both `x64` and `arm64` SKUs and the runtime arch detection (`$env:PROCESSOR_ARCHITECTURE`) drove which MSI to install. Pipeline should:
-- Emit both `CimianTools-x64-<ver>.msi` and `CimianTools-arm64-<ver>.msi` as separate release assets (already happening — good).
-- Run `signtool verify /pa /v <msi>` in the workflow and fail the build if either MSI is unsigned. Per our project rule: this system cannot run unsigned binaries.
+- Emit both `Cimian-<ver>-x64.msi` and `Cimian-<ver>-arm64.msi` as separate release assets (already happening — good).
+- Run `signtool verify /pa /v <msi>` in the workflow when the repo/org variable `SIGN_VERIFY=1`. The default release publishes unsigned (downstream re-signs); orgs that pre-sign before the workflow runs flip the gate.
 - Output a release-notes block with the SHA256 of each MSI for audit.
 
 ### 7. WiX: shrink the MSI


### PR DESCRIPTION
## Summary

- New **`Emit SHA256SUMS.txt`** workflow step hashes every `*.msi`/`*.nupkg`/`*.zip` artifact and writes `release/SHA256SUMS.txt`. The file is uploaded as a release asset and inlined into the release body so downstream tooling (Cimian's downloader, the parent `cimian-bootstrap-mgmt` pipeline) can verify integrity before invoking msiexec.
- New **`Verify signatures (opt-in)`** step runs `signtool verify /pa /v` over every `Cimian-*.msi`. Gated on repo/org variable `SIGN_VERIFY=1` so the existing unsigned-release path (the parent ADO pipeline re-signs downstream) is unaffected by default.
- Release body now includes a SHA256 block with verification hints.

## Why

Today's fleet sweep found partial MSI files (~284 MB of 302 MB) left in `C:\Windows\Temp` after interrupted SCP/Cimian downloads. Without a hash manifest in the release, downstream code cannot detect a truncated MSI and just fails opaquely at install time. This is item #5 + #6 from `MSI_PIPELINE_LEARNINGS.md` (also added to the repo in this PR).

## Test plan

- [ ] Tag a v0.0.0-test dry run; confirm SHA256SUMS.txt appears in the release assets and the body contains the hash block.
- [ ] Run Get-FileHash -Algorithm SHA256 on a downloaded MSI; confirm match.
- [ ] Set SIGN_VERIFY=1 repo variable; tag a release where the MSI is unsigned; confirm the verify step fails the build.
- [ ] Confirm default (SIGN_VERIFY unset) still produces unsigned releases as today.

## Risk

Low. Purely additive — no existing path changes behaviour unless SIGN_VERIFY=1 is set.