### PR TITLE
build: strip pdb+xml from MSI payload, add size guard

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -853,7 +853,9 @@ function Build-MsiPackage {
     if ($env:CIMIAN_MSI_KEEP_PDB -eq '1') { $copyExclude = @('*.xml') }
     Copy-Item -Path (Join-Path $binariesDir '*') -Destination $payloadDir -Recurse -Force -Exclude $copyExclude
 
-    # Audit the payload — report what's there, fail if it's larger than the soft cap.
+    # Audit the payload — report what's there, warn at the soft cap, fail at the hard cap.
+    # Cap comparisons use unrounded bytes so a 250.04 MB payload doesn't slip past a
+    # 250 MB soft cap just because the displayed value rounds down to 250.0.
     $payloadBytes = (Get-ChildItem -Path $payloadDir -Recurse -File | Measure-Object Length -Sum).Sum
     $payloadMB = [math]::Round($payloadBytes / 1MB, 1)
     Write-BuildLog "MSI payload size for $Architecture: $payloadMB MB" "INFO"
@@ -866,10 +868,10 @@ function Build-MsiPackage {
     }
     $softCapMB = if ($env:CIMIAN_MSI_PAYLOAD_SOFT_CAP_MB) { [int]$env:CIMIAN_MSI_PAYLOAD_SOFT_CAP_MB } else { 250 }
     $hardCapMB = if ($env:CIMIAN_MSI_PAYLOAD_HARD_CAP_MB) { [int]$env:CIMIAN_MSI_PAYLOAD_HARD_CAP_MB } else { 0 }
-    if ($payloadMB -gt $softCapMB) {
+    if ($payloadBytes -gt ($softCapMB * 1MB)) {
         Write-BuildLog "MSI payload ($payloadMB MB) exceeds soft cap ($softCapMB MB) for $Architecture" "WARNING"
     }
-    if ($hardCapMB -gt 0 -and $payloadMB -gt $hardCapMB) {
+    if ($hardCapMB -gt 0 -and $payloadBytes -gt ($hardCapMB * 1MB)) {
         throw "MSI payload ($payloadMB MB) exceeds hard cap ($hardCapMB MB) for $Architecture. Set CIMIAN_MSI_PAYLOAD_HARD_CAP_MB=0 to disable."
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -847,7 +847,31 @@ function Build-MsiPackage {
     # Mirror the full publish tree so WinUI 3 companion files (PRI / XBF / runtime DLLs)
     # ride along with Managed Software Center.exe. A selective exe-only copy breaks MSC
     # with "This app can't run on your PC" because the launcher stub can't find its runtime.
-    Copy-Item -Path (Join-Path $binariesDir '*') -Destination $payloadDir -Recurse -Force
+    # We DO strip non-runtime noise (.pdb symbols, XML doc files) — they bloat the MSI
+    # without being used at runtime. Roughly 50-70 MB saved per arch.
+    $copyExclude = @('*.pdb', '*.xml')
+    if ($env:CIMIAN_MSI_KEEP_PDB -eq '1') { $copyExclude = @('*.xml') }
+    Copy-Item -Path (Join-Path $binariesDir '*') -Destination $payloadDir -Recurse -Force -Exclude $copyExclude
+
+    # Audit the payload — report what's there, fail if it's larger than the soft cap.
+    $payloadBytes = (Get-ChildItem -Path $payloadDir -Recurse -File | Measure-Object Length -Sum).Sum
+    $payloadMB = [math]::Round($payloadBytes / 1MB, 1)
+    Write-BuildLog "MSI payload size for $Architecture: $payloadMB MB" "INFO"
+    $topTypes = Get-ChildItem -Path $payloadDir -Recurse -File |
+        Group-Object Extension |
+        Select-Object @{N='Ext';E={$_.Name}}, @{N='Count';E={$_.Count}}, @{N='MB';E={[math]::Round((($_.Group | Measure-Object Length -Sum).Sum/1MB),1)}} |
+        Sort-Object MB -Descending | Select-Object -First 8
+    foreach ($t in $topTypes) {
+        Write-BuildLog "  $($t.Ext.PadRight(10)) $($t.Count.ToString().PadLeft(4)) files  $($t.MB) MB" "INFO"
+    }
+    $softCapMB = if ($env:CIMIAN_MSI_PAYLOAD_SOFT_CAP_MB) { [int]$env:CIMIAN_MSI_PAYLOAD_SOFT_CAP_MB } else { 250 }
+    $hardCapMB = if ($env:CIMIAN_MSI_PAYLOAD_HARD_CAP_MB) { [int]$env:CIMIAN_MSI_PAYLOAD_HARD_CAP_MB } else { 0 }
+    if ($payloadMB -gt $softCapMB) {
+        Write-BuildLog "MSI payload ($payloadMB MB) exceeds soft cap ($softCapMB MB) for $Architecture" "WARNING"
+    }
+    if ($hardCapMB -gt 0 -and $payloadMB -gt $hardCapMB) {
+        throw "MSI payload ($payloadMB MB) exceeds hard cap ($hardCapMB MB) for $Architecture. Set CIMIAN_MSI_PAYLOAD_HARD_CAP_MB=0 to disable."
+    }
 
     $expectedExecutables = @(
         'cimiwatcher.exe', 'managedsoftwareupdate.exe', 'cimitrigger.exe', 'cimistatus.exe',


### PR DESCRIPTION
## Summary

- Exclude `*.pdb` symbol files and `*.xml` doc files from the MSI payload during `Build-MsiPackage` in `build.ps1`. Roughly 50-70 MB saved per arch.
- Print a per-extension breakdown of the payload at build time (top 8 file types by size).
- Add a soft cap (default 250 MB) that emits a build warning, and an optional hard cap (`CIMIAN_MSI_PAYLOAD_HARD_CAP_MB`) that fails the build.
- Override via `CIMIAN_MSI_KEEP_PDB=1` if symbols are needed for a debug release.

## Why

Current MSIs are 290 MB (arm64) and 302 MB (x64). Today's fleet sweep showed SCP-to-target taking 30-60s per device and timing out on slower links — driving the "TIMEOUT" results in the sweep. The MSI carries `.pdb` and `.xml` files that are not referenced at runtime by any Cimian binary. Item #7 from `MSI_PIPELINE_LEARNINGS.md`.

## Test plan

- [ ] Local `./build.ps1 -Sign` and confirm both arch MSIs build and install cleanly.
- [ ] Diff payload size before/after — target -50 to -70 MB per arch.
- [ ] Confirm `cimistatus.exe` (WinUI 3) still launches post-install on a clean Windows VM — the launcher's runtime dependencies are PRI/XBF/DLL not PDB.
- [ ] Smoke `managedsoftwareupdate --checkonly` on a test device.

## Risk

Low-medium. The risk is accidentally dropping a runtime resource — none of the included Cimian binaries should require their PDB at runtime (PDBs are debug symbols), but worth verifying cimistatus loads on a fresh box. The `CIMIAN_MSI_KEEP_PDB=1` escape hatch is in place for emergencies.