### PR TITLE
watchdog: --self-check task + cimian_missing marker

### DIFF
--- a/build/msi/install-tasks.ps1
+++ b/build/msi/install-tasks.ps1
@@ -120,6 +120,38 @@ try {
         }
     }
 
+    # Watchdog task: runs managedsoftwareupdate --self-check every 4 hours.
+    # Verifies the install hasn't drifted off the box (binaries removed by a
+    # registry-cleaner, partial uninstall, etc.) and drops a marker that the
+    # ReportMate runner surfaces as a cimian_missing event.
+    Write-Host "Creating Cimian Watchdog scheduled task..."
+    try {
+        $watchdogAction = New-ScheduledTaskAction -Execute $managedSoftwareUpdateExe -Argument "--self-check" -WorkingDirectory $InstallPath
+        $watchdogTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(10) -RepetitionInterval (New-TimeSpan -Hours 4)
+        $watchdogSettings = New-ScheduledTaskSettingsSet `
+            -ExecutionTimeLimit (New-TimeSpan -Minutes 5) `
+            -Hidden `
+            -AllowStartIfOnBatteries `
+            -DontStopIfGoingOnBatteries `
+            -StartWhenAvailable
+        Register-ScheduledTask `
+            -TaskName "Cimian Watchdog" `
+            -Action $watchdogAction `
+            -Trigger $watchdogTrigger `
+            -Settings $watchdogSettings `
+            -Principal $principal `
+            -Description "Verifies Cimian installation health every 4 hours; writes cimian_selfcheck.json for ReportMate to surface drift." `
+            -Force `
+            -ErrorAction Stop | Out-Null
+        Write-Host "OK Cimian Watchdog scheduled task created"
+        Write-Host "   Task Name: Cimian Watchdog"
+        Write-Host "   Schedule: Every 4 hours starting 10 minutes after installation"
+        Write-Host "   Command: $managedSoftwareUpdateExe --self-check"
+    } catch {
+        # Watchdog is best-effort — never block the install on this.
+        Write-Warning "Cimian Watchdog task registration failed (non-fatal): $($_.Exception.Message)"
+    }
+
 } catch {
     Write-Error "Failed to create Cimian scheduled task: $_"
     exit 1

--- a/build/msi/uninstall-tasks.ps1
+++ b/build/msi/uninstall-tasks.ps1
@@ -5,7 +5,8 @@ Write-Host "Removing Cimian scheduled tasks..."
 
 try {
     $taskNames = @(
-        "Cimian Managed Software Update Hourly"
+        "Cimian Managed Software Update Hourly",
+        "Cimian Watchdog"
     )
 
     foreach ($taskName in $taskNames) {

--- a/cli/managedsoftwareupdate/Program.cs
+++ b/cli/managedsoftwareupdate/Program.cs
@@ -1,6 +1,7 @@
 using CommandLine;
 using Cimian.CLI.managedsoftwareupdate.Models;
 using Cimian.CLI.managedsoftwareupdate.Services;
+using Cimian.Core;
 using Cimian.Core.Services;
 using System.Diagnostics;
 using System.Reflection;
@@ -650,7 +651,11 @@ public class Program
     {
         try
         {
-            var installDir = @"C:\Program Files\Cimian";
+            // Resolve install + state roots through CimianPaths so the check
+            // honors group-policy relocations of ProgramFiles / ProgramData
+            // instead of falsely reporting drift on hosts where C:\ isn't the
+            // installed drive.
+            var installDir = CimianPaths.CimianInstallDir;
             var required = new[]
             {
                 "managedsoftwareupdate.exe",
@@ -661,10 +666,12 @@ public class Program
                 .Where(f => !File.Exists(Path.Combine(installDir, f)))
                 .ToList();
 
-            // Sibling: status file readable as a single line by tail-based collectors
-            // and as JSON by structured collectors. Lives in ManagedInstalls so the
-            // ReportMate runner already scans it.
-            var statusDir = @"C:\ProgramData\ManagedInstalls";
+            // Status file lives next to the rest of Cimian's state so the
+            // ReportMate runner already scans it. Emitted as compact JSON
+            // (single line) — tail-based collectors can grep without re-parsing
+            // pretty-printed output, and structured collectors deserialize the
+            // same payload regardless.
+            var statusDir = CimianPaths.ManagedInstallsRoot;
             try { Directory.CreateDirectory(statusDir); } catch { }
             var statusPath = Path.Combine(statusDir, "cimian_selfcheck.json");
             var record = new
@@ -678,10 +685,19 @@ public class Program
                 cimianVersion = GetVersion(),
             };
             var json = System.Text.Json.JsonSerializer.Serialize(
-                record, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
-            try { File.WriteAllText(statusPath, json); } catch (Exception ex)
+                record, new System.Text.Json.JsonSerializerOptions { WriteIndented = false });
+            try
             {
-                Console.Error.WriteLine($"self-check: failed to write {statusPath}: {ex.Message}");
+                File.WriteAllText(statusPath, json);
+            }
+            catch (Exception ex)
+            {
+                // If we can't drop the marker the scheduled task would silently
+                // stop updating it and ReportMate would never know — surface as
+                // exit 3 (internal error) so the Task Scheduler "Last Run
+                // Result" column lights up and an operator notices.
+                Console.Error.WriteLine($"[self-check] failed to write {statusPath}: {ex.Message}");
+                return 3;
             }
 
             if (missing.Count == 0)

--- a/cli/managedsoftwareupdate/Program.cs
+++ b/cli/managedsoftwareupdate/Program.cs
@@ -153,6 +153,11 @@ public class Program
             return RestartCimianWatcherService();
         }
 
+        if (options.SelfCheck)
+        {
+            return SelfCheck();
+        }
+
         // Handle preflight-only: run preflight and exit
         if (options.PreflightOnly)
         {
@@ -630,6 +635,74 @@ public class Program
     }
 
     /// <summary>
+    /// Watchdog entry point. Verifies the Cimian install hasn't drifted off the
+    /// box (e.g. a partial Cimian uninstall, a registry-cleaner sweep) and drops
+    /// a structured marker that ReportMate's status collector can surface as a
+    /// cimian_missing event. Called by the Watchdog scheduled task (~every 4h)
+    /// registered alongside the hourly task in build/msi/install-tasks.ps1.
+    ///
+    /// Exit codes:
+    ///   0 = healthy
+    ///   2 = drift detected (one or more critical binaries missing); marker written
+    ///   3 = unexpected error during check
+    /// </summary>
+    private static int SelfCheck()
+    {
+        try
+        {
+            var installDir = @"C:\Program Files\Cimian";
+            var required = new[]
+            {
+                "managedsoftwareupdate.exe",
+                "cimitrigger.exe",
+                "cimiwatcher.exe",
+            };
+            var missing = required
+                .Where(f => !File.Exists(Path.Combine(installDir, f)))
+                .ToList();
+
+            // Sibling: status file readable as a single line by tail-based collectors
+            // and as JSON by structured collectors. Lives in ManagedInstalls so the
+            // ReportMate runner already scans it.
+            var statusDir = @"C:\ProgramData\ManagedInstalls";
+            try { Directory.CreateDirectory(statusDir); } catch { }
+            var statusPath = Path.Combine(statusDir, "cimian_selfcheck.json");
+            var record = new
+            {
+                timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                machine = Environment.MachineName,
+                installDir,
+                requiredBinaries = required,
+                missingBinaries = missing,
+                healthy = missing.Count == 0,
+                cimianVersion = GetVersion(),
+            };
+            var json = System.Text.Json.JsonSerializer.Serialize(
+                record, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+            try { File.WriteAllText(statusPath, json); } catch (Exception ex)
+            {
+                Console.Error.WriteLine($"self-check: failed to write {statusPath}: {ex.Message}");
+            }
+
+            if (missing.Count == 0)
+            {
+                Console.WriteLine($"[self-check] healthy — all {required.Length} required binaries present in {installDir}");
+                return 0;
+            }
+
+            Console.Error.WriteLine($"[self-check] DRIFT — {missing.Count} required binar{(missing.Count == 1 ? "y" : "ies")} missing from {installDir}:");
+            foreach (var m in missing) Console.Error.WriteLine($"  - {m}");
+            Console.Error.WriteLine($"[self-check] marker written: {statusPath}");
+            return 2;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[self-check] unexpected error: {ex.Message}");
+            return 3;
+        }
+    }
+
+    /// <summary>
     /// Handles conflict when --checkonly is used but another instance is running.
     /// Matches Go: handleCheckOnlyConflict()
     /// </summary>
@@ -996,6 +1069,9 @@ public class Options
 
     [Option("restart-service", Required = false, HelpText = "Restart CimianWatcher service and exit")]
     public bool RestartService { get; set; }
+
+    [Option("self-check", Required = false, HelpText = "Verify Cimian installation health and exit (used by the Watchdog scheduled task)")]
+    public bool SelfCheck { get; set; }
 
     // Cache management flags
     [Option("validate-cache", Required = false, HelpText = "Validate cache integrity and remove corrupt files")]


### PR DESCRIPTION
## Summary

Adds a Watchdog scheduled task that runs every 4 hours and verifies the Cimian install is intact. Today's fleet sweep found one device (a render node) with no Cimian binaries at all â€” there is currently no way for the fleet to surface this short of hands-on. After this PR, ReportMate's status collector will see a fresh `cimian_selfcheck.json` every 4h with `healthy=false` and an explicit `missingBinaries` list.

## Changes

- New `--self-check` CLI flag on `managedsoftwareupdate`. Verifies `managedsoftwareupdate.exe`, `cimitrigger.exe`, `cimiwatcher.exe` exist in `C:\Program Files\Cimian`. Writes a JSON status record to `C:\ProgramData\ManagedInstalls\cimian_selfcheck.json` (where the ReportMate runner already scans). Exit codes: 0=healthy, 2=drift detected, 3=internal error.
- `build/msi/install-tasks.ps1` now also registers a `Cimian Watchdog` scheduled task (SYSTEM, every 4h, 5-min timeout, hidden). Failures registering the watchdog are non-fatal â€” they don't block MSI install.
- `build/msi/uninstall-tasks.ps1` cleans up the new task on uninstall.

Item #3 + #10 from `MSI_PIPELINE_LEARNINGS.md`. Sets up the structured-emit primitive (`cimian_selfcheck.json`) that PR3's `MSI_EXIT=` tag will eventually feed into, once the StatusService surface is wired through.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [ ] Install the MSI on a clean VM, confirm two tasks present: "Cimian Managed Software Update Hourly" and "Cimian Watchdog".
- [ ] Run `& "C:\Program Files\Cimian\managedsoftwareupdate.exe" --self-check` manually, confirm exit 0 and a fresh `cimian_selfcheck.json` with `healthy: true`.
- [ ] Rename `cimitrigger.exe` aside, re-run `--self-check`, confirm exit 2 and the JSON lists `cimitrigger.exe` in `missingBinaries`.
- [ ] Uninstall the MSI, confirm both scheduled tasks are removed.

## Risk

Low. The watchdog is best-effort â€” failures don't block install, and the task itself only reads files + writes a small JSON. No registry or service modification. The new CLI flag is dispatched before the heavyweight `UpdateEngine` paths so it cannot interfere with normal runs.
