### PR TITLE
msc: merge rapid self-serve clicks + contextual progress label

### DIFF
--- a/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
@@ -21,7 +21,10 @@ public interface ITriggerService
     /// <summary>
     /// Trigger a fast targeted install/uninstall for a single item just requested via
     /// the self-service manifest. Uses `--item <name> --no-preflight` so the run skips
-    /// the full preflight pipeline and only touches the affected package.
+    /// the full preflight pipeline and only touches the affected package. When called
+    /// concurrently before CimianWatcher has consumed the flag file, the names are
+    /// coalesced into a single `--item N1 --item N2 ...` run so rapid clicks do not
+    /// lose entries to a clobbering race.
     /// </summary>
     Task TriggerInstallItemAsync(string itemName);
 
@@ -34,6 +37,14 @@ public interface ITriggerService
     /// Check if an operation is currently running
     /// </summary>
     bool IsOperationRunning { get; }
+
+    /// <summary>
+    /// Human-readable description of the in-flight operation, e.g.
+    /// "Installing Gimp, Cyberduck...". Null when no operation is active.
+    /// Read by the shell to populate the progress overlay so it reflects the
+    /// actual work instead of a generic "Checking for updates...".
+    /// </summary>
+    string? CurrentOperationLabel { get; }
 
     /// <summary>
     /// Event raised when operation status changes

--- a/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
@@ -40,7 +40,8 @@ public interface ITriggerService
 
     /// <summary>
     /// Human-readable description of the in-flight operation, e.g.
-    /// "Installing Gimp, Cyberduck...". Null when no operation is active.
+    /// "Installing Gimp, Cyberduck...". Set when a trigger writes the flag
+    /// file and cleared once CimianWatcher consumes it (or the call fails).
     /// Read by the shell to populate the progress overlay so it reflects the
     /// actual work instead of a generic "Checking for updates...".
     /// </summary>

--- a/gui/ManagedSoftwareCenter/Services/TriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/TriggerService.cs
@@ -23,6 +23,15 @@ public class TriggerService : ITriggerService, IDisposable
     private readonly SemaphoreSlim _flagFileLock = new(1, 1);
     private readonly HashSet<string> _pendingItems = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<string> _pendingItemOrder = new();
+
+    // A single in-flight Task per targeted-install batch. Concurrent
+    // TriggerInstallItemAsync calls that arrive while the flag file from a
+    // prior click is still pending watcher consumption rewrite the file with
+    // the merged --item list and await the SAME task — otherwise they would
+    // start their own polling loops and could recreate the flag file moments
+    // after CimianWatcher deleted it, kicking off a second MSU run that
+    // races the first.
+    private Task? _currentBatch;
     private bool _isOperationRunning;
     private string? _currentOperationLabel;
 
@@ -43,7 +52,14 @@ public class TriggerService : ITriggerService, IDisposable
     {
         _logger?.LogInformation("Triggering check via CimianWatcher");
         _currentOperationLabel = "Checking for updates...";
-        await TriggerViaFlagFileAsync("--checkonly --show-status -vv");
+        try
+        {
+            await WriteFlagFileAndWaitAsync("--checkonly --show-status -vv").ConfigureAwait(false);
+        }
+        finally
+        {
+            _currentOperationLabel = null;
+        }
     }
 
     /// <inheritdoc />
@@ -51,7 +67,14 @@ public class TriggerService : ITriggerService, IDisposable
     {
         _logger?.LogInformation("Triggering install via CimianWatcher");
         _currentOperationLabel = "Installing pending updates...";
-        await TriggerViaFlagFileAsync("--installonly --show-status -vv");
+        try
+        {
+            await WriteFlagFileAndWaitAsync("--installonly --show-status -vv").ConfigureAwait(false);
+        }
+        finally
+        {
+            _currentOperationLabel = null;
+        }
     }
 
     /// <inheritdoc />
@@ -67,8 +90,7 @@ public class TriggerService : ITriggerService, IDisposable
         // stack trace than something coming from inside the merge loop.
         _ = BootstrapArgsBuilder.QuoteArgument(itemName);
 
-        string mergedArgs;
-        string label;
+        Task batchTask;
         await _flagFileLock.WaitAsync().ConfigureAwait(false);
         try
         {
@@ -76,18 +98,36 @@ public class TriggerService : ITriggerService, IDisposable
             {
                 _pendingItemOrder.Add(itemName);
             }
-            mergedArgs = BootstrapArgsBuilder.BuildSelfServeInstallArgs(_pendingItemOrder);
-            label = BuildOperationLabel(_pendingItemOrder);
-            _currentOperationLabel = label;
+            var mergedArgs = BootstrapArgsBuilder.BuildSelfServeInstallArgs(_pendingItemOrder);
+            _currentOperationLabel = BuildOperationLabel(_pendingItemOrder);
+
+            if (_currentBatch != null && !_currentBatch.IsCompleted)
+            {
+                // A batch is already polling for consume — just rewrite the
+                // flag file with the merged --item list under the same lock so
+                // CimianWatcher reads the up-to-date set on its next 10s tick.
+                // The existing batch's poll loop is what we await.
+                await WriteFlagFileAsync(mergedArgs).ConfigureAwait(false);
+                _logger?.LogInformation(
+                    "Merged {Item} into in-flight self-serve batch ({Label})",
+                    itemName, _currentOperationLabel);
+                batchTask = _currentBatch;
+            }
+            else
+            {
+                _logger?.LogInformation(
+                    "Triggering targeted install via CimianWatcher: {Label}",
+                    _currentOperationLabel);
+                _currentBatch = RunSelfServeBatchAsync(mergedArgs);
+                batchTask = _currentBatch;
+            }
         }
         finally
         {
             _flagFileLock.Release();
         }
 
-        _logger?.LogInformation(
-            "Triggering targeted install via CimianWatcher: {Label}", label);
-        await TriggerViaFlagFileAsync(mergedArgs).ConfigureAwait(false);
+        await batchTask.ConfigureAwait(false);
     }
 
     /// <summary>
@@ -133,83 +173,111 @@ public class TriggerService : ITriggerService, IDisposable
     }
 
     /// <summary>
-    /// Writes the bootstrap flag file with custom arguments and waits for
-    /// CimianWatcher to consume it (indicating it launched MSU). Concurrent
-    /// callers polling the same file all exit together once it disappears.
+    /// Self-serve batch poll loop. Writes the merged --item args, waits for
+    /// CimianWatcher to consume the flag file, then clears the pending state
+    /// so the next click starts a fresh batch. Runs once per batch; concurrent
+    /// callers within the same batch reuse the returned Task.
     /// </summary>
-    private async Task TriggerViaFlagFileAsync(string arguments)
+    private async Task RunSelfServeBatchAsync(string initialArgs)
     {
         _isOperationRunning = true;
         OperationStatusChanged?.Invoke(this, true);
-
         try
         {
-            var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
-            var content = $"Bootstrap triggered at: {timestamp}\nSource: ManagedSoftwareCenter\nArgs: {arguments}\n";
-
-            // Ensure the directory exists (it should, but be safe)
-            var dir = Path.GetDirectoryName(BootstrapFlagFile);
-            if (!string.IsNullOrEmpty(dir))
-                Directory.CreateDirectory(dir);
-
-            await File.WriteAllTextAsync(BootstrapFlagFile, content).ConfigureAwait(false);
-            _logger?.LogInformation("Wrote bootstrap flag file with args: {Args}", arguments);
-
-            // Wait for CimianWatcher to consume the flag file
-            var elapsed = TimeSpan.Zero;
-            while (File.Exists(BootstrapFlagFile) && elapsed < ServiceTimeout)
-            {
-                await Task.Delay(PollInterval).ConfigureAwait(false);
-                elapsed += PollInterval;
-            }
-
-            if (File.Exists(BootstrapFlagFile))
-            {
-                _logger?.LogError("CimianWatcher did not consume flag file within {Timeout}s — is the service running?",
-                    ServiceTimeout.TotalSeconds);
-
-                // Clean up the stale flag file
-                try { File.Delete(BootstrapFlagFile); } catch { }
-
-                await ClearPendingItemsAsync().ConfigureAwait(false);
-                _isOperationRunning = false;
-                _currentOperationLabel = null;
-                OperationStatusChanged?.Invoke(this, false);
-                throw new InvalidOperationException(
-                    "CimianWatcher service did not respond. Ensure the service is running: sc query CimianWatcher");
-            }
-
-            _logger?.LogInformation("CimianWatcher consumed flag file — managedsoftwareupdate is running");
-
-            // The service has picked up the flag file and launched MSU.
-            // Clear the pending set so any subsequent click (after this point)
-            // starts a fresh batch instead of re-issuing items already handed
-            // off to the currently-running MSU. Completion of the install run
-            // itself is still signaled by the InstallInfo.yaml FileSystemWatcher
-            // and the StatusReporter pipe — same as before.
-            await ClearPendingItemsAsync().ConfigureAwait(false);
+            await WriteFlagFileAsync(initialArgs).ConfigureAwait(false);
+            await WaitForFlagFileConsumedAsync().ConfigureAwait(false);
         }
         catch (InvalidOperationException)
         {
-            throw; // re-throw the service-not-running error
+            _isOperationRunning = false;
+            OperationStatusChanged?.Invoke(this, false);
+            await ClearBatchStateAsync().ConfigureAwait(false);
+            throw;
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "Failed to trigger via flag file");
-            await ClearPendingItemsAsync().ConfigureAwait(false);
+            _logger?.LogError(ex, "Self-serve batch failed");
             _isOperationRunning = false;
-            _currentOperationLabel = null;
+            OperationStatusChanged?.Invoke(this, false);
+            await ClearBatchStateAsync().ConfigureAwait(false);
+            return;
+        }
+
+        // Consumed cleanly — pending state cleared so the next click starts a
+        // fresh batch. _isOperationRunning stays true; completion of the install
+        // is signaled by the InstallInfo.yaml FileSystemWatcher or the
+        // StatusReporter pipe, which is also responsible for flipping the
+        // overlay back to idle.
+        await ClearBatchStateAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Wraps a one-shot Check/Install flag-file flow that doesn't need batching.
+    /// </summary>
+    private async Task WriteFlagFileAndWaitAsync(string arguments)
+    {
+        _isOperationRunning = true;
+        OperationStatusChanged?.Invoke(this, true);
+        try
+        {
+            await WriteFlagFileAsync(arguments).ConfigureAwait(false);
+            await WaitForFlagFileConsumedAsync().ConfigureAwait(false);
+        }
+        catch (InvalidOperationException)
+        {
+            _isOperationRunning = false;
+            OperationStatusChanged?.Invoke(this, false);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Flag-file trigger failed");
+            _isOperationRunning = false;
             OperationStatusChanged?.Invoke(this, false);
         }
     }
 
-    private async Task ClearPendingItemsAsync()
+    private async Task WriteFlagFileAsync(string arguments)
+    {
+        var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+        var content = $"Bootstrap triggered at: {timestamp}\nSource: ManagedSoftwareCenter\nArgs: {arguments}\n";
+        var dir = Path.GetDirectoryName(BootstrapFlagFile);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(BootstrapFlagFile, content).ConfigureAwait(false);
+        _logger?.LogInformation("Wrote bootstrap flag file with args: {Args}", arguments);
+    }
+
+    private async Task WaitForFlagFileConsumedAsync()
+    {
+        var elapsed = TimeSpan.Zero;
+        while (File.Exists(BootstrapFlagFile) && elapsed < ServiceTimeout)
+        {
+            await Task.Delay(PollInterval).ConfigureAwait(false);
+            elapsed += PollInterval;
+        }
+
+        if (File.Exists(BootstrapFlagFile))
+        {
+            _logger?.LogError("CimianWatcher did not consume flag file within {Timeout}s — is the service running?",
+                ServiceTimeout.TotalSeconds);
+            try { File.Delete(BootstrapFlagFile); } catch { }
+            throw new InvalidOperationException(
+                "CimianWatcher service did not respond. Ensure the service is running: sc query CimianWatcher");
+        }
+
+        _logger?.LogInformation("CimianWatcher consumed flag file — managedsoftwareupdate is running");
+    }
+
+    private async Task ClearBatchStateAsync()
     {
         await _flagFileLock.WaitAsync().ConfigureAwait(false);
         try
         {
             _pendingItems.Clear();
             _pendingItemOrder.Clear();
+            _currentOperationLabel = null;
+            _currentBatch = null;
         }
         finally
         {

--- a/gui/ManagedSoftwareCenter/Services/TriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/TriggerService.cs
@@ -2,6 +2,7 @@
 // Uses flag-file IPC so the SYSTEM service launches the process — no UAC needed.
 
 using System.IO;
+using Cimian.Core.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Cimian.GUI.ManagedSoftwareCenter.Services;
@@ -19,9 +20,15 @@ public class TriggerService : ITriggerService, IDisposable
     private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
 
     private readonly ILogger<TriggerService>? _logger;
+    private readonly SemaphoreSlim _flagFileLock = new(1, 1);
+    private readonly HashSet<string> _pendingItems = new(StringComparer.OrdinalIgnoreCase);
+    private readonly List<string> _pendingItemOrder = new();
     private bool _isOperationRunning;
+    private string? _currentOperationLabel;
 
     public bool IsOperationRunning => _isOperationRunning;
+
+    public string? CurrentOperationLabel => _currentOperationLabel;
 
     public event EventHandler<bool>? OperationStatusChanged;
 
@@ -35,6 +42,7 @@ public class TriggerService : ITriggerService, IDisposable
     public async Task TriggerCheckAsync()
     {
         _logger?.LogInformation("Triggering check via CimianWatcher");
+        _currentOperationLabel = "Checking for updates...";
         await TriggerViaFlagFileAsync("--checkonly --show-status -vv");
     }
 
@@ -42,6 +50,7 @@ public class TriggerService : ITriggerService, IDisposable
     public async Task TriggerInstallAsync()
     {
         _logger?.LogInformation("Triggering install via CimianWatcher");
+        _currentOperationLabel = "Installing pending updates...";
         await TriggerViaFlagFileAsync("--installonly --show-status -vv");
     }
 
@@ -53,67 +62,53 @@ public class TriggerService : ITriggerService, IDisposable
             throw new ArgumentException("itemName must be provided", nameof(itemName));
         }
 
-        // The args string is written verbatim to the flag file, then handed to
-        // ProcessStartInfo.Arguments by CimianWatcher. Names containing spaces,
-        // tabs, quotes, or trailing backslashes would otherwise be split or
-        // misparsed and the --item filter would not match. Quote the name and
-        // reject control characters / embedded double quotes that no legitimate
-        // catalog item should ever contain.
-        var quoted = QuoteArgument(itemName);
+        // Validate the name up front — BuildSelfServeInstallArgs would throw on
+        // control characters too, but catching it here gives a clearer caller
+        // stack trace than something coming from inside the merge loop.
+        _ = BootstrapArgsBuilder.QuoteArgument(itemName);
 
-        _logger?.LogInformation("Triggering targeted install for {Item} via CimianWatcher", itemName);
-        // --no-preflight skips the preflight script (catalogs/config were just refreshed by
-        // the most recent --checkonly), turning a ~30s pipeline into a ~5-10s targeted run.
-        await TriggerViaFlagFileAsync($"--item {quoted} --no-preflight --show-status -vv");
+        string mergedArgs;
+        string label;
+        await _flagFileLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_pendingItems.Add(itemName))
+            {
+                _pendingItemOrder.Add(itemName);
+            }
+            mergedArgs = BootstrapArgsBuilder.BuildSelfServeInstallArgs(_pendingItemOrder);
+            label = BuildOperationLabel(_pendingItemOrder);
+            _currentOperationLabel = label;
+        }
+        finally
+        {
+            _flagFileLock.Release();
+        }
+
+        _logger?.LogInformation(
+            "Triggering targeted install via CimianWatcher: {Label}", label);
+        await TriggerViaFlagFileAsync(mergedArgs).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Quotes a single argument for safe round-trip through a flag-file "Args:"
-    /// line and ProcessStartInfo.Arguments. Follows the Windows C-runtime
-    /// convention (backslash-escape any embedded double-quote and any run of
-    /// backslashes immediately preceding a quote or the closing quote).
+    /// Composes the human-readable progress label rendered in the shell overlay
+    /// while a self-serve run is in flight. Long batches (4+ items) are
+    /// summarized as a count so the message stays single-line.
     /// </summary>
-    internal static string QuoteArgument(string value)
+    internal static string BuildOperationLabel(IReadOnlyList<string> items)
     {
-        if (value.IndexOfAny(new[] { '\r', '\n', '\0' }) >= 0)
-        {
-            throw new ArgumentException("Item name contains control characters", nameof(value));
-        }
-
-        // Fast path: no whitespace, no quotes, no trailing backslash — no quoting needed.
-        if (value.Length > 0
-            && value.IndexOfAny(new[] { ' ', '\t', '"' }) < 0
-            && value[value.Length - 1] != '\\')
-        {
-            return value;
-        }
-
-        var sb = new System.Text.StringBuilder(value.Length + 2);
-        sb.Append('"');
-        var backslashes = 0;
-        foreach (var c in value)
-        {
-            if (c == '\\')
-            {
-                backslashes++;
-            }
-            else if (c == '"')
-            {
-                sb.Append('\\', backslashes * 2 + 1);
-                sb.Append('"');
-                backslashes = 0;
-            }
-            else
-            {
-                if (backslashes > 0) sb.Append('\\', backslashes);
-                backslashes = 0;
-                sb.Append(c);
-            }
-        }
-        if (backslashes > 0) sb.Append('\\', backslashes * 2);
-        sb.Append('"');
-        return sb.ToString();
+        if (items.Count == 0) return "Installing requested items...";
+        if (items.Count == 1) return $"Installing {items[0]}...";
+        if (items.Count <= 3) return $"Installing {string.Join(", ", items)}...";
+        return $"Installing {items.Count} items ({items[0]}, {items[1]}, +{items.Count - 2} more)...";
     }
+
+    /// <summary>
+    /// Back-compat wrapper for the original internal helper. Existing callers
+    /// in this assembly continue to use this name; the implementation lives in
+    /// <see cref="BootstrapArgsBuilder.QuoteArgument"/>.
+    /// </summary>
+    internal static string QuoteArgument(string value) => BootstrapArgsBuilder.QuoteArgument(value);
 
     /// <inheritdoc />
     public Task TriggerStopAsync()
@@ -139,7 +134,8 @@ public class TriggerService : ITriggerService, IDisposable
 
     /// <summary>
     /// Writes the bootstrap flag file with custom arguments and waits for
-    /// CimianWatcher to consume it (indicating it launched MSU).
+    /// CimianWatcher to consume it (indicating it launched MSU). Concurrent
+    /// callers polling the same file all exit together once it disappears.
     /// </summary>
     private async Task TriggerViaFlagFileAsync(string arguments)
     {
@@ -156,14 +152,14 @@ public class TriggerService : ITriggerService, IDisposable
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
 
-            await File.WriteAllTextAsync(BootstrapFlagFile, content);
+            await File.WriteAllTextAsync(BootstrapFlagFile, content).ConfigureAwait(false);
             _logger?.LogInformation("Wrote bootstrap flag file with args: {Args}", arguments);
 
             // Wait for CimianWatcher to consume the flag file
             var elapsed = TimeSpan.Zero;
             while (File.Exists(BootstrapFlagFile) && elapsed < ServiceTimeout)
             {
-                await Task.Delay(PollInterval);
+                await Task.Delay(PollInterval).ConfigureAwait(false);
                 elapsed += PollInterval;
             }
 
@@ -171,11 +167,13 @@ public class TriggerService : ITriggerService, IDisposable
             {
                 _logger?.LogError("CimianWatcher did not consume flag file within {Timeout}s — is the service running?",
                     ServiceTimeout.TotalSeconds);
-                
+
                 // Clean up the stale flag file
                 try { File.Delete(BootstrapFlagFile); } catch { }
 
+                await ClearPendingItemsAsync().ConfigureAwait(false);
                 _isOperationRunning = false;
+                _currentOperationLabel = null;
                 OperationStatusChanged?.Invoke(this, false);
                 throw new InvalidOperationException(
                     "CimianWatcher service did not respond. Ensure the service is running: sc query CimianWatcher");
@@ -184,9 +182,12 @@ public class TriggerService : ITriggerService, IDisposable
             _logger?.LogInformation("CimianWatcher consumed flag file — managedsoftwareupdate is running");
 
             // The service has picked up the flag file and launched MSU.
-            // From here, completion is signaled by the progress pipe
-            // (ProgressMessageType.Complete) or the InstallInfo.yaml
-            // FileSystemWatcher — same as before.
+            // Clear the pending set so any subsequent click (after this point)
+            // starts a fresh batch instead of re-issuing items already handed
+            // off to the currently-running MSU. Completion of the install run
+            // itself is still signaled by the InstallInfo.yaml FileSystemWatcher
+            // and the StatusReporter pipe — same as before.
+            await ClearPendingItemsAsync().ConfigureAwait(false);
         }
         catch (InvalidOperationException)
         {
@@ -195,13 +196,30 @@ public class TriggerService : ITriggerService, IDisposable
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Failed to trigger via flag file");
+            await ClearPendingItemsAsync().ConfigureAwait(false);
             _isOperationRunning = false;
+            _currentOperationLabel = null;
             OperationStatusChanged?.Invoke(this, false);
+        }
+    }
+
+    private async Task ClearPendingItemsAsync()
+    {
+        await _flagFileLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _pendingItems.Clear();
+            _pendingItemOrder.Clear();
+        }
+        finally
+        {
+            _flagFileLock.Release();
         }
     }
 
     public void Dispose()
     {
+        _flagFileLock.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/gui/ManagedSoftwareCenter/ViewModels/ShellViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/ShellViewModel.cs
@@ -491,10 +491,13 @@ public partial class ShellViewModel : ObservableObject
     {
         if (isRunning)
         {
-            // Operation launched — show progress overlay
+            // Operation launched — show progress overlay. Prefer the contextual
+            // label the trigger service composed for this specific run (e.g.
+            // "Installing Gimp...") so users immediately see what they kicked
+            // off; fall back to the generic message for unattributed triggers.
             IsInstalling = true;
             CanRefresh = false;
-            ProgressMessage = "Checking for updates...";
+            ProgressMessage = _triggerService.CurrentOperationLabel ?? "Checking for updates...";
             ProgressDetail = string.Empty;
             ProgressPercent = 0;
             IsProgressIndeterminate = true;

--- a/shared/core/Services/BootstrapArgsBuilder.cs
+++ b/shared/core/Services/BootstrapArgsBuilder.cs
@@ -1,0 +1,209 @@
+// BootstrapArgsBuilder.cs - Pure helpers for composing CimianWatcher flag-file Args lines.
+// Kept in Cimian.Core so the GUI (ManagedSoftwareCenter) and unit tests can share the
+// quoting and merge logic without depending on WinUI.
+
+using System.Text;
+
+namespace Cimian.Core.Services;
+
+/// <summary>
+/// Pure, stateless helpers that compose the "Args:" line of the CimianWatcher
+/// bootstrap flag file. Concentrating the logic here lets unit tests cover the
+/// quoting and multi-item merge behavior without spinning up a TriggerService.
+/// </summary>
+public static class BootstrapArgsBuilder
+{
+    /// <summary>Args appended to every self-serve targeted install run.</summary>
+    public const string SelfServeTrailingArgs = "--no-preflight --show-status -vv";
+
+    /// <summary>
+    /// Quotes a single argument for safe round-trip through a flag-file "Args:"
+    /// line and ProcessStartInfo.Arguments. Follows the Windows C-runtime
+    /// convention: backslash-escape any embedded double-quote and any run of
+    /// backslashes immediately preceding a quote or the closing quote.
+    /// Throws on control characters that cannot legally appear in an item name.
+    /// </summary>
+    public static string QuoteArgument(string value)
+    {
+        if (value == null) throw new ArgumentNullException(nameof(value));
+        if (value.IndexOfAny(new[] { '\r', '\n', '\0' }) >= 0)
+        {
+            throw new ArgumentException("Argument contains control characters", nameof(value));
+        }
+
+        // Fast path: no whitespace, no quotes, no trailing backslash — no quoting needed.
+        if (value.Length > 0
+            && value.IndexOfAny(new[] { ' ', '\t', '"' }) < 0
+            && value[value.Length - 1] != '\\')
+        {
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+        var backslashes = 0;
+        foreach (var c in value)
+        {
+            if (c == '\\')
+            {
+                backslashes++;
+            }
+            else if (c == '"')
+            {
+                sb.Append('\\', backslashes * 2 + 1);
+                sb.Append('"');
+                backslashes = 0;
+            }
+            else
+            {
+                if (backslashes > 0) sb.Append('\\', backslashes);
+                backslashes = 0;
+                sb.Append(c);
+            }
+        }
+        if (backslashes > 0) sb.Append('\\', backslashes * 2);
+        sb.Append('"');
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Builds the full Args line for a self-serve targeted install:
+    /// "--item N1 --item N2 ... --no-preflight --show-status -vv".
+    /// Order of items is preserved from the input; duplicates (case-insensitive)
+    /// are dropped so callers can pass raw click history without preprocessing.
+    /// </summary>
+    public static string BuildSelfServeInstallArgs(IEnumerable<string> itemNames)
+    {
+        if (itemNames == null) throw new ArgumentNullException(nameof(itemNames));
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var sb = new StringBuilder();
+        foreach (var name in itemNames)
+        {
+            if (string.IsNullOrWhiteSpace(name)) continue;
+            if (!seen.Add(name)) continue;
+            if (sb.Length > 0) sb.Append(' ');
+            sb.Append("--item ");
+            sb.Append(QuoteArgument(name));
+        }
+
+        if (sb.Length == 0)
+        {
+            throw new ArgumentException("At least one item name is required", nameof(itemNames));
+        }
+
+        sb.Append(' ');
+        sb.Append(SelfServeTrailingArgs);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Parses an existing "Args:" line (as written by a previous flag-file
+    /// write) and extracts the names that followed each "--item" token.
+    /// Returns an empty list if no --item tokens are present or the line is null/blank.
+    /// </summary>
+    /// <remarks>
+    /// This is intentionally tolerant: any tokens after --item that are themselves
+    /// switches (start with --) are ignored. Quoted names produced by
+    /// <see cref="QuoteArgument"/> are unquoted using the same Windows C-runtime
+    /// rules.
+    /// </remarks>
+    public static IReadOnlyList<string> ExtractItemNames(string? argsLine)
+    {
+        var result = new List<string>();
+        if (string.IsNullOrWhiteSpace(argsLine)) return result;
+
+        var tokens = TokenizeWindowsCommandLine(argsLine);
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            if (!string.Equals(tokens[i], "--item", StringComparison.Ordinal)) continue;
+            if (i + 1 >= tokens.Count) break;
+            var next = tokens[i + 1];
+            if (next.StartsWith("--", StringComparison.Ordinal)) continue;
+            result.Add(next);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Tokenizes a Windows command-line argument string using the C-runtime
+    /// rules implemented by <see cref="QuoteArgument"/> (backslash-quote and
+    /// run-of-backslashes-before-quote escaping). Pure inverse of QuoteArgument
+    /// for the values it produces.
+    /// </summary>
+    internal static IReadOnlyList<string> TokenizeWindowsCommandLine(string input)
+    {
+        var tokens = new List<string>();
+        if (string.IsNullOrEmpty(input)) return tokens;
+
+        var current = new StringBuilder();
+        var inQuotes = false;
+        var hasToken = false;
+        var i = 0;
+
+        while (i < input.Length)
+        {
+            var c = input[i];
+
+            if (c == '\\')
+            {
+                var backslashes = 0;
+                while (i < input.Length && input[i] == '\\')
+                {
+                    backslashes++;
+                    i++;
+                }
+
+                if (i < input.Length && input[i] == '"')
+                {
+                    current.Append('\\', backslashes / 2);
+                    if (backslashes % 2 == 1)
+                    {
+                        current.Append('"');
+                        i++;
+                    }
+                    else
+                    {
+                        inQuotes = !inQuotes;
+                        i++;
+                    }
+                    hasToken = true;
+                }
+                else
+                {
+                    current.Append('\\', backslashes);
+                    hasToken = true;
+                }
+            }
+            else if (c == '"')
+            {
+                inQuotes = !inQuotes;
+                hasToken = true;
+                i++;
+            }
+            else if (!inQuotes && (c == ' ' || c == '\t'))
+            {
+                if (hasToken)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                    hasToken = false;
+                }
+                i++;
+            }
+            else
+            {
+                current.Append(c);
+                hasToken = true;
+                i++;
+            }
+        }
+
+        if (hasToken)
+        {
+            tokens.Add(current.ToString());
+        }
+
+        return tokens;
+    }
+}

--- a/tests/Shared/BootstrapArgsBuilderTests.cs
+++ b/tests/Shared/BootstrapArgsBuilderTests.cs
@@ -1,0 +1,117 @@
+using Cimian.Core.Services;
+using Xunit;
+
+namespace Cimian.Tests.Shared;
+
+public class BootstrapArgsBuilderTests
+{
+    [Theory]
+    [InlineData("Gimp", "Gimp")]
+    [InlineData("VS Code", "\"VS Code\"")]
+    [InlineData("Has\"Quote", "\"Has\\\"Quote\"")]
+    [InlineData("trailing\\", "\"trailing\\\\\"")]
+    [InlineData("a\\\\b", "a\\\\b")]
+    public void QuoteArgument_FollowsWindowsCRuntimeRules(string input, string expected)
+    {
+        Assert.Equal(expected, BootstrapArgsBuilder.QuoteArgument(input));
+    }
+
+    [Theory]
+    [InlineData("hi\nthere")]
+    [InlineData("hi\rthere")]
+    [InlineData("nul\0byte")]
+    public void QuoteArgument_RejectsControlCharacters(string input)
+    {
+        Assert.Throws<ArgumentException>(() => BootstrapArgsBuilder.QuoteArgument(input));
+    }
+
+    [Fact]
+    public void BuildSelfServeInstallArgs_SingleItem_AppendsTrailingArgs()
+    {
+        var args = BootstrapArgsBuilder.BuildSelfServeInstallArgs(new[] { "Gimp" });
+        Assert.Equal("--item Gimp --no-preflight --show-status -vv", args);
+    }
+
+    [Fact]
+    public void BuildSelfServeInstallArgs_MultipleItems_EmitsItemFlagPerEntry()
+    {
+        var args = BootstrapArgsBuilder.BuildSelfServeInstallArgs(new[] { "Gimp", "Cyberduck" });
+        Assert.Equal("--item Gimp --item Cyberduck --no-preflight --show-status -vv", args);
+    }
+
+    [Fact]
+    public void BuildSelfServeInstallArgs_QuotesNamesWithSpaces()
+    {
+        var args = BootstrapArgsBuilder.BuildSelfServeInstallArgs(new[] { "VS Code", "Gimp" });
+        Assert.Equal("--item \"VS Code\" --item Gimp --no-preflight --show-status -vv", args);
+    }
+
+    [Fact]
+    public void BuildSelfServeInstallArgs_DropsDuplicatesCaseInsensitively()
+    {
+        var args = BootstrapArgsBuilder.BuildSelfServeInstallArgs(new[] { "Gimp", "gimp", "GIMP" });
+        Assert.Equal("--item Gimp --no-preflight --show-status -vv", args);
+    }
+
+    [Fact]
+    public void BuildSelfServeInstallArgs_SkipsWhitespaceOnlyEntries()
+    {
+        var args = BootstrapArgsBuilder.BuildSelfServeInstallArgs(new[] { "  ", "Gimp", "" });
+        Assert.Equal("--item Gimp --no-preflight --show-status -vv", args);
+    }
+
+    [Fact]
+    public void BuildSelfServeInstallArgs_EmptyInput_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            BootstrapArgsBuilder.BuildSelfServeInstallArgs(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void ExtractItemNames_SingleItem_ReturnsName()
+    {
+        var names = BootstrapArgsBuilder.ExtractItemNames(
+            "--item Gimp --no-preflight --show-status -vv");
+        Assert.Equal(new[] { "Gimp" }, names);
+    }
+
+    [Fact]
+    public void ExtractItemNames_MultipleItems_PreservesOrder()
+    {
+        var names = BootstrapArgsBuilder.ExtractItemNames(
+            "--item Gimp --item Cyberduck --no-preflight --show-status -vv");
+        Assert.Equal(new[] { "Gimp", "Cyberduck" }, names);
+    }
+
+    [Fact]
+    public void ExtractItemNames_QuotedNames_UnquotesCorrectly()
+    {
+        var names = BootstrapArgsBuilder.ExtractItemNames(
+            "--item \"VS Code\" --item Gimp --no-preflight");
+        Assert.Equal(new[] { "VS Code", "Gimp" }, names);
+    }
+
+    [Fact]
+    public void ExtractItemNames_IgnoresDanglingItemFlag()
+    {
+        var names = BootstrapArgsBuilder.ExtractItemNames("--item Gimp --item --no-preflight");
+        Assert.Equal(new[] { "Gimp" }, names);
+    }
+
+    [Fact]
+    public void ExtractItemNames_EmptyInput_ReturnsEmpty()
+    {
+        Assert.Empty(BootstrapArgsBuilder.ExtractItemNames(null));
+        Assert.Empty(BootstrapArgsBuilder.ExtractItemNames(""));
+        Assert.Empty(BootstrapArgsBuilder.ExtractItemNames("   "));
+    }
+
+    [Fact]
+    public void ExtractItemNames_RoundTripsBuildSelfServeInstallArgs()
+    {
+        var original = new[] { "Gimp", "VS Code", "Has\"Quote", "trailing\\" };
+        var args = BootstrapArgsBuilder.BuildSelfServeInstallArgs(original);
+        var extracted = BootstrapArgsBuilder.ExtractItemNames(args);
+        Assert.Equal(original, extracted);
+    }
+}


### PR DESCRIPTION
## Summary

- **Multi-item race.** `TriggerService` used to overwrite `.cimian.bootstrap` on every click, so a second Install click within CimianWatcher`s 10s poll window would clobber the first `--item` value. Pending names are now held in an in-memory set; each click rewrites the flag file with the full `--item N1 --item N2 ...` list and the set clears once CimianWatcher consumes the file.
- **Progress label.** The shell overlay always said "Checking for updates..." regardless of what the user actually triggered. `TriggerService.CurrentOperationLabel` now carries e.g. `"Installing Gimp, Cyberduck..."` and `ShellViewModel.OnOperationStatusChanged` reads it before falling back.
- Quoting/merge logic moved to `Cimian.Core.Services.BootstrapArgsBuilder` so it is reachable from unit tests without dragging WinUI into the test project. 20 new xUnit cases cover `QuoteArgument` round-trip, `--item` flag emission, duplicate-drop, and `BuildSelfServeInstallArgs` <-> `ExtractItemNames` round-trip.

## Test plan
- [x] `dotnet build` clean on `Cimian.Core`, `Cimian.GUI.ManagedSoftwareCenter`, `Cimian.Tests`
- [x] `dotnet test --filter BootstrapArgsBuilder` -> 20/20 pass
- [x] Full suite: 722 pass, 1 pre-existing unrelated failure (`Cimiimport.ConfigurationServiceTests.GetDefaultConfig_ReturnsValidDefaults` depends on resolving a sibling deployment checkout and fails the same way on `main`)
- [ ] Manual: click Install on two optional items within 10s in MSC -> single flag-file write with both `--item` flags, single MSU run handles both
- [ ] Manual: progress overlay shows item-specific label instead of "Checking for updates..."