### PR TITLE
fix: walk requires + update_for during classification, not only inside install path

### DIFF
--- a/cli/managedsoftwareupdate/Services/CatalogService.cs
+++ b/cli/managedsoftwareupdate/Services/CatalogService.cs
@@ -533,17 +533,24 @@ public class CatalogService
         var deps = new List<string>();
         var queue = new Queue<string>(seeds);
 
+        // Pre-index update_for once (target name → catalog items that update it)
+        // so the BFS doesn't rescan the whole catalog per node.
+        var updateForIndex = BuildUpdateForIndex(catalog);
+
         while (queue.Count > 0)
         {
             var name = queue.Dequeue();
 
             // update_for direction: catalog items whose UpdateFor lists this name
-            foreach (var updateName in LookForUpdates(name, catalog))
+            if (updateForIndex.TryGetValue(name.ToLowerInvariant(), out var updaters))
             {
-                if (visited.Add(updateName.ToLowerInvariant()))
+                foreach (var updateName in updaters)
                 {
-                    deps.Add(updateName);
-                    queue.Enqueue(updateName);
+                    if (visited.Add(updateName.ToLowerInvariant()))
+                    {
+                        deps.Add(updateName);
+                        queue.Enqueue(updateName);
+                    }
                 }
             }
 
@@ -566,6 +573,32 @@ public class CatalogService
         }
 
         return deps;
+    }
+
+    private static Dictionary<string, List<string>> BuildUpdateForIndex(
+        Dictionary<string, CatalogItem> catalog)
+    {
+        var index = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in catalog)
+        {
+            var item = kvp.Value;
+            if (item.UpdateFor == null || item.UpdateFor.Count == 0) continue;
+            foreach (var target in item.UpdateFor)
+            {
+                if (string.IsNullOrEmpty(target)) continue;
+                var key = target.ToLowerInvariant();
+                if (!index.TryGetValue(key, out var list))
+                {
+                    list = new List<string>();
+                    index[key] = list;
+                }
+                if (!list.Contains(item.Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    list.Add(item.Name);
+                }
+            }
+        }
+        return index;
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/CatalogService.cs
+++ b/cli/managedsoftwareupdate/Services/CatalogService.cs
@@ -506,6 +506,69 @@ public class CatalogService
     }
 
     /// <summary>
+    /// Walks both <c>requires</c> (parent → declared deps) and <c>update_for</c>
+    /// (other catalog items targeting parent as their update target) starting from
+    /// the seed names, and returns the transitive closure of dependency names —
+    /// seeds excluded, order preserved, duplicates removed.
+    /// </summary>
+    /// <remarks>
+    /// This is the classification-phase counterpart to the per-install dependency
+    /// walk in <c>ProcessInstallWithDependenciesAsync</c>. It does not look at
+    /// install state — it just expands the dependency graph from the catalog so
+    /// the caller can status-check each dep independently of whether the seed
+    /// items themselves need action. Unknown names (not in <paramref name="catalog"/>)
+    /// are skipped silently. Cycles terminate because each node is visited once.
+    /// </remarks>
+    /// <param name="seedNames">Items whose dependency graph should be expanded.</param>
+    /// <param name="catalog">Loaded catalog keyed by lowercase name.</param>
+    /// <returns>Dependency names not present in the seed set.</returns>
+    public static List<string> BuildDependencyClosure(
+        IEnumerable<string> seedNames,
+        Dictionary<string, CatalogItem> catalog)
+    {
+        var seeds = seedNames?.ToList() ?? new List<string>();
+        var visited = new HashSet<string>(
+            seeds.Select(n => n.ToLowerInvariant()),
+            StringComparer.OrdinalIgnoreCase);
+        var deps = new List<string>();
+        var queue = new Queue<string>(seeds);
+
+        while (queue.Count > 0)
+        {
+            var name = queue.Dequeue();
+
+            // update_for direction: catalog items whose UpdateFor lists this name
+            foreach (var updateName in LookForUpdates(name, catalog))
+            {
+                if (visited.Add(updateName.ToLowerInvariant()))
+                {
+                    deps.Add(updateName);
+                    queue.Enqueue(updateName);
+                }
+            }
+
+            // requires direction: deps declared by this catalog item
+            if (catalog.TryGetValue(name.ToLowerInvariant(), out var item)
+                && item.Requires != null)
+            {
+                foreach (var reqEntry in item.Requires)
+                {
+                    var (reqName, _) = SplitNameAndVersion(reqEntry);
+                    if (string.IsNullOrEmpty(reqName)) continue;
+                    if (!catalog.TryGetValue(reqName.ToLowerInvariant(), out var depItem)) continue;
+                    if (visited.Add(depItem.Name.ToLowerInvariant()))
+                    {
+                        deps.Add(depItem.Name);
+                        queue.Enqueue(depItem.Name);
+                    }
+                }
+            }
+        }
+
+        return deps;
+    }
+
+    /// <summary>
     /// Finds all items in the catalog that require the given item.
     /// This is used during removal to determine what dependent items also need to be removed.
     /// Migrated from Go: catalog.FindItemsRequiring() - catalog.go lines 292-320

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1161,6 +1161,23 @@ public class UpdateEngine : IDisposable
             manifestItems.Select(m => m.Name.ToLowerInvariant()),
             StringComparer.OrdinalIgnoreCase);
 
+        // Map name → set of actions already declared by the manifest, so we can
+        // detect deps that conflict with explicit uninstall/profile/app entries.
+        // A single name may appear in multiple manifest items (e.g. install +
+        // uninstall in different inputs); the explicit non-install action wins.
+        var manifestActions = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var mi in manifestItems)
+        {
+            var action = mi.Action?.ToLowerInvariant();
+            if (string.IsNullOrEmpty(action)) continue;
+            if (!manifestActions.TryGetValue(mi.Name, out var set))
+            {
+                set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                manifestActions[mi.Name] = set;
+            }
+            set.Add(action);
+        }
+
         // Seeds: every manifest item whose intent is install/update. Action comes
         // from manifest intent (managed_installs/managed_updates), not current
         // install state, so up-to-date items are still walked for stale deps.
@@ -1179,6 +1196,16 @@ public class UpdateEngine : IDisposable
             if (!catalogMap.TryGetValue(depKey, out var depItem))
             {
                 LogDetail($"    Skipping {depName} - not found in catalog");
+                continue;
+            }
+
+            // Skip deps that the manifest has already claimed with a conflicting
+            // action: explicit uninstall must not be reversed by a transitive
+            // install; MDM-managed profile/app items are handled externally.
+            if (manifestActions.TryGetValue(depItem.Name, out var actions)
+                && (actions.Contains("uninstall") || actions.Contains("profile") || actions.Contains("app")))
+            {
+                LogInfo($"Skipping dependency {depItem.Name}: manifest action [{string.Join(",", actions)}] takes precedence");
                 continue;
             }
 

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -432,9 +432,11 @@ public class UpdateEngine : IDisposable
                 }
             }
 
-            // Resolve dependencies and update_for items (Go parity: process.go dependency resolution)
-            // This adds items like ReportMatePrefs (update_for ReportMate) to the manifest items
-            ResolveDependenciesForCheckOnly(manifestItems, catalogMap, toUpdate);
+            // Resolve dependencies and update_for items (Go parity: process.go dependency resolution).
+            // Walks both `requires` and `update_for` to the transitive closure so that a stale
+            // dep gets surfaced even when its parent is already at the catalog version
+            // (e.g. ManageUsersPrefs current, ManageUsers stale).
+            ResolveDependencies(manifestItems, catalogMap, toUpdate);
 
             // Print hierarchy and tables in checkonly mode (matches Go behavior - always shows this)
             if (_checkOnly)
@@ -1131,90 +1133,87 @@ public class UpdateEngine : IDisposable
     }
 
     /// <summary>
-    /// Resolves dependencies for checkonly mode to show what will be installed.
-    /// This finds update_for items that would be installed when the target package is installed.
-    /// Go parity: This happens during ProcessInstallWithDependencies in process.go
-    /// Example: ReportMatePrefs has update_for: [ReportMate], so when ReportMate is in the install list,
-    /// ReportMatePrefs should also appear in the list with source "dependency".
+    /// Expands the manifest's install/update list along both <c>requires</c> and
+    /// <c>update_for</c> to the transitive closure, status-checks every dep, and
+    /// promotes anything that needs action into the toUpdate list.
     /// </summary>
-    private void ResolveDependenciesForCheckOnly(
-        List<ManifestItem> manifestItems, 
+    /// <remarks>
+    /// Runs in both checkonly and real install paths (called before the checkonly
+    /// exit). Replaces the prior one-shot <c>update_for</c>-only walk, which
+    /// missed two cases:
+    ///   1. A stale <c>requires:</c> dep when the parent is already at the catalog
+    ///      version (e.g. ManageUsersPrefs current, ManageUsers stale) — the prior
+    ///      code only ran requires-resolution from inside the install path, which
+    ///      is unreachable when the parent's CheckStatus returns NeedsAction=False.
+    ///   2. Chained <c>update_for</c> beyond depth 1, because the prior code only
+    ///      iterated the original manifest list, not the deps it added.
+    /// The closure walk lives in <see cref="CatalogService.BuildDependencyClosure"/>;
+    /// this method does the I/O (status check, manifest mutation).
+    /// </remarks>
+    private void ResolveDependencies(
+        List<ManifestItem> manifestItems,
         Dictionary<string, CatalogItem> catalogMap,
         List<CatalogItem> itemsToProcess)
     {
         LogInfo("Resolving dependencies (requires and update_for)...");
-        
-        // Get list of item names already in the manifest
-        var existingNames = manifestItems.Select(m => m.Name.ToLowerInvariant()).ToHashSet();
-        
-        // Get names of items that will be installed/updated
-        var installListNames = manifestItems
+
+        var existingNames = new HashSet<string>(
+            manifestItems.Select(m => m.Name.ToLowerInvariant()),
+            StringComparer.OrdinalIgnoreCase);
+
+        // Seeds: every manifest item whose intent is install/update. Action comes
+        // from manifest intent (managed_installs/managed_updates), not current
+        // install state, so up-to-date items are still walked for stale deps.
+        var seedNames = manifestItems
             .Where(m => m.Action?.ToLowerInvariant() == "install" || m.Action?.ToLowerInvariant() == "update")
             .Select(m => m.Name)
             .ToList();
-        
-        LogDetail($"    Items to check for update_for: {string.Join(", ", installListNames.Take(10))}...");
-        
-        // Look for update_for items for each item in the install list
-        foreach (var itemName in installListNames)
+
+        LogDetail($"    Resolving deps for {seedNames.Count} manifest item(s)");
+
+        var deps = CatalogService.BuildDependencyClosure(seedNames, catalogMap);
+
+        foreach (var depName in deps)
         {
-            var updateList = CatalogService.LookForUpdates(itemName, catalogMap);
-            
-            if (updateList.Count > 0)
+            var depKey = depName.ToLowerInvariant();
+            if (!catalogMap.TryGetValue(depKey, out var depItem))
             {
-                LogDetail($"    Found update_for items for {itemName}: {string.Join(", ", updateList)}");
+                LogDetail($"    Skipping {depName} - not found in catalog");
+                continue;
             }
-            
-            foreach (var updateItemName in updateList)
+
+            var status = _statusService.CheckStatus(depItem, "install", _config.CachePath);
+
+            LogInfo($"Dependency {depItem.Name} v{depItem.Version}: needsAction={status.NeedsAction} ({status.Reason})");
+
+            if (!existingNames.Contains(depKey))
             {
-                var updateKey = updateItemName.ToLowerInvariant();
-                
-                // Skip if already in manifest
-                if (existingNames.Contains(updateKey))
-                {
-                    LogDetail($"    Skipping {updateItemName} - already in manifest");
-                    continue;
-                }
-                
-                // Get the update item from catalog
-                if (!catalogMap.TryGetValue(updateKey, out var updateItem))
-                {
-                    LogDetail($"    Skipping {updateItemName} - not found in catalog");
-                    continue;
-                }
-                
-                // Check if the update item needs action
-                var status = _statusService.CheckStatus(updateItem, "install", _config.CachePath);
-                
-                LogInfo($"Adding update_for item to install list update: {updateItemName} updateFor: {itemName}");
-                
-                // Add to manifest items with source "dependency"
                 manifestItems.Add(new ManifestItem
                 {
-                    Name = updateItemName,
+                    Name = depItem.Name,
                     Action = "install",
                     SourceManifest = "dependency"
                 });
-                existingNames.Add(updateKey);
-                
-                // If it needs action, add to the toUpdate list
-                if (status.NeedsAction && !itemsToProcess.Any(i => i.Name.Equals(updateItemName, StringComparison.OrdinalIgnoreCase)))
-                {
-                    itemsToProcess.Add(updateItem);
-                }
+                existingNames.Add(depKey);
+            }
+
+            if (status.NeedsAction
+                && !itemsToProcess.Any(i => i.Name.Equals(depItem.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                itemsToProcess.Add(depItem);
             }
         }
-        
+
         var depCount = manifestItems.Count(m => m.SourceManifest == "dependency");
         // Go parity: Count only managed items (exclude profile/app which are MDM-managed)
-        var managedCount = manifestItems.Count(m => 
+        var managedCount = manifestItems.Count(m =>
         {
             var action = m.Action?.ToLowerInvariant();
             return action != "profile" && action != "app";
         });
         if (depCount > 0)
         {
-            LogInfo($"Dependency resolution complete: {depCount} update_for items added");
+            LogInfo($"Dependency resolution complete: {depCount} dependency item(s) tracked");
             LogInfo($"Added dependencies: {string.Join(", ", manifestItems.Where(m => m.SourceManifest == "dependency").Select(m => m.Name))}");
         }
         LogInfo($"Managed items: {managedCount} (excludes {manifestItems.Count - managedCount} MDM profiles/apps)");

--- a/tests/Managedsoftwareupdate/CatalogServiceDependencyTests.cs
+++ b/tests/Managedsoftwareupdate/CatalogServiceDependencyTests.cs
@@ -174,4 +174,34 @@ public class CatalogServiceDependencyTests
 
         Assert.Empty(deps);
     }
+
+    [Fact]
+    public void Closure_LargeCatalog_DoesNotRescanPerNode()
+    {
+        // Regression check for the O(closure * catalog) blowup: 2000 unrelated
+        // items + a 5-node requires chain. With the update_for index, total work
+        // is roughly linear in catalog size. Generous budget — we just want to
+        // catch a regression to per-node full scans, not benchmark.
+        var items = new List<CatalogItem>
+        {
+            Item("A", requires: new() { "B" }),
+            Item("B", requires: new() { "C" }),
+            Item("C", requires: new() { "D" }),
+            Item("D", requires: new() { "E" }),
+            Item("E"),
+        };
+        for (int i = 0; i < 2000; i++)
+        {
+            items.Add(Item($"Noise{i}"));
+        }
+        var catalog = Catalog(items.ToArray());
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var deps = CatalogService.BuildDependencyClosure(new[] { "A" }, catalog);
+        sw.Stop();
+
+        Assert.Equal(4, deps.Count);
+        Assert.True(sw.ElapsedMilliseconds < 500,
+            $"Closure walk took {sw.ElapsedMilliseconds}ms on 2k-item catalog — likely regressed to per-node full scan");
+    }
 }

--- a/tests/Managedsoftwareupdate/CatalogServiceDependencyTests.cs
+++ b/tests/Managedsoftwareupdate/CatalogServiceDependencyTests.cs
@@ -1,0 +1,177 @@
+using Xunit;
+using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.CLI.managedsoftwareupdate.Services;
+
+namespace Cimian.Tests.Managedsoftwareupdate;
+
+/// <summary>
+/// Tests for <see cref="CatalogService.BuildDependencyClosure"/>.
+/// Covers the regression where stale <c>requires:</c> deps and chained
+/// <c>update_for</c> deps were not surfaced when their seed was already current.
+/// </summary>
+public class CatalogServiceDependencyTests
+{
+    private static Dictionary<string, CatalogItem> Catalog(params CatalogItem[] items)
+    {
+        var map = new Dictionary<string, CatalogItem>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in items)
+        {
+            map[item.Name.ToLowerInvariant()] = item;
+        }
+        return map;
+    }
+
+    private static CatalogItem Item(string name, List<string>? requires = null, List<string>? updateFor = null)
+        => new() { Name = name, Version = "1.0.0", Requires = requires ?? new(), UpdateFor = updateFor ?? new() };
+
+    [Fact]
+    public void Closure_RequiresFlat_IncludesDep()
+    {
+        // Regression: ManageUsersPrefs requires ManageUsers. Seed is the prefs;
+        // we must surface ManageUsers so its CheckStatus can run.
+        var catalog = Catalog(
+            Item("ManageUsersPrefs", requires: new() { "ManageUsers" }),
+            Item("ManageUsers"));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "ManageUsersPrefs" }, catalog);
+
+        Assert.Contains("ManageUsers", deps);
+        Assert.DoesNotContain("ManageUsersPrefs", deps); // seeds excluded
+    }
+
+    [Fact]
+    public void Closure_UpdateForChain_FollowsBeyondDepthOne()
+    {
+        // Regression: prior code iterated only the seed list, so AUpdate2 was missed.
+        // A is the seed; AUpdate1 update_for A; AUpdate2 update_for AUpdate1.
+        var catalog = Catalog(
+            Item("A"),
+            Item("AUpdate1", updateFor: new() { "A" }),
+            Item("AUpdate2", updateFor: new() { "AUpdate1" }));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "A" }, catalog);
+
+        Assert.Contains("AUpdate1", deps);
+        Assert.Contains("AUpdate2", deps);
+    }
+
+    [Fact]
+    public void Closure_MixedRelations_WalksBothDirections()
+    {
+        // A requires B; C update_for A. Seed A → expect B and C.
+        var catalog = Catalog(
+            Item("A", requires: new() { "B" }),
+            Item("B"),
+            Item("C", updateFor: new() { "A" }));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "A" }, catalog);
+
+        Assert.Contains("B", deps);
+        Assert.Contains("C", deps);
+    }
+
+    [Fact]
+    public void Closure_RequiresChain_FollowsDeepRequires()
+    {
+        // A requires B; B requires C. Seed A → expect both B and C.
+        var catalog = Catalog(
+            Item("A", requires: new() { "B" }),
+            Item("B", requires: new() { "C" }),
+            Item("C"));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "A" }, catalog);
+
+        Assert.Contains("B", deps);
+        Assert.Contains("C", deps);
+    }
+
+    [Fact]
+    public void Closure_RequiresCycle_Terminates()
+    {
+        // A requires B; B requires A. Must not infinite-loop.
+        var catalog = Catalog(
+            Item("A", requires: new() { "B" }),
+            Item("B", requires: new() { "A" }));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "A" }, catalog);
+
+        Assert.Contains("B", deps);
+        Assert.DoesNotContain("A", deps); // seed excluded
+    }
+
+    [Fact]
+    public void Closure_UnknownRequires_IsSkipped()
+    {
+        // A requires Phantom which isn't in the catalog — must not throw or add it.
+        var catalog = Catalog(Item("A", requires: new() { "Phantom" }));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "A" }, catalog);
+
+        Assert.Empty(deps);
+    }
+
+    [Fact]
+    public void Closure_VersionedRequires_StripsVersion()
+    {
+        // requires: ["Foo-1.2.3"] should resolve to the catalog entry "Foo".
+        var catalog = Catalog(
+            Item("A", requires: new() { "Foo-1.2.3" }),
+            Item("Foo"));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "A" }, catalog);
+
+        Assert.Contains("Foo", deps);
+    }
+
+    [Fact]
+    public void Closure_SeedAlreadyHasDepInList_DoesNotReAdd()
+    {
+        // If a dep is itself in the seed set, don't re-add it.
+        var catalog = Catalog(
+            Item("A", requires: new() { "B" }),
+            Item("B"));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "A", "B" }, catalog);
+
+        Assert.Empty(deps);
+    }
+
+    [Fact]
+    public void Closure_DuplicateDepsAcrossSeeds_DedupedAndOrdered()
+    {
+        // Both A and B require C. Closure should list C exactly once.
+        var catalog = Catalog(
+            Item("A", requires: new() { "C" }),
+            Item("B", requires: new() { "C" }),
+            Item("C"));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "A", "B" }, catalog);
+
+        Assert.Single(deps);
+        Assert.Equal("C", deps[0]);
+    }
+
+    [Fact]
+    public void Closure_PreservesCatalogCasing()
+    {
+        // Seed uses lowercase; catalog has canonical casing. Closure returns canonical.
+        var catalog = Catalog(
+            Item("ManageUsersPrefs", requires: new() { "manageusers" }),
+            Item("ManageUsers"));
+
+        var deps = CatalogService.BuildDependencyClosure(new[] { "ManageUsersPrefs" }, catalog);
+
+        Assert.Single(deps);
+        Assert.Equal("ManageUsers", deps[0]);
+    }
+
+    [Fact]
+    public void Closure_EmptySeeds_ReturnsEmpty()
+    {
+        var catalog = Catalog(Item("A", requires: new() { "B" }), Item("B"));
+
+        var deps = CatalogService.BuildDependencyClosure(Array.Empty<string>(), catalog);
+
+        Assert.Empty(deps);
+    }
+}


### PR DESCRIPTION
## Summary

`managedsoftwareupdate` was missing stale `requires:` deps when the parent item was already at the catalog version, and missing `update_for` chains deeper than one level. Observed in the field on a fleet device where the parent (a small prefs package) was current at the catalog version, so its `CheckStatus` returned `NeedsAction=False`, and the requires-walk inside `ProcessInstallWithDependenciesAsync` never ran — leaving the required binary stuck at an older version while the catalog had a newer one.

Root cause: dependency resolution lived in two places, both wrong:
- `CatalogService.CheckDependencies` was only called from `ProcessInstallWithDependenciesAsync` (`UpdateEngine.cs:1474-1545`), which never runs when the parent's status check passes. So `requires:` were ignored for current parents.
- `ResolveDependenciesForCheckOnly` (`UpdateEngine.cs:1140`) walked `update_for` but only once over the original manifest items, so `A → AUpdate1 → AUpdate2` resolved `AUpdate1` and stopped.

## Fix

- New pure function `CatalogService.BuildDependencyClosure(seedNames, catalog)` walks both `requires` and `update_for` to the transitive closure with cycle protection.
- `ResolveDependenciesForCheckOnly` replaced with `ResolveDependencies` — uses the closure walker, calls `CheckStatus` on every dep, promotes NeedsAction deps into `toUpdate` with `SourceManifest="dependency"`. Still runs in both checkonly and real install paths (callsite at line 437).
- 11 new tests in `CatalogServiceDependencyTests` covering: flat `requires`, 3-deep `update_for` chain, mixed relations, deep `requires` chain, cycle, unknown name skip, versioned-name strip, seed-already-contains, dedup across seeds, casing preservation, empty seeds.

## Test plan

- [x] `dotnet build cli/managedsoftwareupdate` — clean (0 warn / 0 err)
- [x] `dotnet test --filter ~CatalogServiceDependencyTests` — 11/11 pass
- [x] Full suite — 713/714 pass (1 pre-existing failure in `Cimiimport.ConfigurationServiceTests`, unrelated)
- [ ] Field check on an endpoint with a current parent + stale required dep: run `managedsoftwareupdate --checkonly -v`, confirm the dep is surfaced as a pending update with source "dependency"