### PR TITLE
build: brace $Architecture in payload-size log to avoid PS scope parse [hotfix]

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -858,7 +858,10 @@ function Build-MsiPackage {
     # 250 MB soft cap just because the displayed value rounds down to 250.0.
     $payloadBytes = (Get-ChildItem -Path $payloadDir -Recurse -File | Measure-Object Length -Sum).Sum
     $payloadMB = [math]::Round($payloadBytes / 1MB, 1)
-    Write-BuildLog "MSI payload size for $Architecture: $payloadMB MB" "INFO"
+    # ${Architecture}: — braces are required so PowerShell doesn't try to parse
+    # "Architecture:" as a scope qualifier (Variable / Env: / etc.) and fail at
+    # tokenize time. Without the braces the build fails before it ever runs.
+    Write-BuildLog "MSI payload size for ${Architecture}: $payloadMB MB" "INFO"
     $topTypes = Get-ChildItem -Path $payloadDir -Recurse -File |
         Group-Object Extension |
         Select-Object @{N='Ext';E={$_.Name}}, @{N='Count';E={$_.Count}}, @{N='MB';E={[math]::Round((($_.Group | Measure-Object Length -Sum).Sum/1MB),1)}} |


### PR DESCRIPTION
## Summary
PR #42 introduced `Write-BuildLog "MSI payload size for $Architecture: $payloadMB MB"` at `build.ps1:861`. PowerShell tokenizes `$Architecture:` as a scope-qualified variable (`Variable:`, `Env:`, etc.) and aborts with a ParserError before the script runs. The `v0.0.6` release tag fired and failed at build seconds in.

Wrapping the variable as `${Architecture}` delimits the name and lets the literal colon through. Validated locally with `[Parser]::ParseFile`.

## Test plan
- [x] `[Parser]::ParseFile build.ps1` -> 0 errors
- [ ] Merge and let v0.0.6 (or v0.0.7) release tag rebuild