### PR TITLE
loopguard: skip counters when postinstall self-reports via CIMIAN-WARNING

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1642,8 +1642,18 @@ public class UpdateEngine : IDisposable
                 Cimian.Core.Models.DetectionMethod.None,
                 item.Version);
 
-            // Record successful install for loop guard tracking
-            _loopGuard?.RecordAttempt(item.Name, item.Version, success: true, ComputeCatalogFingerprint(item));
+            // Record successful install for loop guard tracking. When the postinstall
+            // self-reported a Warning via the CIMIAN-WARNING marker, this isn't a real
+            // install attempt for loop-detection purposes — the script ran successfully
+            // but the system is in a known-bad state awaiting external remediation
+            // (e.g. SecureBoot, BIOS password). Counting these would suppress packages
+            // whose only job is to keep flagging the unremediated state.
+            _loopGuard?.RecordAttempt(
+                item.Name,
+                item.Version,
+                success: true,
+                ComputeCatalogFingerprint(item),
+                selfReportedWarning: warningMessage != null);
 
             // Add to installed items
             if (!installedItems.Contains(item.Name, StringComparer.OrdinalIgnoreCase))

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -202,10 +202,27 @@ public class LoopGuard
     /// <summary>
     /// Records an install attempt (call after InstallerService.InstallAsync completes).
     /// catalogFingerprint should match what was passed to ShouldSuppress for consistency.
+    /// <para>
+    /// Set <paramref name="selfReportedWarning"/> to true when the postinstall script
+    /// signalled a Warning outcome via the <c>CIMIAN-WARNING:</c> marker convention
+    /// (see <see cref="Cimian.Core.Models.ItemOutcome.WarningMessage"/>). Those runs
+    /// are intentional soft-fails — the script ran successfully but the system is in
+    /// a known-bad state awaiting external remediation (e.g. SecureBoot enabled by
+    /// user, BIOS password set). They are NOT install loops, and counting them would
+    /// suppress packages whose only job is to keep flagging the unremediated state.
+    /// Real install loops (repeated normal installs of the same version with no
+    /// marker) still accumulate and trip suppression as before.
+    /// </para>
     /// </summary>
-    public void RecordAttempt(string packageName, string version, bool success, string? catalogFingerprint = null)
+    public void RecordAttempt(string packageName, string version, bool success, string? catalogFingerprint = null, bool selfReportedWarning = false)
     {
         if (string.IsNullOrEmpty(packageName))
+            return;
+
+        // Self-reported warnings are not install attempts for loop-detection purposes.
+        // Skip counter updates entirely so the per-version count and rapid-fire window
+        // are not polluted by intentional soft-fails. See remarks above.
+        if (selfReportedWarning)
             return;
 
         var key = packageName.ToLowerInvariant();

--- a/tests/LoopGuardTests.cs
+++ b/tests/LoopGuardTests.cs
@@ -102,6 +102,72 @@ public class LoopGuardTests : IDisposable
 
     #endregion
 
+    #region Self-Reported Warning Carve-Out
+
+    [Fact]
+    public void SelfReportedWarning_DoesNotIncrementAttemptCount()
+    {
+        var guard = CreateGuard();
+
+        guard.RecordAttempt("WarnPkg", "1.0.0", success: true, selfReportedWarning: true);
+        guard.RecordAttempt("WarnPkg", "1.0.0", success: true, selfReportedWarning: true);
+        guard.RecordAttempt("WarnPkg", "1.0.0", success: true, selfReportedWarning: true);
+
+        // Self-reported warnings must not pollute loop counters
+        var state = guard.GetPackageState("WarnPkg");
+        state.Should().BeNull("self-reported warnings should not create per-package loop state");
+    }
+
+    [Fact]
+    public void SelfReportedWarning_DoesNotTripRapidFireSuppression()
+    {
+        var guard = CreateGuard();
+
+        // Same pattern that trips suppression for normal attempts: 3 in 2 hours
+        guard.RecordAttempt("FirmwarePkg", "2026.06.10", success: true, selfReportedWarning: true);
+        guard.RecordAttempt("FirmwarePkg", "2026.06.10", success: true, selfReportedWarning: true);
+        guard.RecordAttempt("FirmwarePkg", "2026.06.10", success: true, selfReportedWarning: true);
+
+        var (suppress, _) = guard.ShouldSuppress("FirmwarePkg", "2026.06.10");
+        suppress.Should().BeFalse("CIMIAN-WARNING markers signal awaiting external remediation, not install loops");
+    }
+
+    [Fact]
+    public void NormalAttempts_StillSuppress_WhenInterleavedWithSelfReportedWarnings()
+    {
+        var guard = CreateGuard();
+
+        // Mix: 2 normal attempts + 1 self-reported warning → only 2 count
+        guard.RecordAttempt("MixedPkg", "1.0.0", success: true);
+        guard.RecordAttempt("MixedPkg", "1.0.0", success: true, selfReportedWarning: true);
+        guard.RecordAttempt("MixedPkg", "1.0.0", success: true);
+
+        var (suppress, _) = guard.ShouldSuppress("MixedPkg", "1.0.0");
+        suppress.Should().BeFalse("two real attempts should not trip the 3-in-2h threshold");
+
+        // Third real attempt should trip suppression
+        guard.RecordAttempt("MixedPkg", "1.0.0", success: true);
+        var (suppress2, reason) = guard.ShouldSuppress("MixedPkg", "1.0.0");
+        suppress2.Should().BeTrue("loop guard must still catch real install loops");
+        reason.Should().Contain("LOOP SUPPRESSED");
+    }
+
+    [Fact]
+    public void SelfReportedWarning_DefaultsToFalse_PreservesExistingBehavior()
+    {
+        var guard = CreateGuard();
+
+        // Call without selfReportedWarning (existing call sites) — must behave as before
+        guard.RecordAttempt("LegacyPkg", "1.0.0", success: true);
+        guard.RecordAttempt("LegacyPkg", "1.0.0", success: true);
+        guard.RecordAttempt("LegacyPkg", "1.0.0", success: true);
+
+        var (suppress, _) = guard.ShouldSuppress("LegacyPkg", "1.0.0");
+        suppress.Should().BeTrue("default selfReportedWarning=false must preserve rapid-fire suppression");
+    }
+
+    #endregion
+
     #region Rapid-Fire Detection
 
     [Fact]


### PR DESCRIPTION
## Summary

The refactored firmware pkginfos (EnableSecureBoot, UpdateSecureBootCert, LenovoBiosPowerOn, DellBiosPowerOn, EnableBitLocker) intentionally run their postinstall every session and exit with a `CIMIAN-WARNING:` marker until the device is remediated externally (user enables SecureBoot, admin sets BIOS password, etc.). LoopGuard was counting those runs as install attempts and tripping suppression after 3-4 sessions, replacing the pkginfo's actual warning reason with `LOOP SUPPRESSED: ...`.

Observed in production today via ReportMate: 805 fleet-wide `Warning` items, of which ~95% surface the loop-suppression message instead of the pkginfo's CIMIAN-WARNING reason. Example breakdown:

| Pkginfo | Warnings | Dominant reason |
|---|---:|---|
| LenovoBiosPowerOn | 115 | LOOP SUPPRESSED |
| BitLockerKeyEscrow | 58 | LOOP SUPPRESSED (indefinite, hit 30 attempts) |
| DellBiosPowerOn | 47 | LOOP SUPPRESSED |
| UpdateSecureBootCert | 45 | LOOP SUPPRESSED |
| EnableSecureBoot | 26 | LOOP SUPPRESSED (1 raw marker visible) |

One device confirms the marker pipeline works end-to-end when LoopGuard hasnt yet suppressed: `PF4QEAYN` shows `lastWarning: "bios-password-mismatch"` cleanly.

## Carve-out

`LoopGuard.RecordAttempt` now accepts an optional `selfReportedWarning` parameter. When the postinstall returned a `WarningMessage` via the marker convention, the caller passes `true` and `LoopGuard` returns early without touching any counters (per-version count, rapid-fire window, attempt count, threshold eval).

Real install loops - repeated normal installs of the same version with no marker - still accumulate and trip suppression exactly as before. The carve-out is per-attempt, not per-package, so a buggy pkginfo that emits the marker once but then enters a real loop will still get caught.

## Files changed

- `shared/core/Services/LoopGuard.cs` - new `selfReportedWarning` param on `RecordAttempt`, with doc explaining why
- `cli/managedsoftwareupdate/Services/UpdateEngine.cs` - success branch passes `selfReportedWarning: warningMessage != null`. Hard-failure branch unchanged so real failures still feed loop detection.
- `tests/LoopGuardTests.cs` - 4 new tests:
  - self-reported warnings dont create per-package state
  - 3 self-reported warnings in 2h dont trip rapid-fire
  - mixed real + self-reported still trips on 3rd *real* attempt
  - default `selfReportedWarning=false` preserves existing behavior

All 39 LoopGuardTests pass (35 existing + 4 new).

## Rollout note

This PR alone wont free the ~25 devices currently in stale `LOOP SUPPRESSED` state - their `state.json` entries persist until expiry (6h-24h) or, for `BitLockerKeyEscrow` at 30+ attempts, indefinitely.

But the catalog fingerprint (`UpdateEngine.cs ComputeCatalogFingerprint`) includes the postinstall script, so any text change to the refactored firmware pkginfos will flip the fingerprint and LoopGuard auto-clears suppression on next run. A follow-up no-op whitespace bump to those pkginfos in the deployment repo will unblock the existing affected devices once this Cimian release ships.

## Test plan

- [x] `dotnet build tests/Cimian.Tests.csproj -c Release` - clean
- [x] `dotnet test --filter "FullyQualifiedName~LoopGuardTests"` - 39/39 pass
- [ ] After release: monitor ReportMate `/api/v1/devices/installs` for the refactored firmware pkginfos - `LOOP SUPPRESSED` reasons should be replaced by the raw `CIMIAN-WARNING:` text (e.g. `bios-password-mismatch`, `secureboot-disabled`) once devices pick up new Cimian + bumped pkginfos.