### PR TITLE
schema: stale-usage removal fields + IUsageDataSource abstraction

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -128,6 +128,30 @@ public class PkgsInfo
     [YamlMember(Alias = "unattended_uninstall")]
     public bool UnattendedUninstall { get; set; }
 
+    /// <summary>
+    /// Opt-in stale-usage removal: uninstall this package when none of its
+    /// tracked executables have been used for this many days. Requires
+    /// unattended_uninstall and usage data (ReportMate usagetracker).
+    /// Null or &lt;= 0 disables the feature for this package.
+    /// </summary>
+    [YamlMember(Alias = "days_untouched_before_uninstall")]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates stale-usage removal. When empty,
+    /// the client falls back to .exe entries in the installs array.
+    /// </summary>
+    [YamlMember(Alias = "usage_tracked_paths")]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    /// <summary>
+    /// Minimum days of usage history that must exist on the device before
+    /// stale-usage removal may act (guards freshly imaged machines).
+    /// Null defers to the client's global default.
+    /// </summary>
+    [YamlMember(Alias = "minimum_usage_history_days")]
+    public int? MinimumUsageHistoryDays { get; set; }
+
     [YamlMember(Alias = "minimum_os_version")]
     public string? MinOSVersion { get; set; }
 

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -132,6 +132,30 @@ public class PkgsInfo
 
     [YamlMember(Alias = "installer", Order = 25, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public Installer? Installer { get; set; }
+
+    [YamlMember(Alias = "unattended_uninstall", Order = 26, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public bool UnattendedUninstall { get; set; }
+
+    /// <summary>
+    /// Opt-in stale-usage removal: uninstall when none of the tracked
+    /// executables have been used for this many days.
+    /// </summary>
+    [YamlMember(Alias = "days_untouched_before_uninstall", Order = 27, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates stale-usage removal. When empty,
+    /// the client falls back to .exe entries in the installs array.
+    /// </summary>
+    [YamlMember(Alias = "usage_tracked_paths", Order = 28, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    /// <summary>
+    /// Minimum days of usage history required on the device before
+    /// stale-usage removal may act.
+    /// </summary>
+    [YamlMember(Alias = "minimum_usage_history_days", Order = 29, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public int? MinimumUsageHistoryDays { get; set; }
 }
 
 /// <summary>

--- a/cli/makepkginfo/Program.cs
+++ b/cli/makepkginfo/Program.cs
@@ -101,6 +101,21 @@ class Program
             "--OnDemand",
             "Set 'OnDemand: true' - items that can be run multiple times");
 
+        var daysUntouchedOption = new Option<int?>(
+            "--days_untouched_before_uninstall",
+            "Uninstall when no tracked executable has been used for this many days (requires --unattended_uninstall and usage data)");
+
+        var usageTrackedPathOption = new Option<string[]>(
+            "--usage_tracked_path",
+            "Executable path whose usage gates stale-usage removal (can be specified multiple times; defaults to .exe entries in installs)")
+        {
+            AllowMultipleArgumentsPerToken = true
+        };
+
+        var minUsageHistoryOption = new Option<int?>(
+            "--minimum_usage_history_days",
+            "Minimum days of usage history required on a device before stale-usage removal may act");
+
         var newPkgOption = new Option<bool>(
             "--new",
             "Create a new pkginfo stub");
@@ -141,6 +156,9 @@ class Program
         rootCommand.AddOption(unattendedInstallOption);
         rootCommand.AddOption(unattendedUninstallOption);
         rootCommand.AddOption(onDemandOption);
+        rootCommand.AddOption(daysUntouchedOption);
+        rootCommand.AddOption(usageTrackedPathOption);
+        rootCommand.AddOption(minUsageHistoryOption);
         rootCommand.AddOption(newPkgOption);
         rootCommand.AddOption(additionalFilesOption);
         rootCommand.AddArgument(installerArgument);
@@ -168,6 +186,9 @@ class Program
             var unattendedInstall = context.ParseResult.GetValueForOption(unattendedInstallOption);
             var unattendedUninstall = context.ParseResult.GetValueForOption(unattendedUninstallOption);
             var onDemand = context.ParseResult.GetValueForOption(onDemandOption);
+            var daysUntouched = context.ParseResult.GetValueForOption(daysUntouchedOption);
+            var usageTrackedPaths = context.ParseResult.GetValueForOption(usageTrackedPathOption);
+            var minUsageHistory = context.ParseResult.GetValueForOption(minUsageHistoryOption);
             var newPkg = context.ParseResult.GetValueForOption(newPkgOption);
             var additionalFiles = context.ParseResult.GetValueForOption(additionalFilesOption);
             var installerPath = context.ParseResult.GetValueForArgument(installerArgument);
@@ -234,6 +255,9 @@ class Program
                     UnattendedInstall = unattendedInstall,
                     UnattendedUninstall = unattendedUninstall,
                     OnDemand = onDemand,
+                    DaysUntouchedBeforeUninstall = daysUntouched,
+                    UsageTrackedPaths = usageTrackedPaths?.Length > 0 ? usageTrackedPaths.ToList() : null,
+                    MinimumUsageHistoryDays = minUsageHistory,
                     MinOSVersion = minOSVersion,
                     MaxOSVersion = maxOSVersion,
                     MinCimianVersion = minCimianVersion,

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -183,10 +183,14 @@ public class PkgInfoBuilder
             Description = finalDesc,
             InstallerType = installerType,
             UnattendedInstall = options.UnattendedInstall,
+            UnattendedUninstall = options.UnattendedUninstall,
             OnDemand = options.OnDemand,
             MinOSVersion = options.MinOSVersion,
             MaxOSVersion = options.MaxOSVersion,
             MinCimianVersion = options.MinCimianVersion,
+            DaysUntouchedBeforeUninstall = options.DaysUntouchedBeforeUninstall,
+            UsageTrackedPaths = options.UsageTrackedPaths,
+            MinimumUsageHistoryDays = options.MinimumUsageHistoryDays,
             Installs = installs
         };
 
@@ -400,6 +404,9 @@ public class PkgsInfoOptions
     public bool UnattendedInstall { get; set; }
     public bool UnattendedUninstall { get; set; }
     public bool OnDemand { get; set; }
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+    public List<string>? UsageTrackedPaths { get; set; }
+    public int? MinimumUsageHistoryDays { get; set; }
     public string? MinOSVersion { get; set; }
     public string? MaxOSVersion { get; set; }
     public string? MinCimianVersion { get; set; }

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -399,6 +399,29 @@ public class CatalogItem
     [YamlMember(Alias = "force_install_after_date")]
     public DateTime? ForceInstallAfterDate { get; set; }
 
+    /// <summary>
+    /// Opt-in stale-usage removal: uninstall when none of the tracked
+    /// executables have been used for this many days. Requires
+    /// UnattendedUninstall and an available usage data source.
+    /// Null or &lt;= 0 disables the feature for this package.
+    /// </summary>
+    [YamlMember(Alias = "days_untouched_before_uninstall")]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates stale-usage removal. When empty,
+    /// the client falls back to .exe entries in the installs array.
+    /// </summary>
+    [YamlMember(Alias = "usage_tracked_paths")]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    /// <summary>
+    /// Minimum days of usage history required on this device before
+    /// stale-usage removal may act. Null defers to the global default.
+    /// </summary>
+    [YamlMember(Alias = "minimum_usage_history_days")]
+    public int? MinimumUsageHistoryDays { get; set; }
+
     [YamlMember(Alias = "restart_action")]
     public string? RestartAction { get; set; }
 

--- a/shared/core/Models/StatusReasonCode.cs
+++ b/shared/core/Models/StatusReasonCode.cs
@@ -135,6 +135,15 @@ public static class StatusReasonCode
     /// <summary>Auto run deferred this item because a user is active — either it is not unattended-eligible, or its restart_action would interrupt the session</summary>
     public const string DeferredUserActive = "deferred_user_active";
 
+    /// <summary>Package queued for removal: no tracked executable used within days_untouched_before_uninstall</summary>
+    public const string StaleUsageUninstall = "stale_usage_uninstall";
+
+    /// <summary>Stale-usage check skipped: no usage data exists for any tracked executable</summary>
+    public const string StaleUsageSkippedNoData = "stale_usage_skipped_no_data";
+
+    /// <summary>Stale-usage check skipped: device has fewer days of usage history than minimum_usage_history_days</summary>
+    public const string StaleUsageSkippedInsufficientHistory = "stale_usage_skipped_insufficient_history";
+
     #endregion
 
     #region Removed Reasons - Package confirmed removed
@@ -204,6 +213,9 @@ public static class DetectionMethod
 
     /// <summary>ManagedInstalls registry tracking</summary>
     public const string ManagedInstalls = "managed_installs";
+
+    /// <summary>ReportMate usagetracker per-user usage data</summary>
+    public const string ReportMateUsage = "reportmate_usage";
 
     /// <summary>No detection method used</summary>
     public const string None = "none";

--- a/shared/core/Services/IUsageDataSource.cs
+++ b/shared/core/Services/IUsageDataSource.cs
@@ -1,0 +1,68 @@
+// IUsageDataSource.cs - Abstraction over per-device application usage data
+// Backs the stale-usage removal feature (days_untouched_before_uninstall):
+// the engine asks "when was this executable last used on this device?" and
+// refuses to act when the source cannot answer confidently.
+
+namespace Cimian.Core.Services;
+
+/// <summary>
+/// Provides device-wide application usage answers for stale-usage removal.
+/// Implementations aggregate across all users on the device — a package is
+/// only "untouched" when NO user has used it. All methods must fail safe:
+/// absence of data is never evidence of disuse.
+/// </summary>
+public interface IUsageDataSource
+{
+    /// <summary>
+    /// True when the source is present and responsive on this device.
+    /// False means the entire stale-usage pass should be skipped.
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Human-readable source name for logging and reports.</summary>
+    string SourceName { get; }
+
+    /// <summary>
+    /// Returns the most recent observed usage timestamp (UTC) for the
+    /// executable across all users on this device. Path comparison is
+    /// case-insensitive. Returns false when the executable has no record —
+    /// callers must treat that as "no signal", not "unused".
+    /// </summary>
+    bool TryGetLastUsed(string executablePath, out DateTime lastUsedUtc);
+
+    /// <summary>
+    /// Calendar days of usage history this source can attest to on this
+    /// device (earliest record to today). Gates against acting on freshly
+    /// imaged machines that simply have no history yet.
+    /// </summary>
+    int GetHistoryDays();
+
+    /// <summary>
+    /// Days since the source last recorded anything (any user, any app).
+    /// Stale telemetry — e.g. no logons for weeks — must not drive
+    /// uninstalls; callers skip the pass when this exceeds their threshold.
+    /// </summary>
+    int GetDataFreshnessDays();
+}
+
+/// <summary>
+/// Null implementation used when stale-usage removal is disabled or no
+/// usage source is configured. Reports unavailable and returns no data,
+/// so every caller takes its fail-safe path.
+/// </summary>
+public sealed class NoOpUsageDataSource : IUsageDataSource
+{
+    public bool IsAvailable => false;
+
+    public string SourceName => "none";
+
+    public bool TryGetLastUsed(string executablePath, out DateTime lastUsedUtc)
+    {
+        lastUsedUtc = default;
+        return false;
+    }
+
+    public int GetHistoryDays() => 0;
+
+    public int GetDataFreshnessDays() => int.MaxValue;
+}

--- a/shared/import/Models/ImportModels.cs
+++ b/shared/import/Models/ImportModels.cs
@@ -48,6 +48,15 @@ public class PkgsInfo
     [YamlMember(Alias = "unattended_uninstall")]
     public bool UnattendedUninstall { get; set; }
 
+    [YamlMember(Alias = "days_untouched_before_uninstall")]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    [YamlMember(Alias = "usage_tracked_paths")]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    [YamlMember(Alias = "minimum_usage_history_days")]
+    public int? MinimumUsageHistoryDays { get; set; }
+
     [YamlMember(Alias = "requires")]
     public List<string>? Requires { get; set; }
 

--- a/tests/Makepkginfo/PkgInfoBuilderTests.cs
+++ b/tests/Makepkginfo/PkgInfoBuilderTests.cs
@@ -168,6 +168,50 @@ public class PkgInfoBuilderTests
     }
 
     [Fact]
+    public void BuildFromInstaller_EmitsUnattendedUninstall_AndUsageStaleFields()
+    {
+        // Pins the PkgsInfoOptions -> PkgsInfo wiring in BuildFromInstaller.
+        // --unattended_uninstall was historically parsed but silently dropped
+        // (the model had no property and BuildFromInstaller never assigned
+        // it), so this test guards the whole option set end to end: build
+        // from a real file, then assert the YAML keys actually appear.
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "installer payload");
+
+            var options = new PkgsInfoOptions
+            {
+                Name = "StaleApp",
+                Version = "1.0",
+                Catalogs = new List<string> { "Testing" },
+                UnattendedInstall = true,
+                UnattendedUninstall = true,
+                DaysUntouchedBeforeUninstall = 30,
+                UsageTrackedPaths = new List<string> { @"C:\Program Files\StaleApp\staleapp.exe" },
+                MinimumUsageHistoryDays = 14,
+            };
+
+            var pkgsinfo = _builder.BuildFromInstaller(tempFile, options);
+
+            Assert.True(pkgsinfo.UnattendedUninstall);
+            Assert.Equal(30, pkgsinfo.DaysUntouchedBeforeUninstall);
+            Assert.Equal(options.UsageTrackedPaths, pkgsinfo.UsageTrackedPaths);
+            Assert.Equal(14, pkgsinfo.MinimumUsageHistoryDays);
+
+            var yaml = _builder.SerializePkgsInfo(pkgsinfo);
+            Assert.Contains("unattended_uninstall: true", yaml);
+            Assert.Contains("days_untouched_before_uninstall: 30", yaml);
+            Assert.Contains("usage_tracked_paths:", yaml);
+            Assert.Contains("minimum_usage_history_days: 14", yaml);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void SerializePkgsInfo_ReturnsValidYaml()
     {
         var pkgsinfo = new PkgsInfo

--- a/tests/Shared/UsageStaleSchemaTests.cs
+++ b/tests/Shared/UsageStaleSchemaTests.cs
@@ -1,7 +1,6 @@
 using Cimian.Core.Services;
 using Xunit;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Cimian.Tests.Shared;
 

--- a/tests/Shared/UsageStaleSchemaTests.cs
+++ b/tests/Shared/UsageStaleSchemaTests.cs
@@ -1,0 +1,120 @@
+using Cimian.Core.Services;
+using Xunit;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// Schema tests for the stale-usage removal fields
+/// (days_untouched_before_uninstall, usage_tracked_paths,
+/// minimum_usage_history_days). The same YAML keys must round-trip through
+/// every model that carries them: cimiimport's PkgsInfo, makecatalogs'
+/// PkgsInfo, and the engine's CatalogItem. A field landing in one model but
+/// not another silently strips it during the import → catalog → client
+/// pipeline, so each model gets its own deserialization pin.
+/// </summary>
+public class UsageStaleSchemaTests
+{
+    private const string PkginfoYaml = """
+        name: StaleApp
+        version: '1.0'
+        unattended_uninstall: true
+        days_untouched_before_uninstall: 30
+        usage_tracked_paths:
+        - C:\Program Files\StaleApp\staleapp.exe
+        - C:\Program Files\StaleApp\helper.exe
+        minimum_usage_history_days: 14
+        """;
+
+    private static IDeserializer PlainDeserializer() => new DeserializerBuilder()
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    [Fact]
+    public void CimiimportPkgsInfo_Deserializes_UsageStaleFields()
+    {
+        var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Cimiimport.Models.PkgsInfo>(PkginfoYaml);
+
+        Assert.Equal(30, pkg.DaysUntouchedBeforeUninstall);
+        Assert.Equal(2, pkg.UsageTrackedPaths?.Count);
+        Assert.Equal(14, pkg.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void MakecatalogsPkgsInfo_Deserializes_UsageStaleFields()
+    {
+        var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(PkginfoYaml);
+
+        Assert.Equal(30, pkg.DaysUntouchedBeforeUninstall);
+        Assert.Equal(2, pkg.UsageTrackedPaths?.Count);
+        Assert.Equal(14, pkg.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void EngineCatalogItem_Deserializes_UsageStaleFields()
+    {
+        var item = PlainDeserializer().Deserialize<Cimian.CLI.managedsoftwareupdate.Models.CatalogItem>(PkginfoYaml);
+
+        Assert.True(item.UnattendedUninstall);
+        Assert.Equal(30, item.DaysUntouchedBeforeUninstall);
+        Assert.Equal(2, item.UsageTrackedPaths?.Count);
+        Assert.Equal(14, item.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void EngineCatalogItem_FieldsDefaultNull_WhenAbsent()
+    {
+        // Absence must read as "feature disabled", never zero — the engine
+        // treats null/<=0 as opt-out, so a default of 0 is equivalent, but
+        // null is the canonical not-configured signal for reporting.
+        const string minimal = """
+            name: PlainApp
+            version: '1.0'
+            """;
+
+        var item = PlainDeserializer().Deserialize<Cimian.CLI.managedsoftwareupdate.Models.CatalogItem>(minimal);
+
+        Assert.Null(item.DaysUntouchedBeforeUninstall);
+        Assert.Null(item.UsageTrackedPaths);
+        Assert.Null(item.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void MakecatalogsPkgsInfo_RoundTrips_UsageStaleFields()
+    {
+        var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(PkginfoYaml);
+        var yaml = new SerializerBuilder().Build().Serialize(pkg);
+        var again = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(yaml);
+
+        Assert.Equal(30, again.DaysUntouchedBeforeUninstall);
+        Assert.Equal(pkg.UsageTrackedPaths, again.UsageTrackedPaths);
+        Assert.Equal(14, again.MinimumUsageHistoryDays);
+    }
+}
+
+/// <summary>
+/// Contract pins for NoOpUsageDataSource: every answer must push callers
+/// down their fail-safe path (skip the stale-usage pass entirely).
+/// </summary>
+public class NoOpUsageDataSourceTests
+{
+    private readonly NoOpUsageDataSource _source = new();
+
+    [Fact]
+    public void IsAvailable_IsFalse() => Assert.False(_source.IsAvailable);
+
+    [Fact]
+    public void TryGetLastUsed_ReturnsFalse_ForAnyPath()
+    {
+        Assert.False(_source.TryGetLastUsed(@"C:\Program Files\Any\any.exe", out var lastUsed));
+        Assert.Equal(default, lastUsed);
+    }
+
+    [Fact]
+    public void GetHistoryDays_IsZero() => Assert.Equal(0, _source.GetHistoryDays());
+
+    [Fact]
+    public void GetDataFreshnessDays_IsMaxValue_SoAnyStalenessThresholdRejects()
+        => Assert.Equal(int.MaxValue, _source.GetDataFreshnessDays());
+}


### PR DESCRIPTION
## Summary

Phase 1 of bringing Munki''s "uninstall if unused for N days" (`app_usage` / removal predicate) to Cimian, sourcing usage data from **ReportMate usagetracker** (now shipping as of reportmate-client-win `2026.06.11.0622`) rather than building a parallel tracker.

**This PR is schema + abstraction only — zero behavior change.** The engine pass that actually queues stale uninstalls lands in a follow-up PR behind a `Config.yaml` flag (default off).

## New pkginfo fields

| YAML key | Type | Meaning |
|---|---|---|
| `days_untouched_before_uninstall` | `int?` | Opt-in: uninstall when no tracked exe used for N days. Null/<=0 = feature off for this package. |
| `usage_tracked_paths` | `list` | Exe paths whose usage gates removal. Empty = fall back to `.exe` entries in `installs`. |
| `minimum_usage_history_days` | `int?` | Refuse to act on devices with less usage history (fresh-image guard). Null = client global default. |

Added to **all four** model copies so the import → catalog → client pipeline doesn''t strip them: makecatalogs `PkgsInfo`, cimiimport `PkgsInfo`, makepkginfo `PkgsInfo`, engine `CatalogItem`.

## IUsageDataSource

`shared/core/Services/IUsageDataSource.cs` — abstracts "when was this exe last used on this device" with explicit fail-safe semantics (no data is never evidence of disuse):

- `IsAvailable` / `SourceName`
- `TryGetLastUsed(exePath, out lastUsedUtc)` — device-wide MAX across all users
- `GetHistoryDays()` — fresh-image guard input
- `GetDataFreshnessDays()` — stale-telemetry guard (no logons for weeks must not drive uninstalls)

`NoOpUsageDataSource` ships now (reports unavailable → every caller skips); `ReportMateUsageDataSource` reading `%ProgramData%\ManagedReports\usagetracker\*.json` follows in PR 2.

## StatusReasonCode

`stale_usage_uninstall` plus two skip codes (`stale_usage_skipped_no_data`, `stale_usage_skipped_insufficient_history`) so "considered but refused" is queryable from reports. `DetectionMethod.ReportMateUsage`.

## makepkginfo

New flags: `--days_untouched_before_uninstall`, `--usage_tracked_path` (repeatable), `--minimum_usage_history_days`.

**Latent bug fixed while wiring:** makepkginfo parsed `--unattended_uninstall` into `PkgsInfoOptions` but its own `PkgsInfo` model had no such property and `BuildFromInstaller` never assigned it — the flag was silently dropped from generated pkginfo. Added the field and the missing assignment.

## Tests

`tests/Shared/UsageStaleSchemaTests.cs`: per-model deserialization pins, round-trip, absent-fields-stay-null, and `NoOpUsageDataSource` contract pins (9 tests, all green).

Full suite: 752/753 pass. The 1 failure (`ScriptServiceTests.ExecuteScriptWithDetailsAsync_StderrMarker_CapturesMessage`) **fails identically on clean origin/main** (verified on a detached-HEAD baseline worktree at 06beaaf) — pre-existing, unrelated to this PR, likely from the recent CIMIAN-WARNING stderr-marker work.

## Roadmap

- **PR 2**: `ReportMateUsageDataSource` + fixture tests
- **PR 3**: `IdentifyStaleUsageItems` pass in `UpdateEngine.IdentifyActions` (after `IdentifyAutoRemoveItems`), gated by `UsageStaleUninstallEnabled` config (default off)