### PR TITLE
usage: ReportMateUsageDataSource reading usagetracker per-user JSON

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -128,6 +128,30 @@ public class PkgsInfo
     [YamlMember(Alias = "unattended_uninstall")]
     public bool UnattendedUninstall { get; set; }
 
+    /// <summary>
+    /// Opt-in stale-usage removal: uninstall this package when none of its
+    /// tracked executables have been used for this many days. Requires
+    /// unattended_uninstall and usage data (ReportMate usagetracker).
+    /// Null or &lt;= 0 disables the feature for this package.
+    /// </summary>
+    [YamlMember(Alias = "days_untouched_before_uninstall")]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates stale-usage removal. When empty,
+    /// the client falls back to .exe entries in the installs array.
+    /// </summary>
+    [YamlMember(Alias = "usage_tracked_paths")]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    /// <summary>
+    /// Minimum days of usage history that must exist on the device before
+    /// stale-usage removal may act (guards freshly imaged machines).
+    /// Null defers to the client's global default.
+    /// </summary>
+    [YamlMember(Alias = "minimum_usage_history_days")]
+    public int? MinimumUsageHistoryDays { get; set; }
+
     [YamlMember(Alias = "minimum_os_version")]
     public string? MinOSVersion { get; set; }
 

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -132,6 +132,30 @@ public class PkgsInfo
 
     [YamlMember(Alias = "installer", Order = 25, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public Installer? Installer { get; set; }
+
+    [YamlMember(Alias = "unattended_uninstall", Order = 26, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public bool UnattendedUninstall { get; set; }
+
+    /// <summary>
+    /// Opt-in stale-usage removal: uninstall when none of the tracked
+    /// executables have been used for this many days.
+    /// </summary>
+    [YamlMember(Alias = "days_untouched_before_uninstall", Order = 27, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates stale-usage removal. When empty,
+    /// the client falls back to .exe entries in the installs array.
+    /// </summary>
+    [YamlMember(Alias = "usage_tracked_paths", Order = 28, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    /// <summary>
+    /// Minimum days of usage history required on the device before
+    /// stale-usage removal may act.
+    /// </summary>
+    [YamlMember(Alias = "minimum_usage_history_days", Order = 29, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public int? MinimumUsageHistoryDays { get; set; }
 }
 
 /// <summary>

--- a/cli/makepkginfo/Program.cs
+++ b/cli/makepkginfo/Program.cs
@@ -101,6 +101,21 @@ class Program
             "--OnDemand",
             "Set 'OnDemand: true' - items that can be run multiple times");
 
+        var daysUntouchedOption = new Option<int?>(
+            "--days_untouched_before_uninstall",
+            "Uninstall when no tracked executable has been used for this many days (requires --unattended_uninstall and usage data)");
+
+        var usageTrackedPathOption = new Option<string[]>(
+            "--usage_tracked_path",
+            "Executable path whose usage gates stale-usage removal (can be specified multiple times; defaults to .exe entries in installs)")
+        {
+            AllowMultipleArgumentsPerToken = true
+        };
+
+        var minUsageHistoryOption = new Option<int?>(
+            "--minimum_usage_history_days",
+            "Minimum days of usage history required on a device before stale-usage removal may act");
+
         var newPkgOption = new Option<bool>(
             "--new",
             "Create a new pkginfo stub");
@@ -141,6 +156,9 @@ class Program
         rootCommand.AddOption(unattendedInstallOption);
         rootCommand.AddOption(unattendedUninstallOption);
         rootCommand.AddOption(onDemandOption);
+        rootCommand.AddOption(daysUntouchedOption);
+        rootCommand.AddOption(usageTrackedPathOption);
+        rootCommand.AddOption(minUsageHistoryOption);
         rootCommand.AddOption(newPkgOption);
         rootCommand.AddOption(additionalFilesOption);
         rootCommand.AddArgument(installerArgument);
@@ -168,6 +186,9 @@ class Program
             var unattendedInstall = context.ParseResult.GetValueForOption(unattendedInstallOption);
             var unattendedUninstall = context.ParseResult.GetValueForOption(unattendedUninstallOption);
             var onDemand = context.ParseResult.GetValueForOption(onDemandOption);
+            var daysUntouched = context.ParseResult.GetValueForOption(daysUntouchedOption);
+            var usageTrackedPaths = context.ParseResult.GetValueForOption(usageTrackedPathOption);
+            var minUsageHistory = context.ParseResult.GetValueForOption(minUsageHistoryOption);
             var newPkg = context.ParseResult.GetValueForOption(newPkgOption);
             var additionalFiles = context.ParseResult.GetValueForOption(additionalFilesOption);
             var installerPath = context.ParseResult.GetValueForArgument(installerArgument);
@@ -234,6 +255,9 @@ class Program
                     UnattendedInstall = unattendedInstall,
                     UnattendedUninstall = unattendedUninstall,
                     OnDemand = onDemand,
+                    DaysUntouchedBeforeUninstall = daysUntouched,
+                    UsageTrackedPaths = usageTrackedPaths?.Length > 0 ? usageTrackedPaths.ToList() : null,
+                    MinimumUsageHistoryDays = minUsageHistory,
                     MinOSVersion = minOSVersion,
                     MaxOSVersion = maxOSVersion,
                     MinCimianVersion = minCimianVersion,

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -183,10 +183,14 @@ public class PkgInfoBuilder
             Description = finalDesc,
             InstallerType = installerType,
             UnattendedInstall = options.UnattendedInstall,
+            UnattendedUninstall = options.UnattendedUninstall,
             OnDemand = options.OnDemand,
             MinOSVersion = options.MinOSVersion,
             MaxOSVersion = options.MaxOSVersion,
             MinCimianVersion = options.MinCimianVersion,
+            DaysUntouchedBeforeUninstall = options.DaysUntouchedBeforeUninstall,
+            UsageTrackedPaths = options.UsageTrackedPaths,
+            MinimumUsageHistoryDays = options.MinimumUsageHistoryDays,
             Installs = installs
         };
 
@@ -400,6 +404,9 @@ public class PkgsInfoOptions
     public bool UnattendedInstall { get; set; }
     public bool UnattendedUninstall { get; set; }
     public bool OnDemand { get; set; }
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+    public List<string>? UsageTrackedPaths { get; set; }
+    public int? MinimumUsageHistoryDays { get; set; }
     public string? MinOSVersion { get; set; }
     public string? MaxOSVersion { get; set; }
     public string? MinCimianVersion { get; set; }

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -399,6 +399,29 @@ public class CatalogItem
     [YamlMember(Alias = "force_install_after_date")]
     public DateTime? ForceInstallAfterDate { get; set; }
 
+    /// <summary>
+    /// Opt-in stale-usage removal: uninstall when none of the tracked
+    /// executables have been used for this many days. Requires
+    /// UnattendedUninstall and an available usage data source.
+    /// Null or &lt;= 0 disables the feature for this package.
+    /// </summary>
+    [YamlMember(Alias = "days_untouched_before_uninstall")]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates stale-usage removal. When empty,
+    /// the client falls back to .exe entries in the installs array.
+    /// </summary>
+    [YamlMember(Alias = "usage_tracked_paths")]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    /// <summary>
+    /// Minimum days of usage history required on this device before
+    /// stale-usage removal may act. Null defers to the global default.
+    /// </summary>
+    [YamlMember(Alias = "minimum_usage_history_days")]
+    public int? MinimumUsageHistoryDays { get; set; }
+
     [YamlMember(Alias = "restart_action")]
     public string? RestartAction { get; set; }
 

--- a/shared/core/Models/StatusReasonCode.cs
+++ b/shared/core/Models/StatusReasonCode.cs
@@ -135,6 +135,15 @@ public static class StatusReasonCode
     /// <summary>Auto run deferred this item because a user is active — either it is not unattended-eligible, or its restart_action would interrupt the session</summary>
     public const string DeferredUserActive = "deferred_user_active";
 
+    /// <summary>Package queued for removal: no tracked executable used within days_untouched_before_uninstall</summary>
+    public const string StaleUsageUninstall = "stale_usage_uninstall";
+
+    /// <summary>Stale-usage check skipped: no usage data exists for any tracked executable</summary>
+    public const string StaleUsageSkippedNoData = "stale_usage_skipped_no_data";
+
+    /// <summary>Stale-usage check skipped: device has fewer days of usage history than minimum_usage_history_days</summary>
+    public const string StaleUsageSkippedInsufficientHistory = "stale_usage_skipped_insufficient_history";
+
     #endregion
 
     #region Removed Reasons - Package confirmed removed
@@ -204,6 +213,9 @@ public static class DetectionMethod
 
     /// <summary>ManagedInstalls registry tracking</summary>
     public const string ManagedInstalls = "managed_installs";
+
+    /// <summary>ReportMate usagetracker per-user usage data</summary>
+    public const string ReportMateUsage = "reportmate_usage";
 
     /// <summary>No detection method used</summary>
     public const string None = "none";

--- a/shared/core/Services/IUsageDataSource.cs
+++ b/shared/core/Services/IUsageDataSource.cs
@@ -1,0 +1,68 @@
+// IUsageDataSource.cs - Abstraction over per-device application usage data
+// Backs the stale-usage removal feature (days_untouched_before_uninstall):
+// the engine asks "when was this executable last used on this device?" and
+// refuses to act when the source cannot answer confidently.
+
+namespace Cimian.Core.Services;
+
+/// <summary>
+/// Provides device-wide application usage answers for stale-usage removal.
+/// Implementations aggregate across all users on the device — a package is
+/// only "untouched" when NO user has used it. All methods must fail safe:
+/// absence of data is never evidence of disuse.
+/// </summary>
+public interface IUsageDataSource
+{
+    /// <summary>
+    /// True when the source is present and responsive on this device.
+    /// False means the entire stale-usage pass should be skipped.
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Human-readable source name for logging and reports.</summary>
+    string SourceName { get; }
+
+    /// <summary>
+    /// Returns the most recent observed usage timestamp (UTC) for the
+    /// executable across all users on this device. Path comparison is
+    /// case-insensitive. Returns false when the executable has no record —
+    /// callers must treat that as "no signal", not "unused".
+    /// </summary>
+    bool TryGetLastUsed(string executablePath, out DateTime lastUsedUtc);
+
+    /// <summary>
+    /// Calendar days of usage history this source can attest to on this
+    /// device (earliest record to today). Gates against acting on freshly
+    /// imaged machines that simply have no history yet.
+    /// </summary>
+    int GetHistoryDays();
+
+    /// <summary>
+    /// Days since the source last recorded anything (any user, any app).
+    /// Stale telemetry — e.g. no logons for weeks — must not drive
+    /// uninstalls; callers skip the pass when this exceeds their threshold.
+    /// </summary>
+    int GetDataFreshnessDays();
+}
+
+/// <summary>
+/// Null implementation used when stale-usage removal is disabled or no
+/// usage source is configured. Reports unavailable and returns no data,
+/// so every caller takes its fail-safe path.
+/// </summary>
+public sealed class NoOpUsageDataSource : IUsageDataSource
+{
+    public bool IsAvailable => false;
+
+    public string SourceName => "none";
+
+    public bool TryGetLastUsed(string executablePath, out DateTime lastUsedUtc)
+    {
+        lastUsedUtc = default;
+        return false;
+    }
+
+    public int GetHistoryDays() => 0;
+
+    public int GetDataFreshnessDays() => int.MaxValue;
+}

--- a/shared/core/Services/ReportMateUsageDataSource.cs
+++ b/shared/core/Services/ReportMateUsageDataSource.cs
@@ -1,0 +1,259 @@
+// ReportMateUsageDataSource.cs - IUsageDataSource backed by ReportMate usagetracker
+// Reads the per-user JSON files written by ReportMate's usagetracker.exe
+// companion (reportmate-client-win). Each logged-in user gets one file at
+// %ProgramData%\ManagedReports\usagetracker\{username}.json holding
+// per-(exe path, local date) cumulative foreground/active counters.
+
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Cimian.Core.Services;
+
+/// <summary>
+/// Usage data source backed by ReportMate usagetracker per-user JSON files.
+/// Answers are device-wide: the last-used timestamp for an executable is the
+/// MAX across every user's file, so a package one user runs daily is never
+/// considered untouched because another user ignores it.
+///
+/// Granularity is one day — usagetracker keys counters by local date, so
+/// "last used" resolves to local midnight of the most recent day with
+/// non-zero foreground or active seconds. That is exact enough for
+/// thresholds measured in tens of days.
+///
+/// All parsing is defensive: a malformed or mid-rotation file degrades to
+/// "no data from that user" (logged), never an exception to the caller.
+/// </summary>
+public sealed class ReportMateUsageDataSource : IUsageDataSource
+{
+    /// <summary>Default usagetracker state directory on a managed device.</summary>
+    public static readonly string DefaultDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+        "ManagedReports", "usagetracker");
+
+    private readonly string _directory;
+    private readonly ILogger? _logger;
+    private readonly Lazy<Snapshot> _snapshot;
+
+    public ReportMateUsageDataSource(string? directory = null, ILogger? logger = null)
+    {
+        _directory = string.IsNullOrEmpty(directory) ? DefaultDirectory : directory;
+        _logger = logger;
+        // One scan per agent run: the files are tiny (KBs) and the engine
+        // asks about many packages, so parse everything once and serve
+        // lookups from memory.
+        _snapshot = new Lazy<Snapshot>(LoadSnapshot);
+    }
+
+    public bool IsAvailable => _snapshot.Value.FilesParsed > 0;
+
+    public string SourceName => "reportmate-usagetracker";
+
+    public bool TryGetLastUsed(string executablePath, out DateTime lastUsedUtc)
+    {
+        lastUsedUtc = default;
+        if (string.IsNullOrWhiteSpace(executablePath))
+        {
+            return false;
+        }
+
+        var snap = _snapshot.Value;
+
+        // Exact path match first (usagetracker keys by absolute exe path).
+        if (snap.LastUsedByExePath.TryGetValue(executablePath, out lastUsedUtc))
+        {
+            return true;
+        }
+
+        // Fall back to basename matching: pkginfo authors may record a path
+        // under Program Files while the tracker observed Program Files (x86),
+        // or per-user installs under AppData. The basename is stable across
+        // those layouts. MAX across all matches keeps the device-wide rule.
+        var baseName = Path.GetFileName(executablePath);
+        if (!string.IsNullOrEmpty(baseName) &&
+            snap.LastUsedByExeName.TryGetValue(baseName, out lastUsedUtc))
+        {
+            return true;
+        }
+
+        lastUsedUtc = default;
+        return false;
+    }
+
+    public int GetHistoryDays()
+    {
+        var earliest = _snapshot.Value.EarliestRecordUtc;
+        if (earliest is null)
+        {
+            return 0;
+        }
+
+        var days = (int)(DateTime.UtcNow - earliest.Value).TotalDays;
+        return Math.Max(0, days);
+    }
+
+    public int GetDataFreshnessDays()
+    {
+        var latest = _snapshot.Value.LatestWriteUtc;
+        if (latest is null)
+        {
+            return int.MaxValue;
+        }
+
+        var days = (int)(DateTime.UtcNow - latest.Value).TotalDays;
+        return Math.Max(0, days);
+    }
+
+    // ─────────────────────────── parsing ───────────────────────────
+
+    private sealed class Snapshot
+    {
+        public Dictionary<string, DateTime> LastUsedByExePath { get; } =
+            new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, DateTime> LastUsedByExeName { get; } =
+            new(StringComparer.OrdinalIgnoreCase);
+        public DateTime? EarliestRecordUtc { get; set; }
+        public DateTime? LatestWriteUtc { get; set; }
+        public int FilesParsed { get; set; }
+    }
+
+    // Mirrors usagetracker's TrackerState. Field semantics:
+    //   ByAppByDate[absolute exe path][yyyy-MM-dd local date] = counters
+    private sealed class TrackerState
+    {
+        public string? Username { get; set; }
+        public DateTime? StartedAt { get; set; }
+        public DateTime? LastUpdatedAt { get; set; }
+        public Dictionary<string, Dictionary<string, AppDayCounters>>? ByAppByDate { get; set; }
+    }
+
+    private sealed class AppDayCounters
+    {
+        public double ForegroundSeconds { get; set; }
+        public double ActiveSeconds { get; set; }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private Snapshot LoadSnapshot()
+    {
+        var snap = new Snapshot();
+
+        string[] files;
+        try
+        {
+            if (!Directory.Exists(_directory))
+            {
+                _logger?.LogDebug("Usage source directory not found: {Directory}", _directory);
+                return snap;
+            }
+            files = Directory.GetFiles(_directory, "*.json", SearchOption.TopDirectoryOnly);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning("Cannot enumerate usage source directory {Directory}: {Message}",
+                _directory, ex.Message);
+            return snap;
+        }
+
+        foreach (var file in files)
+        {
+            try
+            {
+                ParseUserFile(file, snap);
+                snap.FilesParsed++;
+            }
+            catch (Exception ex)
+            {
+                // One unreadable user file (torn write, schema drift) must not
+                // poison the others — and absolutely must not become "the app
+                // is unused".
+                _logger?.LogWarning("Skipping unreadable usage file {File}: {Message}",
+                    Path.GetFileName(file), ex.Message);
+            }
+        }
+
+        return snap;
+    }
+
+    private void ParseUserFile(string file, Snapshot snap)
+    {
+        var state = JsonSerializer.Deserialize<TrackerState>(File.ReadAllText(file), JsonOptions);
+        if (state is null)
+        {
+            return;
+        }
+
+        // Freshness: prefer the writer's own stamp; fall back to file mtime
+        // so a schema without LastUpdatedAt still yields a usable signal.
+        var write = state.LastUpdatedAt?.ToUniversalTime()
+                    ?? File.GetLastWriteTimeUtc(file);
+        if (snap.LatestWriteUtc is null || write > snap.LatestWriteUtc)
+        {
+            snap.LatestWriteUtc = write;
+        }
+
+        // History floor: a fresh file with no usage rows still attests that
+        // tracking has been running since StartedAt.
+        var started = state.StartedAt?.ToUniversalTime();
+        if (started is not null &&
+            (snap.EarliestRecordUtc is null || started < snap.EarliestRecordUtc))
+        {
+            snap.EarliestRecordUtc = started;
+        }
+
+        if (state.ByAppByDate is null)
+        {
+            return;
+        }
+
+        foreach (var (exePath, byDate) in state.ByAppByDate)
+        {
+            if (string.IsNullOrWhiteSpace(exePath) || byDate is null)
+            {
+                continue;
+            }
+
+            foreach (var (dateKey, counters) in byDate)
+            {
+                if (!DateTime.TryParseExact(dateKey, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                        DateTimeStyles.None, out var localDate))
+                {
+                    continue;
+                }
+
+                var dayUtc = DateTime.SpecifyKind(localDate, DateTimeKind.Local).ToUniversalTime();
+
+                if (snap.EarliestRecordUtc is null || dayUtc < snap.EarliestRecordUtc)
+                {
+                    snap.EarliestRecordUtc = dayUtc;
+                }
+
+                // A date row with all-zero counters is bookkeeping, not usage.
+                if (counters is null ||
+                    (counters.ForegroundSeconds <= 0 && counters.ActiveSeconds <= 0))
+                {
+                    continue;
+                }
+
+                Bump(snap.LastUsedByExePath, exePath, dayUtc);
+                var baseName = Path.GetFileName(exePath);
+                if (!string.IsNullOrEmpty(baseName))
+                {
+                    Bump(snap.LastUsedByExeName, baseName, dayUtc);
+                }
+            }
+        }
+    }
+
+    private static void Bump(Dictionary<string, DateTime> map, string key, DateTime candidateUtc)
+    {
+        if (!map.TryGetValue(key, out var existing) || candidateUtc > existing)
+        {
+            map[key] = candidateUtc;
+        }
+    }
+}

--- a/shared/core/Services/ReportMateUsageDataSource.cs
+++ b/shared/core/Services/ReportMateUsageDataSource.cs
@@ -100,8 +100,21 @@ public sealed class ReportMateUsageDataSource : IUsageDataSource
             return int.MaxValue;
         }
 
-        var days = (int)(DateTime.UtcNow - latest.Value).TotalDays;
-        return Math.Max(0, days);
+        var age = DateTime.UtcNow - latest.Value;
+
+        // A write stamp from the future means clock skew or tampering. Up to
+        // a day of skew reads as "fresh now"; beyond that the telemetry is
+        // not trustworthy, and untrustworthy must mean "too stale to act on",
+        // never "perfectly fresh".
+        if (age < TimeSpan.FromDays(-1))
+        {
+            _logger?.LogWarning(
+                "Usage data write stamp is {Hours:F0}h in the future - treating as invalid",
+                -age.TotalHours);
+            return int.MaxValue;
+        }
+
+        return Math.Max(0, (int)age.TotalDays);
     }
 
     // ─────────────────────────── parsing ───────────────────────────
@@ -154,8 +167,7 @@ public sealed class ReportMateUsageDataSource : IUsageDataSource
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning("Cannot enumerate usage source directory {Directory}: {Message}",
-                _directory, ex.Message);
+            _logger?.LogWarning(ex, "Cannot enumerate usage source directory {Directory}", _directory);
             return snap;
         }
 
@@ -171,8 +183,7 @@ public sealed class ReportMateUsageDataSource : IUsageDataSource
                 // One unreadable user file (torn write, schema drift) must not
                 // poison the others — and absolutely must not become "the app
                 // is unused".
-                _logger?.LogWarning("Skipping unreadable usage file {File}: {Message}",
-                    Path.GetFileName(file), ex.Message);
+                _logger?.LogWarning(ex, "Skipping unreadable usage file {File}", Path.GetFileName(file));
             }
         }
 

--- a/shared/import/Models/ImportModels.cs
+++ b/shared/import/Models/ImportModels.cs
@@ -48,6 +48,15 @@ public class PkgsInfo
     [YamlMember(Alias = "unattended_uninstall")]
     public bool UnattendedUninstall { get; set; }
 
+    [YamlMember(Alias = "days_untouched_before_uninstall")]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    [YamlMember(Alias = "usage_tracked_paths")]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    [YamlMember(Alias = "minimum_usage_history_days")]
+    public int? MinimumUsageHistoryDays { get; set; }
+
     [YamlMember(Alias = "requires")]
     public List<string>? Requires { get; set; }
 

--- a/tests/Makepkginfo/PkgInfoBuilderTests.cs
+++ b/tests/Makepkginfo/PkgInfoBuilderTests.cs
@@ -168,6 +168,50 @@ public class PkgInfoBuilderTests
     }
 
     [Fact]
+    public void BuildFromInstaller_EmitsUnattendedUninstall_AndUsageStaleFields()
+    {
+        // Pins the PkgsInfoOptions -> PkgsInfo wiring in BuildFromInstaller.
+        // --unattended_uninstall was historically parsed but silently dropped
+        // (the model had no property and BuildFromInstaller never assigned
+        // it), so this test guards the whole option set end to end: build
+        // from a real file, then assert the YAML keys actually appear.
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "installer payload");
+
+            var options = new PkgsInfoOptions
+            {
+                Name = "StaleApp",
+                Version = "1.0",
+                Catalogs = new List<string> { "Testing" },
+                UnattendedInstall = true,
+                UnattendedUninstall = true,
+                DaysUntouchedBeforeUninstall = 30,
+                UsageTrackedPaths = new List<string> { @"C:\Program Files\StaleApp\staleapp.exe" },
+                MinimumUsageHistoryDays = 14,
+            };
+
+            var pkgsinfo = _builder.BuildFromInstaller(tempFile, options);
+
+            Assert.True(pkgsinfo.UnattendedUninstall);
+            Assert.Equal(30, pkgsinfo.DaysUntouchedBeforeUninstall);
+            Assert.Equal(options.UsageTrackedPaths, pkgsinfo.UsageTrackedPaths);
+            Assert.Equal(14, pkgsinfo.MinimumUsageHistoryDays);
+
+            var yaml = _builder.SerializePkgsInfo(pkgsinfo);
+            Assert.Contains("unattended_uninstall: true", yaml);
+            Assert.Contains("days_untouched_before_uninstall: 30", yaml);
+            Assert.Contains("usage_tracked_paths:", yaml);
+            Assert.Contains("minimum_usage_history_days: 14", yaml);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void SerializePkgsInfo_ReturnsValidYaml()
     {
         var pkgsinfo = new PkgsInfo

--- a/tests/Shared/ReportMateUsageDataSourceTests.cs
+++ b/tests/Shared/ReportMateUsageDataSourceTests.cs
@@ -215,4 +215,37 @@ public sealed class ReportMateUsageDataSourceTests : IDisposable
         Assert.Equal(0, source.GetHistoryDays());
         Assert.Equal(int.MaxValue, source.GetDataFreshnessDays());
     }
+
+    [Fact]
+    public void GetDataFreshnessDays_FutureWriteStamp_IsInvalid_NotFresh()
+    {
+        // LastUpdatedAt 3 days in the future = clock skew or tampering.
+        // Treating it as "fresh" would let untrustworthy telemetry drive
+        // uninstalls; it must read as too-stale-to-act instead.
+        WriteUserFile("skewed", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 12, lastUpdatedDaysAgo: -3));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.Equal(int.MaxValue, source.GetDataFreshnessDays());
+    }
+
+    [Fact]
+    public void GetDataFreshnessDays_SmallFutureSkew_ReadsAsFresh()
+    {
+        // A few hours of clock skew is normal fleet reality - don't let it
+        // disable the feature device-wide. -0.5 days is within the 1-day
+        // tolerance window.
+        var json = $$"""
+            {
+              "SchemaVersion": 1,
+              "Username": "slight",
+              "StartedAt": "{{DateTime.UtcNow.AddDays(-30):O}}",
+              "LastUpdatedAt": "{{DateTime.UtcNow.AddHours(12):O}}",
+              "ByAppByDate": {}
+            }
+            """;
+        WriteUserFile("slight", json);
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.Equal(0, source.GetDataFreshnessDays());
+    }
 }

--- a/tests/Shared/ReportMateUsageDataSourceTests.cs
+++ b/tests/Shared/ReportMateUsageDataSourceTests.cs
@@ -1,0 +1,218 @@
+using System.Globalization;
+using Cimian.Core.Services;
+using Xunit;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// Fixture tests for ReportMateUsageDataSource. Each test writes usagetracker
+/// JSON files (the schema reportmate-client-win's usagetracker.exe produces)
+/// into a temp directory and points the source at it. The contract under
+/// test is the fail-safe behavior: parse errors and missing data must always
+/// degrade toward "no signal", never toward "unused".
+/// </summary>
+public sealed class ReportMateUsageDataSourceTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ReportMateUsageDataSourceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cimian-usage-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static string DateKey(int daysAgo) =>
+        DateTime.Now.AddDays(-daysAgo).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private void WriteUserFile(string username, string json) =>
+        File.WriteAllText(Path.Combine(_dir, username + ".json"), json);
+
+    private static string TrackerJson(
+        string exePath, int lastUsedDaysAgo,
+        double activeSeconds = 120, int startedDaysAgo = 60, int lastUpdatedDaysAgo = 0)
+    {
+        var exe = exePath.Replace(@"\", @"\\");
+        return $$"""
+            {
+              "SchemaVersion": 1,
+              "Username": "user",
+              "StartedAt": "{{DateTime.UtcNow.AddDays(-startedDaysAgo):O}}",
+              "LastUpdatedAt": "{{DateTime.UtcNow.AddDays(-lastUpdatedDaysAgo):O}}",
+              "ByAppByDate": {
+                "{{exe}}": {
+                  "{{DateKey(lastUsedDaysAgo)}}": { "ForegroundSeconds": 300, "ActiveSeconds": {{activeSeconds}} }
+                }
+              }
+            }
+            """;
+    }
+
+    // ── availability ────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsAvailable_False_WhenDirectoryMissing()
+    {
+        var source = new ReportMateUsageDataSource(Path.Combine(_dir, "does-not-exist"));
+        Assert.False(source.IsAvailable);
+    }
+
+    [Fact]
+    public void IsAvailable_False_WhenDirectoryEmpty()
+    {
+        var source = new ReportMateUsageDataSource(_dir);
+        Assert.False(source.IsAvailable);
+    }
+
+    [Fact]
+    public void IsAvailable_True_WithOneParseableFile()
+    {
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 3));
+        var source = new ReportMateUsageDataSource(_dir);
+        Assert.True(source.IsAvailable);
+    }
+
+    // ── lookups ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TryGetLastUsed_ExactPath_CaseInsensitive()
+    {
+        WriteUserFile("alice", TrackerJson(@"C:\Program Files\StaleApp\staleapp.exe", lastUsedDaysAgo: 5));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.TryGetLastUsed(@"C:\PROGRAM FILES\STALEAPP\STALEAPP.EXE", out var lastUsed));
+        var daysSince = (DateTime.UtcNow - lastUsed).TotalDays;
+        Assert.InRange(daysSince, 3.5, 6.5); // day granularity + TZ slop
+    }
+
+    [Fact]
+    public void TryGetLastUsed_FallsBackToBasename_WhenPathDiffers()
+    {
+        // Tracker observed the (x86) layout; pkginfo recorded the 64-bit path.
+        WriteUserFile("alice", TrackerJson(@"C:\Program Files (x86)\StaleApp\staleapp.exe", lastUsedDaysAgo: 5));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.TryGetLastUsed(@"C:\Program Files\StaleApp\staleapp.exe", out _));
+    }
+
+    [Fact]
+    public void TryGetLastUsed_False_ForUnknownExecutable()
+    {
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 3));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.False(source.TryGetLastUsed(@"C:\Apps\never-seen.exe", out var lastUsed));
+        Assert.Equal(default, lastUsed);
+    }
+
+    [Fact]
+    public void TryGetLastUsed_TakesMax_AcrossUsers()
+    {
+        // Bob used the app yesterday; Alice last touched it 40 days ago.
+        // Device-wide answer must be Bob's — the app is NOT stale.
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\shared.exe", lastUsedDaysAgo: 40));
+        WriteUserFile("bob", TrackerJson(@"C:\Apps\shared.exe", lastUsedDaysAgo: 1));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.TryGetLastUsed(@"C:\Apps\shared.exe", out var lastUsed));
+        Assert.InRange((DateTime.UtcNow - lastUsed).TotalDays, -0.5, 2.5);
+    }
+
+    [Fact]
+    public void TryGetLastUsed_IgnoresZeroCounterDays()
+    {
+        // A recent date row with all-zero counters is bookkeeping, not usage:
+        // last-used must resolve to the older day with real activity.
+        var json = $$"""
+            {
+              "SchemaVersion": 1,
+              "Username": "alice",
+              "StartedAt": "{{DateTime.UtcNow.AddDays(-60):O}}",
+              "LastUpdatedAt": "{{DateTime.UtcNow:O}}",
+              "ByAppByDate": {
+                "C:\\Apps\\tool.exe": {
+                  "{{DateKey(30)}}": { "ForegroundSeconds": 500, "ActiveSeconds": 200 },
+                  "{{DateKey(1)}}": { "ForegroundSeconds": 0, "ActiveSeconds": 0 }
+                }
+              }
+            }
+            """;
+        WriteUserFile("alice", json);
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.TryGetLastUsed(@"C:\Apps\tool.exe", out var lastUsed));
+        Assert.InRange((DateTime.UtcNow - lastUsed).TotalDays, 28.5, 31.5);
+    }
+
+    // ── robustness ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void MalformedFile_IsSkipped_OthersStillParsed()
+    {
+        WriteUserFile("corrupt", "{ this is not json ");
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 3));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.IsAvailable);
+        Assert.True(source.TryGetLastUsed(@"C:\Apps\tool.exe", out _));
+    }
+
+    [Fact]
+    public void EmptyByAppByDate_StillCountsTowardAvailabilityAndHistory()
+    {
+        // Fresh user, tracker running but nothing used yet: the file proves
+        // tracking has been active since StartedAt, so history accrues even
+        // though no app rows exist.
+        var json = $$"""
+            {
+              "SchemaVersion": 1,
+              "Username": "fresh",
+              "StartedAt": "{{DateTime.UtcNow.AddDays(-20):O}}",
+              "LastUpdatedAt": "{{DateTime.UtcNow:O}}",
+              "ByAppByDate": {}
+            }
+            """;
+        WriteUserFile("fresh", json);
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.IsAvailable);
+        Assert.InRange(source.GetHistoryDays(), 19, 21);
+    }
+
+    // ── guards ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetHistoryDays_SpansEarliestRecord()
+    {
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 10, startedDaysAgo: 45));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.InRange(source.GetHistoryDays(), 44, 46);
+    }
+
+    [Fact]
+    public void GetDataFreshnessDays_ReflectsLatestWrite()
+    {
+        // Telemetry last written 9 days ago (e.g. device idle, no logons):
+        // callers with a 7-day staleness threshold must refuse to act.
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 12, lastUpdatedDaysAgo: 9));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.InRange(source.GetDataFreshnessDays(), 8, 10);
+    }
+
+    [Fact]
+    public void Guards_AreFailSafe_WhenNoFiles()
+    {
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.Equal(0, source.GetHistoryDays());
+        Assert.Equal(int.MaxValue, source.GetDataFreshnessDays());
+    }
+}

--- a/tests/Shared/UsageStaleSchemaTests.cs
+++ b/tests/Shared/UsageStaleSchemaTests.cs
@@ -1,7 +1,6 @@
 using Cimian.Core.Services;
 using Xunit;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Cimian.Tests.Shared;
 

--- a/tests/Shared/UsageStaleSchemaTests.cs
+++ b/tests/Shared/UsageStaleSchemaTests.cs
@@ -1,0 +1,120 @@
+using Cimian.Core.Services;
+using Xunit;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// Schema tests for the stale-usage removal fields
+/// (days_untouched_before_uninstall, usage_tracked_paths,
+/// minimum_usage_history_days). The same YAML keys must round-trip through
+/// every model that carries them: cimiimport's PkgsInfo, makecatalogs'
+/// PkgsInfo, and the engine's CatalogItem. A field landing in one model but
+/// not another silently strips it during the import → catalog → client
+/// pipeline, so each model gets its own deserialization pin.
+/// </summary>
+public class UsageStaleSchemaTests
+{
+    private const string PkginfoYaml = """
+        name: StaleApp
+        version: '1.0'
+        unattended_uninstall: true
+        days_untouched_before_uninstall: 30
+        usage_tracked_paths:
+        - C:\Program Files\StaleApp\staleapp.exe
+        - C:\Program Files\StaleApp\helper.exe
+        minimum_usage_history_days: 14
+        """;
+
+    private static IDeserializer PlainDeserializer() => new DeserializerBuilder()
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    [Fact]
+    public void CimiimportPkgsInfo_Deserializes_UsageStaleFields()
+    {
+        var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Cimiimport.Models.PkgsInfo>(PkginfoYaml);
+
+        Assert.Equal(30, pkg.DaysUntouchedBeforeUninstall);
+        Assert.Equal(2, pkg.UsageTrackedPaths?.Count);
+        Assert.Equal(14, pkg.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void MakecatalogsPkgsInfo_Deserializes_UsageStaleFields()
+    {
+        var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(PkginfoYaml);
+
+        Assert.Equal(30, pkg.DaysUntouchedBeforeUninstall);
+        Assert.Equal(2, pkg.UsageTrackedPaths?.Count);
+        Assert.Equal(14, pkg.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void EngineCatalogItem_Deserializes_UsageStaleFields()
+    {
+        var item = PlainDeserializer().Deserialize<Cimian.CLI.managedsoftwareupdate.Models.CatalogItem>(PkginfoYaml);
+
+        Assert.True(item.UnattendedUninstall);
+        Assert.Equal(30, item.DaysUntouchedBeforeUninstall);
+        Assert.Equal(2, item.UsageTrackedPaths?.Count);
+        Assert.Equal(14, item.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void EngineCatalogItem_FieldsDefaultNull_WhenAbsent()
+    {
+        // Absence must read as "feature disabled", never zero — the engine
+        // treats null/<=0 as opt-out, so a default of 0 is equivalent, but
+        // null is the canonical not-configured signal for reporting.
+        const string minimal = """
+            name: PlainApp
+            version: '1.0'
+            """;
+
+        var item = PlainDeserializer().Deserialize<Cimian.CLI.managedsoftwareupdate.Models.CatalogItem>(minimal);
+
+        Assert.Null(item.DaysUntouchedBeforeUninstall);
+        Assert.Null(item.UsageTrackedPaths);
+        Assert.Null(item.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void MakecatalogsPkgsInfo_RoundTrips_UsageStaleFields()
+    {
+        var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(PkginfoYaml);
+        var yaml = new SerializerBuilder().Build().Serialize(pkg);
+        var again = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(yaml);
+
+        Assert.Equal(30, again.DaysUntouchedBeforeUninstall);
+        Assert.Equal(pkg.UsageTrackedPaths, again.UsageTrackedPaths);
+        Assert.Equal(14, again.MinimumUsageHistoryDays);
+    }
+}
+
+/// <summary>
+/// Contract pins for NoOpUsageDataSource: every answer must push callers
+/// down their fail-safe path (skip the stale-usage pass entirely).
+/// </summary>
+public class NoOpUsageDataSourceTests
+{
+    private readonly NoOpUsageDataSource _source = new();
+
+    [Fact]
+    public void IsAvailable_IsFalse() => Assert.False(_source.IsAvailable);
+
+    [Fact]
+    public void TryGetLastUsed_ReturnsFalse_ForAnyPath()
+    {
+        Assert.False(_source.TryGetLastUsed(@"C:\Program Files\Any\any.exe", out var lastUsed));
+        Assert.Equal(default, lastUsed);
+    }
+
+    [Fact]
+    public void GetHistoryDays_IsZero() => Assert.Equal(0, _source.GetHistoryDays());
+
+    [Fact]
+    public void GetDataFreshnessDays_IsMaxValue_SoAnyStalenessThresholdRejects()
+        => Assert.Equal(int.MaxValue, _source.GetDataFreshnessDays());
+}


### PR DESCRIPTION
## Summary

PR 2 of 3 for stale-usage removal (stacked on #50 — merge that first; this PR''s base is `feat/usage-stale-uninstall-schema`).

Implements `IUsageDataSource` against the per-user JSON files ReportMate''s `usagetracker.exe` writes to `%ProgramData%\ManagedReports\usagetracker\{username}.json` (shipping in reportmate-client-win `2026.06.11.0622`+).

## Semantics

- **Device-wide answers**: last-used per exe is the MAX across every user file — one user running an app daily keeps it from being "untouched" regardless of other users.
- **Day granularity**: usagetracker keys counters by local date; last-used resolves to local midnight of the newest day with non-zero foreground/active seconds. Zero-counter rows are bookkeeping, not usage, and are ignored.
- **Exact path lookup** (OrdinalIgnoreCase) with **basename fallback** for Program Files vs (x86) vs per-user layout drift.
- **`GetHistoryDays`** spans from the earliest record (or `StartedAt` for a fresh file with no rows) — brand-new devices fail the minimum-history guard.
- **`GetDataFreshnessDays`** from the writer''s own `LastUpdatedAt` (file-mtime fallback) — weeks-idle telemetry refuses to drive uninstalls.
- **Defensive parsing**: a torn/malformed user file degrades to "no data from that user" (logged), never an exception or a false "unused".

One directory scan per instance (`Lazy` snapshot): the engine asks about many packages per run and the files are KB-sized.

## Tests

13 fixture tests writing real usagetracker-schema JSON to a temp dir: availability, case-insensitive lookup, basename fallback, multi-user MAX, zero-counter rows, malformed-file skip, fresh-file history accrual, freshness guard, fail-safe defaults. All green.

## Schema validation against production

Parser field names and nesting validated against a **real** state file written by usagetracker `2026.06.11` on a production device (7 apps tracked):

```json
{"SchemaVersion":1,"Username":"...","UserSid":"S-1-12-1-...","StartedAt":"2026-06-11T05:53:03Z",
 "LastUpdatedAt":"2026-06-11T06:11:34Z",
 "ByAppByDate":{"C:\\Windows\\explorer.exe":{"2026-06-10":{"ForegroundSeconds":60.1,"ActiveSeconds":60.1}}, ...}}
```

## Next

PR 3 wires `IdentifyStaleUsageItems` into `UpdateEngine.IdentifyActions` behind a `Config.yaml` flag (default off).