### PR TITLE
engine: stale-usage removal pass behind UsageStaleUninstallEnabled

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -128,6 +128,30 @@ public class PkgsInfo
     [YamlMember(Alias = "unattended_uninstall")]
     public bool UnattendedUninstall { get; set; }
 
+    /// <summary>
+    /// Opt-in stale-usage removal: uninstall this package when none of its
+    /// tracked executables have been used for this many days. Requires
+    /// unattended_uninstall and usage data (ReportMate usagetracker).
+    /// Null or &lt;= 0 disables the feature for this package.
+    /// </summary>
+    [YamlMember(Alias = "days_untouched_before_uninstall")]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates stale-usage removal. When empty,
+    /// the client falls back to .exe entries in the installs array.
+    /// </summary>
+    [YamlMember(Alias = "usage_tracked_paths")]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    /// <summary>
+    /// Minimum days of usage history that must exist on the device before
+    /// stale-usage removal may act (guards freshly imaged machines).
+    /// Null defers to the client's global default.
+    /// </summary>
+    [YamlMember(Alias = "minimum_usage_history_days")]
+    public int? MinimumUsageHistoryDays { get; set; }
+
     [YamlMember(Alias = "minimum_os_version")]
     public string? MinOSVersion { get; set; }
 

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -132,6 +132,30 @@ public class PkgsInfo
 
     [YamlMember(Alias = "installer", Order = 25, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public Installer? Installer { get; set; }
+
+    [YamlMember(Alias = "unattended_uninstall", Order = 26, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public bool UnattendedUninstall { get; set; }
+
+    /// <summary>
+    /// Opt-in stale-usage removal: uninstall when none of the tracked
+    /// executables have been used for this many days.
+    /// </summary>
+    [YamlMember(Alias = "days_untouched_before_uninstall", Order = 27, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates stale-usage removal. When empty,
+    /// the client falls back to .exe entries in the installs array.
+    /// </summary>
+    [YamlMember(Alias = "usage_tracked_paths", Order = 28, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    /// <summary>
+    /// Minimum days of usage history required on the device before
+    /// stale-usage removal may act.
+    /// </summary>
+    [YamlMember(Alias = "minimum_usage_history_days", Order = 29, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public int? MinimumUsageHistoryDays { get; set; }
 }
 
 /// <summary>

--- a/cli/makepkginfo/Program.cs
+++ b/cli/makepkginfo/Program.cs
@@ -101,6 +101,21 @@ class Program
             "--OnDemand",
             "Set 'OnDemand: true' - items that can be run multiple times");
 
+        var daysUntouchedOption = new Option<int?>(
+            "--days_untouched_before_uninstall",
+            "Uninstall when no tracked executable has been used for this many days (requires --unattended_uninstall and usage data)");
+
+        var usageTrackedPathOption = new Option<string[]>(
+            "--usage_tracked_path",
+            "Executable path whose usage gates stale-usage removal (can be specified multiple times; defaults to .exe entries in installs)")
+        {
+            AllowMultipleArgumentsPerToken = true
+        };
+
+        var minUsageHistoryOption = new Option<int?>(
+            "--minimum_usage_history_days",
+            "Minimum days of usage history required on a device before stale-usage removal may act");
+
         var newPkgOption = new Option<bool>(
             "--new",
             "Create a new pkginfo stub");
@@ -141,6 +156,9 @@ class Program
         rootCommand.AddOption(unattendedInstallOption);
         rootCommand.AddOption(unattendedUninstallOption);
         rootCommand.AddOption(onDemandOption);
+        rootCommand.AddOption(daysUntouchedOption);
+        rootCommand.AddOption(usageTrackedPathOption);
+        rootCommand.AddOption(minUsageHistoryOption);
         rootCommand.AddOption(newPkgOption);
         rootCommand.AddOption(additionalFilesOption);
         rootCommand.AddArgument(installerArgument);
@@ -168,6 +186,9 @@ class Program
             var unattendedInstall = context.ParseResult.GetValueForOption(unattendedInstallOption);
             var unattendedUninstall = context.ParseResult.GetValueForOption(unattendedUninstallOption);
             var onDemand = context.ParseResult.GetValueForOption(onDemandOption);
+            var daysUntouched = context.ParseResult.GetValueForOption(daysUntouchedOption);
+            var usageTrackedPaths = context.ParseResult.GetValueForOption(usageTrackedPathOption);
+            var minUsageHistory = context.ParseResult.GetValueForOption(minUsageHistoryOption);
             var newPkg = context.ParseResult.GetValueForOption(newPkgOption);
             var additionalFiles = context.ParseResult.GetValueForOption(additionalFilesOption);
             var installerPath = context.ParseResult.GetValueForArgument(installerArgument);
@@ -234,6 +255,9 @@ class Program
                     UnattendedInstall = unattendedInstall,
                     UnattendedUninstall = unattendedUninstall,
                     OnDemand = onDemand,
+                    DaysUntouchedBeforeUninstall = daysUntouched,
+                    UsageTrackedPaths = usageTrackedPaths?.Length > 0 ? usageTrackedPaths.ToList() : null,
+                    MinimumUsageHistoryDays = minUsageHistory,
                     MinOSVersion = minOSVersion,
                     MaxOSVersion = maxOSVersion,
                     MinCimianVersion = minCimianVersion,

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -183,10 +183,14 @@ public class PkgInfoBuilder
             Description = finalDesc,
             InstallerType = installerType,
             UnattendedInstall = options.UnattendedInstall,
+            UnattendedUninstall = options.UnattendedUninstall,
             OnDemand = options.OnDemand,
             MinOSVersion = options.MinOSVersion,
             MaxOSVersion = options.MaxOSVersion,
             MinCimianVersion = options.MinCimianVersion,
+            DaysUntouchedBeforeUninstall = options.DaysUntouchedBeforeUninstall,
+            UsageTrackedPaths = options.UsageTrackedPaths,
+            MinimumUsageHistoryDays = options.MinimumUsageHistoryDays,
             Installs = installs
         };
 
@@ -400,6 +404,9 @@ public class PkgsInfoOptions
     public bool UnattendedInstall { get; set; }
     public bool UnattendedUninstall { get; set; }
     public bool OnDemand { get; set; }
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+    public List<string>? UsageTrackedPaths { get; set; }
+    public int? MinimumUsageHistoryDays { get; set; }
     public string? MinOSVersion { get; set; }
     public string? MaxOSVersion { get; set; }
     public string? MinCimianVersion { get; set; }

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -399,6 +399,29 @@ public class CatalogItem
     [YamlMember(Alias = "force_install_after_date")]
     public DateTime? ForceInstallAfterDate { get; set; }
 
+    /// <summary>
+    /// Opt-in stale-usage removal: uninstall when none of the tracked
+    /// executables have been used for this many days. Requires
+    /// UnattendedUninstall and an available usage data source.
+    /// Null or &lt;= 0 disables the feature for this package.
+    /// </summary>
+    [YamlMember(Alias = "days_untouched_before_uninstall")]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates stale-usage removal. When empty,
+    /// the client falls back to .exe entries in the installs array.
+    /// </summary>
+    [YamlMember(Alias = "usage_tracked_paths")]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    /// <summary>
+    /// Minimum days of usage history required on this device before
+    /// stale-usage removal may act. Null defers to the global default.
+    /// </summary>
+    [YamlMember(Alias = "minimum_usage_history_days")]
+    public int? MinimumUsageHistoryDays { get; set; }
+
     [YamlMember(Alias = "restart_action")]
     public string? RestartAction { get; set; }
 

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -93,6 +93,27 @@ public class CimianConfig
     [YamlMember(Alias = "AutoRemove")]
     public bool AutoRemove { get; set; }
 
+    /// <summary>
+    /// Master switch for stale-usage removal (days_untouched_before_uninstall).
+    /// Off by default: packages opt in via pkginfo, fleets opt in here.
+    /// </summary>
+    [YamlMember(Alias = "UsageStaleUninstallEnabled")]
+    public bool UsageStaleUninstallEnabled { get; set; }
+
+    /// <summary>
+    /// Global fallback for minimum_usage_history_days when a package doesn't
+    /// set its own: refuse stale removal on devices with less usage history.
+    /// </summary>
+    [YamlMember(Alias = "UsageStaleUninstallMinimumHistoryDays")]
+    public int UsageStaleUninstallMinimumHistoryDays { get; set; } = 14;
+
+    /// <summary>
+    /// Skip the entire stale-usage pass when the usage source hasn't recorded
+    /// anything within this many days — idle telemetry must not drive removals.
+    /// </summary>
+    [YamlMember(Alias = "UsageStaleUninstallMaxSourceStalenessDays")]
+    public int UsageStaleUninstallMaxSourceStalenessDays { get; set; } = 7;
+
     // SSL client certificate authentication
     [YamlMember(Alias = "UseClientCertificate")]
     public bool UseClientCertificate { get; set; }

--- a/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
+++ b/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
@@ -1,0 +1,132 @@
+// StaleUsageEvaluator.cs - per-package stale-usage removal decision
+// Pure decision logic for "should this installed package be uninstalled
+// because nobody has used it" — separated from UpdateEngine so the guard
+// ladder is unit-testable without registry or manifest plumbing.
+
+using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.Core.Services;
+
+namespace Cimian.CLI.managedsoftwareupdate.Services;
+
+public enum StaleUsageOutcome
+{
+    /// <summary>days_untouched_before_uninstall absent or &lt;= 0.</summary>
+    NotOptedIn,
+    /// <summary>Package has not approved silent removal (unattended_uninstall false).</summary>
+    NotUnattended,
+    /// <summary>No uninstall method defined — nothing the engine could run.</summary>
+    NotUninstallable,
+    /// <summary>No usage_tracked_paths and no .exe in the installs array.</summary>
+    NoTrackedExecutables,
+    /// <summary>Device has less usage history than the package (or global) minimum.</summary>
+    InsufficientHistory,
+    /// <summary>No tracked executable has any usage record — absence is not disuse.</summary>
+    NoUsageData,
+    /// <summary>Used within the threshold; keep.</summary>
+    RecentlyUsed,
+    /// <summary>All tracked executables untouched past the threshold; uninstall.</summary>
+    Stale,
+}
+
+/// <param name="Outcome">The decision.</param>
+/// <param name="DaysSinceLastUsed">Days since the newest usage across tracked exes (-1 when no data).</param>
+/// <param name="ThresholdDays">The package's days_untouched_before_uninstall.</param>
+public sealed record StaleUsageDecision(
+    StaleUsageOutcome Outcome,
+    double DaysSinceLastUsed = -1,
+    int ThresholdDays = 0);
+
+/// <summary>
+/// Evaluates one catalog item against a usage data source. Every ambiguous
+/// state resolves to a non-removal outcome: only a package that opted in,
+/// can be silently uninstalled, has enough device history, and has a real
+/// usage record older than its threshold comes back <see cref="StaleUsageOutcome.Stale"/>.
+/// </summary>
+public static class StaleUsageEvaluator
+{
+    public static StaleUsageDecision Evaluate(
+        CatalogItem item,
+        IUsageDataSource usage,
+        int globalMinimumHistoryDays)
+    {
+        var threshold = item.DaysUntouchedBeforeUninstall ?? 0;
+        if (threshold <= 0)
+        {
+            return new StaleUsageDecision(StaleUsageOutcome.NotOptedIn);
+        }
+
+        if (!item.UnattendedUninstall)
+        {
+            return new StaleUsageDecision(StaleUsageOutcome.NotUnattended, ThresholdDays: threshold);
+        }
+
+        if (!item.IsUninstallable())
+        {
+            return new StaleUsageDecision(StaleUsageOutcome.NotUninstallable, ThresholdDays: threshold);
+        }
+
+        var trackedPaths = ResolveTrackedExecutables(item);
+        if (trackedPaths.Count == 0)
+        {
+            return new StaleUsageDecision(StaleUsageOutcome.NoTrackedExecutables, ThresholdDays: threshold);
+        }
+
+        var minHistory = item.MinimumUsageHistoryDays ?? globalMinimumHistoryDays;
+        if (usage.GetHistoryDays() < minHistory)
+        {
+            return new StaleUsageDecision(StaleUsageOutcome.InsufficientHistory, ThresholdDays: threshold);
+        }
+
+        DateTime? newest = null;
+        foreach (var exe in trackedPaths)
+        {
+            if (usage.TryGetLastUsed(exe, out var lastUsed) &&
+                (newest is null || lastUsed > newest))
+            {
+                newest = lastUsed;
+            }
+        }
+
+        if (newest is null)
+        {
+            // None of the tracked exes has ever been observed. The tracker may
+            // predate the app, the paths may not match, or the app may truly
+            // never have launched — indistinguishable, so never uninstall.
+            return new StaleUsageDecision(StaleUsageOutcome.NoUsageData, ThresholdDays: threshold);
+        }
+
+        var daysSince = (DateTime.UtcNow - newest.Value).TotalDays;
+        return daysSince > threshold
+            ? new StaleUsageDecision(StaleUsageOutcome.Stale, daysSince, threshold)
+            : new StaleUsageDecision(StaleUsageOutcome.RecentlyUsed, daysSince, threshold);
+    }
+
+    /// <summary>
+    /// usage_tracked_paths when present; otherwise every .exe mentioned in the
+    /// installs array (path or key_path — key_path is the MSI's primary
+    /// executable, which is exactly what a user launches).
+    /// </summary>
+    internal static List<string> ResolveTrackedExecutables(CatalogItem item)
+    {
+        if (item.UsageTrackedPaths is { Count: > 0 })
+        {
+            return item.UsageTrackedPaths
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .ToList();
+        }
+
+        var fromInstalls = new List<string>();
+        foreach (var inst in item.Installs)
+        {
+            if (inst.Path?.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                fromInstalls.Add(inst.Path);
+            }
+            if (inst.KeyPath?.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                fromInstalls.Add(inst.KeyPath);
+            }
+        }
+        return fromInstalls;
+    }
+}

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -50,6 +50,8 @@ public class UpdateEngine : IDisposable
     private List<ManifestItem> _allManifestItems = new();
     private Dictionary<string, CatalogItem> _catalogMap = new();
 
+    private readonly IUsageDataSource _usageSource;
+
     public UpdateEngine(CimianConfig config)
     {
         _config = config;
@@ -60,6 +62,12 @@ public class UpdateEngine : IDisposable
         _installerService = new InstallerService(config);
         _statusService = new StatusService();
         _scriptService = new ScriptService();
+
+        // Stale-usage removal reads ReportMate usagetracker data; when the
+        // feature is off the NoOp source makes the whole pass a cheap branch.
+        _usageSource = config.UsageStaleUninstallEnabled
+            ? new ReportMateUsageDataSource()
+            : new NoOpUsageDataSource();
 
         // Enable ANSI color support on Windows console
         EnableAnsiColors();
@@ -414,6 +422,22 @@ public class UpdateEngine : IDisposable
                         _sessionLogger?.Log("INFO", $"AutoRemove: {item.Name} v{item.Version} no longer in any manifest");
                     }
                     toUninstall.AddRange(autoRemoveItems);
+                }
+            }
+
+            // Stale-usage removal: queue uninstall for opted-in packages whose
+            // tracked executables nobody on the device has used within
+            // days_untouched_before_uninstall. Peer of AutoRemove, not a
+            // dependency walker — and placed before the downstream filters so
+            // install_window / blocking_applications / unattended gating apply
+            // to these uninstalls the same as any other.
+            if (_config.UsageStaleUninstallEnabled)
+            {
+                var staleUsageItems = IdentifyStaleUsageItems(manifestItems, catalogMap, toUninstall);
+                if (staleUsageItems.Count > 0)
+                {
+                    ConsoleLogger.Info($"StaleUsage: {staleUsageItems.Count} package(s) untouched past their threshold");
+                    toUninstall.AddRange(staleUsageItems);
                 }
             }
 
@@ -1130,6 +1154,114 @@ public class UpdateEngine : IDisposable
         }
 
         return autoRemove;
+    }
+
+    /// <summary>
+    /// Identifies Cimian-installed packages eligible for stale-usage removal:
+    /// opted in via days_untouched_before_uninstall, unattended-uninstallable,
+    /// and untouched by every user on the device past the threshold per the
+    /// usage data source. Mirrors <see cref="IdentifyAutoRemoveItems"/>: only
+    /// packages in the ManagedInstalls registry are candidates, and anything
+    /// still named by a manifest is skipped — uninstalling a manifested item
+    /// would just reinstall next run (admin intent wins). Self-serve items are
+    /// deliberately untouched in this pass; removing those requires clearing
+    /// the self-serve manifest entry too (follow-up).
+    /// </summary>
+    private List<CatalogItem> IdentifyStaleUsageItems(
+        List<ManifestItem> manifestItems,
+        Dictionary<string, CatalogItem> catalogMap,
+        List<CatalogItem> alreadyQueued)
+    {
+        var stale = new List<CatalogItem>();
+
+        if (!_usageSource.IsAvailable)
+        {
+            ConsoleLogger.Info($"StaleUsage: usage source '{_usageSource.SourceName}' unavailable - skipping pass");
+            return stale;
+        }
+
+        var freshness = _usageSource.GetDataFreshnessDays();
+        if (freshness > _config.UsageStaleUninstallMaxSourceStalenessDays)
+        {
+            ConsoleLogger.Warn(
+                $"StaleUsage: usage data is {freshness} day(s) old (max {_config.UsageStaleUninstallMaxSourceStalenessDays}) - skipping pass");
+            return stale;
+        }
+
+        var manifestedNames = new HashSet<string>(
+            manifestItems.Select(m => m.Name).Where(n => !string.IsNullOrEmpty(n)),
+            StringComparer.OrdinalIgnoreCase);
+        var queuedNames = new HashSet<string>(
+            alreadyQueued.Select(i => i.Name),
+            StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            using var managedKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(
+                @"SOFTWARE\ManagedInstalls");
+            if (managedKey == null) return stale;
+
+            foreach (var name in managedKey.GetSubKeyNames())
+            {
+                if (manifestedNames.Contains(name) || queuedNames.Contains(name)) continue;
+                if (!catalogMap.TryGetValue(name.ToLowerInvariant(), out var catalogItem)) continue;
+
+                var decision = StaleUsageEvaluator.Evaluate(
+                    catalogItem, _usageSource, _config.UsageStaleUninstallMinimumHistoryDays);
+
+                switch (decision.Outcome)
+                {
+                    case StaleUsageOutcome.Stale:
+                        ConsoleLogger.Info(
+                            $"    -> StaleUsage: {catalogItem.Name} untouched {decision.DaysSinceLastUsed:F0} day(s) (threshold {decision.ThresholdDays}) - queuing uninstall");
+                        _sessionLogger?.LogStatusCheck(
+                            catalogItem.Name, catalogItem.Version, "removal_pending",
+                            $"untouched {decision.DaysSinceLastUsed:F0} day(s), threshold {decision.ThresholdDays}, source {_usageSource.SourceName}",
+                            StatusReasonCode.StaleUsageUninstall,
+                            DetectionMethod.ReportMateUsage,
+                            needsAction: true);
+                        stale.Add(catalogItem);
+                        break;
+
+                    case StaleUsageOutcome.NoUsageData:
+                        ConsoleLogger.Detail($"    StaleUsage: {catalogItem.Name} has no usage data - skipping (fail-safe)");
+                        _sessionLogger?.LogStatusCheck(
+                            catalogItem.Name, catalogItem.Version, "installed",
+                            "stale-usage check skipped: no usage data for any tracked executable",
+                            StatusReasonCode.StaleUsageSkippedNoData,
+                            DetectionMethod.ReportMateUsage);
+                        break;
+
+                    case StaleUsageOutcome.InsufficientHistory:
+                        ConsoleLogger.Detail($"    StaleUsage: {catalogItem.Name} - insufficient usage history on device - skipping");
+                        _sessionLogger?.LogStatusCheck(
+                            catalogItem.Name, catalogItem.Version, "installed",
+                            $"stale-usage check skipped: device history {_usageSource.GetHistoryDays()} day(s) below minimum",
+                            StatusReasonCode.StaleUsageSkippedInsufficientHistory,
+                            DetectionMethod.ReportMateUsage);
+                        break;
+
+                    case StaleUsageOutcome.RecentlyUsed:
+                        ConsoleLogger.Detail(
+                            $"    StaleUsage: {catalogItem.Name} used {decision.DaysSinceLastUsed:F0} day(s) ago (threshold {decision.ThresholdDays}) - keeping");
+                        break;
+
+                    case StaleUsageOutcome.NotUnattended:
+                    case StaleUsageOutcome.NotUninstallable:
+                    case StaleUsageOutcome.NoTrackedExecutables:
+                        ConsoleLogger.Detail($"    StaleUsage: {catalogItem.Name} skipped ({decision.Outcome})");
+                        break;
+
+                    // NotOptedIn is the overwhelmingly common case - stay silent.
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            ConsoleLogger.Warn($"StaleUsage: failed to enumerate ManagedInstalls registry: {ex.Message}");
+        }
+
+        return stale;
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -50,8 +50,6 @@ public class UpdateEngine : IDisposable
     private List<ManifestItem> _allManifestItems = new();
     private Dictionary<string, CatalogItem> _catalogMap = new();
 
-    private readonly IUsageDataSource _usageSource;
-
     public UpdateEngine(CimianConfig config)
     {
         _config = config;
@@ -62,12 +60,6 @@ public class UpdateEngine : IDisposable
         _installerService = new InstallerService(config);
         _statusService = new StatusService();
         _scriptService = new ScriptService();
-
-        // Stale-usage removal reads ReportMate usagetracker data; when the
-        // feature is off the NoOp source makes the whole pass a cheap branch.
-        _usageSource = config.UsageStaleUninstallEnabled
-            ? new ReportMateUsageDataSource()
-            : new NoOpUsageDataSource();
 
         // Enable ANSI color support on Windows console
         EnableAnsiColors();
@@ -433,7 +425,11 @@ public class UpdateEngine : IDisposable
             // to these uninstalls the same as any other.
             if (_config.UsageStaleUninstallEnabled)
             {
-                var staleUsageItems = IdentifyStaleUsageItems(manifestItems, catalogMap, toUninstall);
+                // Resolved here rather than in the constructor: preflight can
+                // reload _config, and the source's lazy snapshot should reflect
+                // this run's on-disk data, not engine-construction time.
+                var usageSource = new ReportMateUsageDataSource();
+                var staleUsageItems = IdentifyStaleUsageItems(manifestItems, catalogMap, toUninstall, usageSource);
                 if (staleUsageItems.Count > 0)
                 {
                     ConsoleLogger.Info($"StaleUsage: {staleUsageItems.Count} package(s) untouched past their threshold");
@@ -1170,17 +1166,18 @@ public class UpdateEngine : IDisposable
     private List<CatalogItem> IdentifyStaleUsageItems(
         List<ManifestItem> manifestItems,
         Dictionary<string, CatalogItem> catalogMap,
-        List<CatalogItem> alreadyQueued)
+        List<CatalogItem> alreadyQueued,
+        IUsageDataSource usageSource)
     {
         var stale = new List<CatalogItem>();
 
-        if (!_usageSource.IsAvailable)
+        if (!usageSource.IsAvailable)
         {
-            ConsoleLogger.Info($"StaleUsage: usage source '{_usageSource.SourceName}' unavailable - skipping pass");
+            ConsoleLogger.Info($"StaleUsage: usage source '{usageSource.SourceName}' unavailable - skipping pass");
             return stale;
         }
 
-        var freshness = _usageSource.GetDataFreshnessDays();
+        var freshness = usageSource.GetDataFreshnessDays();
         if (freshness > _config.UsageStaleUninstallMaxSourceStalenessDays)
         {
             ConsoleLogger.Warn(
@@ -1207,16 +1204,18 @@ public class UpdateEngine : IDisposable
                 if (!catalogMap.TryGetValue(name.ToLowerInvariant(), out var catalogItem)) continue;
 
                 var decision = StaleUsageEvaluator.Evaluate(
-                    catalogItem, _usageSource, _config.UsageStaleUninstallMinimumHistoryDays);
+                    catalogItem, usageSource, _config.UsageStaleUninstallMinimumHistoryDays);
 
                 switch (decision.Outcome)
                 {
                     case StaleUsageOutcome.Stale:
                         ConsoleLogger.Info(
                             $"    -> StaleUsage: {catalogItem.Name} untouched {decision.DaysSinceLastUsed:F0} day(s) (threshold {decision.ThresholdDays}) - queuing uninstall");
+                        // "pending" (not a custom status) so NormalizeItemStatus maps it
+                        // for downstream consumers; the reason code marks it a removal.
                         _sessionLogger?.LogStatusCheck(
-                            catalogItem.Name, catalogItem.Version, "removal_pending",
-                            $"untouched {decision.DaysSinceLastUsed:F0} day(s), threshold {decision.ThresholdDays}, source {_usageSource.SourceName}",
+                            catalogItem.Name, catalogItem.Version, "pending",
+                            $"untouched {decision.DaysSinceLastUsed:F0} day(s), threshold {decision.ThresholdDays}, source {usageSource.SourceName}",
                             StatusReasonCode.StaleUsageUninstall,
                             DetectionMethod.ReportMateUsage,
                             needsAction: true);
@@ -1236,7 +1235,7 @@ public class UpdateEngine : IDisposable
                         ConsoleLogger.Detail($"    StaleUsage: {catalogItem.Name} - insufficient usage history on device - skipping");
                         _sessionLogger?.LogStatusCheck(
                             catalogItem.Name, catalogItem.Version, "installed",
-                            $"stale-usage check skipped: device history {_usageSource.GetHistoryDays()} day(s) below minimum",
+                            $"stale-usage check skipped: device history {usageSource.GetHistoryDays()} day(s) below minimum",
                             StatusReasonCode.StaleUsageSkippedInsufficientHistory,
                             DetectionMethod.ReportMateUsage);
                         break;

--- a/shared/core/Models/StatusReasonCode.cs
+++ b/shared/core/Models/StatusReasonCode.cs
@@ -135,6 +135,15 @@ public static class StatusReasonCode
     /// <summary>Auto run deferred this item because a user is active — either it is not unattended-eligible, or its restart_action would interrupt the session</summary>
     public const string DeferredUserActive = "deferred_user_active";
 
+    /// <summary>Package queued for removal: no tracked executable used within days_untouched_before_uninstall</summary>
+    public const string StaleUsageUninstall = "stale_usage_uninstall";
+
+    /// <summary>Stale-usage check skipped: no usage data exists for any tracked executable</summary>
+    public const string StaleUsageSkippedNoData = "stale_usage_skipped_no_data";
+
+    /// <summary>Stale-usage check skipped: device has fewer days of usage history than minimum_usage_history_days</summary>
+    public const string StaleUsageSkippedInsufficientHistory = "stale_usage_skipped_insufficient_history";
+
     #endregion
 
     #region Removed Reasons - Package confirmed removed
@@ -204,6 +213,9 @@ public static class DetectionMethod
 
     /// <summary>ManagedInstalls registry tracking</summary>
     public const string ManagedInstalls = "managed_installs";
+
+    /// <summary>ReportMate usagetracker per-user usage data</summary>
+    public const string ReportMateUsage = "reportmate_usage";
 
     /// <summary>No detection method used</summary>
     public const string None = "none";

--- a/shared/core/Services/IUsageDataSource.cs
+++ b/shared/core/Services/IUsageDataSource.cs
@@ -1,0 +1,68 @@
+// IUsageDataSource.cs - Abstraction over per-device application usage data
+// Backs the stale-usage removal feature (days_untouched_before_uninstall):
+// the engine asks "when was this executable last used on this device?" and
+// refuses to act when the source cannot answer confidently.
+
+namespace Cimian.Core.Services;
+
+/// <summary>
+/// Provides device-wide application usage answers for stale-usage removal.
+/// Implementations aggregate across all users on the device — a package is
+/// only "untouched" when NO user has used it. All methods must fail safe:
+/// absence of data is never evidence of disuse.
+/// </summary>
+public interface IUsageDataSource
+{
+    /// <summary>
+    /// True when the source is present and responsive on this device.
+    /// False means the entire stale-usage pass should be skipped.
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Human-readable source name for logging and reports.</summary>
+    string SourceName { get; }
+
+    /// <summary>
+    /// Returns the most recent observed usage timestamp (UTC) for the
+    /// executable across all users on this device. Path comparison is
+    /// case-insensitive. Returns false when the executable has no record —
+    /// callers must treat that as "no signal", not "unused".
+    /// </summary>
+    bool TryGetLastUsed(string executablePath, out DateTime lastUsedUtc);
+
+    /// <summary>
+    /// Calendar days of usage history this source can attest to on this
+    /// device (earliest record to today). Gates against acting on freshly
+    /// imaged machines that simply have no history yet.
+    /// </summary>
+    int GetHistoryDays();
+
+    /// <summary>
+    /// Days since the source last recorded anything (any user, any app).
+    /// Stale telemetry — e.g. no logons for weeks — must not drive
+    /// uninstalls; callers skip the pass when this exceeds their threshold.
+    /// </summary>
+    int GetDataFreshnessDays();
+}
+
+/// <summary>
+/// Null implementation used when stale-usage removal is disabled or no
+/// usage source is configured. Reports unavailable and returns no data,
+/// so every caller takes its fail-safe path.
+/// </summary>
+public sealed class NoOpUsageDataSource : IUsageDataSource
+{
+    public bool IsAvailable => false;
+
+    public string SourceName => "none";
+
+    public bool TryGetLastUsed(string executablePath, out DateTime lastUsedUtc)
+    {
+        lastUsedUtc = default;
+        return false;
+    }
+
+    public int GetHistoryDays() => 0;
+
+    public int GetDataFreshnessDays() => int.MaxValue;
+}

--- a/shared/core/Services/ReportMateUsageDataSource.cs
+++ b/shared/core/Services/ReportMateUsageDataSource.cs
@@ -1,0 +1,259 @@
+// ReportMateUsageDataSource.cs - IUsageDataSource backed by ReportMate usagetracker
+// Reads the per-user JSON files written by ReportMate's usagetracker.exe
+// companion (reportmate-client-win). Each logged-in user gets one file at
+// %ProgramData%\ManagedReports\usagetracker\{username}.json holding
+// per-(exe path, local date) cumulative foreground/active counters.
+
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Cimian.Core.Services;
+
+/// <summary>
+/// Usage data source backed by ReportMate usagetracker per-user JSON files.
+/// Answers are device-wide: the last-used timestamp for an executable is the
+/// MAX across every user's file, so a package one user runs daily is never
+/// considered untouched because another user ignores it.
+///
+/// Granularity is one day — usagetracker keys counters by local date, so
+/// "last used" resolves to local midnight of the most recent day with
+/// non-zero foreground or active seconds. That is exact enough for
+/// thresholds measured in tens of days.
+///
+/// All parsing is defensive: a malformed or mid-rotation file degrades to
+/// "no data from that user" (logged), never an exception to the caller.
+/// </summary>
+public sealed class ReportMateUsageDataSource : IUsageDataSource
+{
+    /// <summary>Default usagetracker state directory on a managed device.</summary>
+    public static readonly string DefaultDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+        "ManagedReports", "usagetracker");
+
+    private readonly string _directory;
+    private readonly ILogger? _logger;
+    private readonly Lazy<Snapshot> _snapshot;
+
+    public ReportMateUsageDataSource(string? directory = null, ILogger? logger = null)
+    {
+        _directory = string.IsNullOrEmpty(directory) ? DefaultDirectory : directory;
+        _logger = logger;
+        // One scan per agent run: the files are tiny (KBs) and the engine
+        // asks about many packages, so parse everything once and serve
+        // lookups from memory.
+        _snapshot = new Lazy<Snapshot>(LoadSnapshot);
+    }
+
+    public bool IsAvailable => _snapshot.Value.FilesParsed > 0;
+
+    public string SourceName => "reportmate-usagetracker";
+
+    public bool TryGetLastUsed(string executablePath, out DateTime lastUsedUtc)
+    {
+        lastUsedUtc = default;
+        if (string.IsNullOrWhiteSpace(executablePath))
+        {
+            return false;
+        }
+
+        var snap = _snapshot.Value;
+
+        // Exact path match first (usagetracker keys by absolute exe path).
+        if (snap.LastUsedByExePath.TryGetValue(executablePath, out lastUsedUtc))
+        {
+            return true;
+        }
+
+        // Fall back to basename matching: pkginfo authors may record a path
+        // under Program Files while the tracker observed Program Files (x86),
+        // or per-user installs under AppData. The basename is stable across
+        // those layouts. MAX across all matches keeps the device-wide rule.
+        var baseName = Path.GetFileName(executablePath);
+        if (!string.IsNullOrEmpty(baseName) &&
+            snap.LastUsedByExeName.TryGetValue(baseName, out lastUsedUtc))
+        {
+            return true;
+        }
+
+        lastUsedUtc = default;
+        return false;
+    }
+
+    public int GetHistoryDays()
+    {
+        var earliest = _snapshot.Value.EarliestRecordUtc;
+        if (earliest is null)
+        {
+            return 0;
+        }
+
+        var days = (int)(DateTime.UtcNow - earliest.Value).TotalDays;
+        return Math.Max(0, days);
+    }
+
+    public int GetDataFreshnessDays()
+    {
+        var latest = _snapshot.Value.LatestWriteUtc;
+        if (latest is null)
+        {
+            return int.MaxValue;
+        }
+
+        var days = (int)(DateTime.UtcNow - latest.Value).TotalDays;
+        return Math.Max(0, days);
+    }
+
+    // ─────────────────────────── parsing ───────────────────────────
+
+    private sealed class Snapshot
+    {
+        public Dictionary<string, DateTime> LastUsedByExePath { get; } =
+            new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, DateTime> LastUsedByExeName { get; } =
+            new(StringComparer.OrdinalIgnoreCase);
+        public DateTime? EarliestRecordUtc { get; set; }
+        public DateTime? LatestWriteUtc { get; set; }
+        public int FilesParsed { get; set; }
+    }
+
+    // Mirrors usagetracker's TrackerState. Field semantics:
+    //   ByAppByDate[absolute exe path][yyyy-MM-dd local date] = counters
+    private sealed class TrackerState
+    {
+        public string? Username { get; set; }
+        public DateTime? StartedAt { get; set; }
+        public DateTime? LastUpdatedAt { get; set; }
+        public Dictionary<string, Dictionary<string, AppDayCounters>>? ByAppByDate { get; set; }
+    }
+
+    private sealed class AppDayCounters
+    {
+        public double ForegroundSeconds { get; set; }
+        public double ActiveSeconds { get; set; }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private Snapshot LoadSnapshot()
+    {
+        var snap = new Snapshot();
+
+        string[] files;
+        try
+        {
+            if (!Directory.Exists(_directory))
+            {
+                _logger?.LogDebug("Usage source directory not found: {Directory}", _directory);
+                return snap;
+            }
+            files = Directory.GetFiles(_directory, "*.json", SearchOption.TopDirectoryOnly);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning("Cannot enumerate usage source directory {Directory}: {Message}",
+                _directory, ex.Message);
+            return snap;
+        }
+
+        foreach (var file in files)
+        {
+            try
+            {
+                ParseUserFile(file, snap);
+                snap.FilesParsed++;
+            }
+            catch (Exception ex)
+            {
+                // One unreadable user file (torn write, schema drift) must not
+                // poison the others — and absolutely must not become "the app
+                // is unused".
+                _logger?.LogWarning("Skipping unreadable usage file {File}: {Message}",
+                    Path.GetFileName(file), ex.Message);
+            }
+        }
+
+        return snap;
+    }
+
+    private void ParseUserFile(string file, Snapshot snap)
+    {
+        var state = JsonSerializer.Deserialize<TrackerState>(File.ReadAllText(file), JsonOptions);
+        if (state is null)
+        {
+            return;
+        }
+
+        // Freshness: prefer the writer's own stamp; fall back to file mtime
+        // so a schema without LastUpdatedAt still yields a usable signal.
+        var write = state.LastUpdatedAt?.ToUniversalTime()
+                    ?? File.GetLastWriteTimeUtc(file);
+        if (snap.LatestWriteUtc is null || write > snap.LatestWriteUtc)
+        {
+            snap.LatestWriteUtc = write;
+        }
+
+        // History floor: a fresh file with no usage rows still attests that
+        // tracking has been running since StartedAt.
+        var started = state.StartedAt?.ToUniversalTime();
+        if (started is not null &&
+            (snap.EarliestRecordUtc is null || started < snap.EarliestRecordUtc))
+        {
+            snap.EarliestRecordUtc = started;
+        }
+
+        if (state.ByAppByDate is null)
+        {
+            return;
+        }
+
+        foreach (var (exePath, byDate) in state.ByAppByDate)
+        {
+            if (string.IsNullOrWhiteSpace(exePath) || byDate is null)
+            {
+                continue;
+            }
+
+            foreach (var (dateKey, counters) in byDate)
+            {
+                if (!DateTime.TryParseExact(dateKey, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                        DateTimeStyles.None, out var localDate))
+                {
+                    continue;
+                }
+
+                var dayUtc = DateTime.SpecifyKind(localDate, DateTimeKind.Local).ToUniversalTime();
+
+                if (snap.EarliestRecordUtc is null || dayUtc < snap.EarliestRecordUtc)
+                {
+                    snap.EarliestRecordUtc = dayUtc;
+                }
+
+                // A date row with all-zero counters is bookkeeping, not usage.
+                if (counters is null ||
+                    (counters.ForegroundSeconds <= 0 && counters.ActiveSeconds <= 0))
+                {
+                    continue;
+                }
+
+                Bump(snap.LastUsedByExePath, exePath, dayUtc);
+                var baseName = Path.GetFileName(exePath);
+                if (!string.IsNullOrEmpty(baseName))
+                {
+                    Bump(snap.LastUsedByExeName, baseName, dayUtc);
+                }
+            }
+        }
+    }
+
+    private static void Bump(Dictionary<string, DateTime> map, string key, DateTime candidateUtc)
+    {
+        if (!map.TryGetValue(key, out var existing) || candidateUtc > existing)
+        {
+            map[key] = candidateUtc;
+        }
+    }
+}

--- a/shared/core/Services/ReportMateUsageDataSource.cs
+++ b/shared/core/Services/ReportMateUsageDataSource.cs
@@ -100,8 +100,21 @@ public sealed class ReportMateUsageDataSource : IUsageDataSource
             return int.MaxValue;
         }
 
-        var days = (int)(DateTime.UtcNow - latest.Value).TotalDays;
-        return Math.Max(0, days);
+        var age = DateTime.UtcNow - latest.Value;
+
+        // A write stamp from the future means clock skew or tampering. Up to
+        // a day of skew reads as "fresh now"; beyond that the telemetry is
+        // not trustworthy, and untrustworthy must mean "too stale to act on",
+        // never "perfectly fresh".
+        if (age < TimeSpan.FromDays(-1))
+        {
+            _logger?.LogWarning(
+                "Usage data write stamp is {Hours:F0}h in the future - treating as invalid",
+                -age.TotalHours);
+            return int.MaxValue;
+        }
+
+        return Math.Max(0, (int)age.TotalDays);
     }
 
     // ─────────────────────────── parsing ───────────────────────────
@@ -154,8 +167,7 @@ public sealed class ReportMateUsageDataSource : IUsageDataSource
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning("Cannot enumerate usage source directory {Directory}: {Message}",
-                _directory, ex.Message);
+            _logger?.LogWarning(ex, "Cannot enumerate usage source directory {Directory}", _directory);
             return snap;
         }
 
@@ -171,8 +183,7 @@ public sealed class ReportMateUsageDataSource : IUsageDataSource
                 // One unreadable user file (torn write, schema drift) must not
                 // poison the others — and absolutely must not become "the app
                 // is unused".
-                _logger?.LogWarning("Skipping unreadable usage file {File}: {Message}",
-                    Path.GetFileName(file), ex.Message);
+                _logger?.LogWarning(ex, "Skipping unreadable usage file {File}", Path.GetFileName(file));
             }
         }
 

--- a/shared/import/Models/ImportModels.cs
+++ b/shared/import/Models/ImportModels.cs
@@ -48,6 +48,15 @@ public class PkgsInfo
     [YamlMember(Alias = "unattended_uninstall")]
     public bool UnattendedUninstall { get; set; }
 
+    [YamlMember(Alias = "days_untouched_before_uninstall")]
+    public int? DaysUntouchedBeforeUninstall { get; set; }
+
+    [YamlMember(Alias = "usage_tracked_paths")]
+    public List<string>? UsageTrackedPaths { get; set; }
+
+    [YamlMember(Alias = "minimum_usage_history_days")]
+    public int? MinimumUsageHistoryDays { get; set; }
+
     [YamlMember(Alias = "requires")]
     public List<string>? Requires { get; set; }
 

--- a/tests/Makepkginfo/PkgInfoBuilderTests.cs
+++ b/tests/Makepkginfo/PkgInfoBuilderTests.cs
@@ -168,6 +168,50 @@ public class PkgInfoBuilderTests
     }
 
     [Fact]
+    public void BuildFromInstaller_EmitsUnattendedUninstall_AndUsageStaleFields()
+    {
+        // Pins the PkgsInfoOptions -> PkgsInfo wiring in BuildFromInstaller.
+        // --unattended_uninstall was historically parsed but silently dropped
+        // (the model had no property and BuildFromInstaller never assigned
+        // it), so this test guards the whole option set end to end: build
+        // from a real file, then assert the YAML keys actually appear.
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "installer payload");
+
+            var options = new PkgsInfoOptions
+            {
+                Name = "StaleApp",
+                Version = "1.0",
+                Catalogs = new List<string> { "Testing" },
+                UnattendedInstall = true,
+                UnattendedUninstall = true,
+                DaysUntouchedBeforeUninstall = 30,
+                UsageTrackedPaths = new List<string> { @"C:\Program Files\StaleApp\staleapp.exe" },
+                MinimumUsageHistoryDays = 14,
+            };
+
+            var pkgsinfo = _builder.BuildFromInstaller(tempFile, options);
+
+            Assert.True(pkgsinfo.UnattendedUninstall);
+            Assert.Equal(30, pkgsinfo.DaysUntouchedBeforeUninstall);
+            Assert.Equal(options.UsageTrackedPaths, pkgsinfo.UsageTrackedPaths);
+            Assert.Equal(14, pkgsinfo.MinimumUsageHistoryDays);
+
+            var yaml = _builder.SerializePkgsInfo(pkgsinfo);
+            Assert.Contains("unattended_uninstall: true", yaml);
+            Assert.Contains("days_untouched_before_uninstall: 30", yaml);
+            Assert.Contains("usage_tracked_paths:", yaml);
+            Assert.Contains("minimum_usage_history_days: 14", yaml);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void SerializePkgsInfo_ReturnsValidYaml()
     {
         var pkgsinfo = new PkgsInfo

--- a/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
+++ b/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
@@ -1,0 +1,188 @@
+using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.CLI.managedsoftwareupdate.Services;
+using Cimian.Core.Services;
+using Xunit;
+
+namespace Cimian.Tests.Managedsoftwareupdate;
+
+/// <summary>
+/// Pins the stale-usage decision ladder. The ordering of the guards matters:
+/// a package must fall out at the FIRST failed gate (opt-in → unattended →
+/// uninstallable → tracked exes → history → data → threshold) so reports
+/// attribute the skip to the real cause.
+/// </summary>
+public class StaleUsageEvaluatorTests
+{
+    private const string Exe = @"C:\Program Files\StaleApp\staleapp.exe";
+
+    private sealed class FakeUsageSource : IUsageDataSource
+    {
+        public Dictionary<string, DateTime> Data { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public int HistoryDays { get; set; } = 60;
+        public int FreshnessDays { get; set; } = 0;
+
+        public bool IsAvailable => true;
+        public string SourceName => "fake";
+        public int GetHistoryDays() => HistoryDays;
+        public int GetDataFreshnessDays() => FreshnessDays;
+
+        public bool TryGetLastUsed(string executablePath, out DateTime lastUsedUtc) =>
+            Data.TryGetValue(executablePath, out lastUsedUtc);
+    }
+
+    /// <summary>Opted-in, unattended, MSI-uninstallable item tracking one exe.</summary>
+    private static CatalogItem Item(int? threshold = 30, bool unattended = true) => new()
+    {
+        Name = "StaleApp",
+        Version = "1.0",
+        UnattendedUninstall = unattended,
+        Uninstallable = true,
+        DaysUntouchedBeforeUninstall = threshold,
+        UsageTrackedPaths = new List<string> { Exe },
+        Installs = new List<InstallCheckItem>
+        {
+            new() { Type = "msi", ProductCode = "{11111111-2222-3333-4444-555555555555}" },
+        },
+    };
+
+    private static FakeUsageSource SourceWithUsage(int daysAgo)
+    {
+        var s = new FakeUsageSource();
+        s.Data[Exe] = DateTime.UtcNow.AddDays(-daysAgo);
+        return s;
+    }
+
+    // ── guard ladder ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void NotOptedIn_WhenThresholdAbsentOrNonPositive(int? threshold)
+    {
+        var decision = StaleUsageEvaluator.Evaluate(Item(threshold), SourceWithUsage(100), 14);
+        Assert.Equal(StaleUsageOutcome.NotOptedIn, decision.Outcome);
+    }
+
+    [Fact]
+    public void NotUnattended_BlocksRemoval_EvenWhenAncient()
+    {
+        var decision = StaleUsageEvaluator.Evaluate(Item(unattended: false), SourceWithUsage(365), 14);
+        Assert.Equal(StaleUsageOutcome.NotUnattended, decision.Outcome);
+    }
+
+    [Fact]
+    public void NotUninstallable_WhenNoRemovalMethodDefined()
+    {
+        var item = Item();
+        item.Installs.Clear(); // drop the MSI product code — nothing left to run
+        var decision = StaleUsageEvaluator.Evaluate(item, SourceWithUsage(365), 14);
+        Assert.Equal(StaleUsageOutcome.NotUninstallable, decision.Outcome);
+    }
+
+    [Fact]
+    public void NoTrackedExecutables_WhenNoPathsAndNoExeInstalls()
+    {
+        var item = Item();
+        item.UsageTrackedPaths = null; // fall back to installs — which has only the MSI row
+        var decision = StaleUsageEvaluator.Evaluate(item, SourceWithUsage(365), 14);
+        Assert.Equal(StaleUsageOutcome.NoTrackedExecutables, decision.Outcome);
+    }
+
+    [Fact]
+    public void InsufficientHistory_UsesGlobalDefault()
+    {
+        var source = SourceWithUsage(100);
+        source.HistoryDays = 5; // device imaged last week
+        var decision = StaleUsageEvaluator.Evaluate(Item(), source, 14);
+        Assert.Equal(StaleUsageOutcome.InsufficientHistory, decision.Outcome);
+    }
+
+    [Fact]
+    public void InsufficientHistory_PackageOverride_BeatsGlobal()
+    {
+        var source = SourceWithUsage(100);
+        source.HistoryDays = 20; // passes the global 14, fails the package's 45
+        var item = Item();
+        item.MinimumUsageHistoryDays = 45;
+        var decision = StaleUsageEvaluator.Evaluate(item, source, 14);
+        Assert.Equal(StaleUsageOutcome.InsufficientHistory, decision.Outcome);
+    }
+
+    [Fact]
+    public void NoUsageData_NeverRemoves()
+    {
+        var source = new FakeUsageSource(); // tracker never saw this exe
+        var decision = StaleUsageEvaluator.Evaluate(Item(), source, 14);
+        Assert.Equal(StaleUsageOutcome.NoUsageData, decision.Outcome);
+    }
+
+    // ── threshold ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void RecentlyUsed_WhenWithinThreshold()
+    {
+        var decision = StaleUsageEvaluator.Evaluate(Item(threshold: 30), SourceWithUsage(10), 14);
+        Assert.Equal(StaleUsageOutcome.RecentlyUsed, decision.Outcome);
+        Assert.InRange(decision.DaysSinceLastUsed, 9, 11);
+    }
+
+    [Fact]
+    public void Stale_WhenPastThreshold()
+    {
+        var decision = StaleUsageEvaluator.Evaluate(Item(threshold: 30), SourceWithUsage(45), 14);
+        Assert.Equal(StaleUsageOutcome.Stale, decision.Outcome);
+        Assert.InRange(decision.DaysSinceLastUsed, 44, 46);
+        Assert.Equal(30, decision.ThresholdDays);
+    }
+
+    [Fact]
+    public void NewestUsage_AcrossTrackedExes_Wins()
+    {
+        // Main exe untouched for 90 days, helper used 5 days ago: the package
+        // is in use — one live exe vetoes removal.
+        const string helper = @"C:\Program Files\StaleApp\helper.exe";
+        var source = SourceWithUsage(90);
+        source.Data[helper] = DateTime.UtcNow.AddDays(-5);
+
+        var item = Item(threshold: 30);
+        item.UsageTrackedPaths = new List<string> { Exe, helper };
+
+        var decision = StaleUsageEvaluator.Evaluate(item, source, 14);
+        Assert.Equal(StaleUsageOutcome.RecentlyUsed, decision.Outcome);
+    }
+
+    // ── tracked-exe resolution ──────────────────────────────────────────
+
+    [Fact]
+    public void ResolveTrackedExecutables_FallsBackToInstallsExes()
+    {
+        var item = Item();
+        item.UsageTrackedPaths = null;
+        item.Installs.Add(new InstallCheckItem { Type = "file", Path = Exe });
+        item.Installs.Add(new InstallCheckItem
+        {
+            Type = "msi",
+            ProductCode = "{66666666-7777-8888-9999-000000000000}",
+            KeyPath = @"C:\Program Files\StaleApp\fromkeypath.exe",
+        });
+        item.Installs.Add(new InstallCheckItem { Type = "file", Path = @"C:\Program Files\StaleApp\readme.txt" });
+
+        var exes = StaleUsageEvaluator.ResolveTrackedExecutables(item);
+
+        Assert.Contains(Exe, exes);
+        Assert.Contains(@"C:\Program Files\StaleApp\fromkeypath.exe", exes);
+        Assert.DoesNotContain(@"C:\Program Files\StaleApp\readme.txt", exes);
+    }
+
+    [Fact]
+    public void ResolveTrackedExecutables_ExplicitPaths_TakePrecedence()
+    {
+        var item = Item();
+        item.Installs.Add(new InstallCheckItem { Type = "file", Path = @"C:\Other\other.exe" });
+
+        var exes = StaleUsageEvaluator.ResolveTrackedExecutables(item);
+
+        Assert.Equal(new[] { Exe }, exes);
+    }
+}

--- a/tests/Shared/ReportMateUsageDataSourceTests.cs
+++ b/tests/Shared/ReportMateUsageDataSourceTests.cs
@@ -215,4 +215,37 @@ public sealed class ReportMateUsageDataSourceTests : IDisposable
         Assert.Equal(0, source.GetHistoryDays());
         Assert.Equal(int.MaxValue, source.GetDataFreshnessDays());
     }
+
+    [Fact]
+    public void GetDataFreshnessDays_FutureWriteStamp_IsInvalid_NotFresh()
+    {
+        // LastUpdatedAt 3 days in the future = clock skew or tampering.
+        // Treating it as "fresh" would let untrustworthy telemetry drive
+        // uninstalls; it must read as too-stale-to-act instead.
+        WriteUserFile("skewed", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 12, lastUpdatedDaysAgo: -3));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.Equal(int.MaxValue, source.GetDataFreshnessDays());
+    }
+
+    [Fact]
+    public void GetDataFreshnessDays_SmallFutureSkew_ReadsAsFresh()
+    {
+        // A few hours of clock skew is normal fleet reality - don't let it
+        // disable the feature device-wide. -0.5 days is within the 1-day
+        // tolerance window.
+        var json = $$"""
+            {
+              "SchemaVersion": 1,
+              "Username": "slight",
+              "StartedAt": "{{DateTime.UtcNow.AddDays(-30):O}}",
+              "LastUpdatedAt": "{{DateTime.UtcNow.AddHours(12):O}}",
+              "ByAppByDate": {}
+            }
+            """;
+        WriteUserFile("slight", json);
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.Equal(0, source.GetDataFreshnessDays());
+    }
 }

--- a/tests/Shared/ReportMateUsageDataSourceTests.cs
+++ b/tests/Shared/ReportMateUsageDataSourceTests.cs
@@ -1,0 +1,218 @@
+using System.Globalization;
+using Cimian.Core.Services;
+using Xunit;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// Fixture tests for ReportMateUsageDataSource. Each test writes usagetracker
+/// JSON files (the schema reportmate-client-win's usagetracker.exe produces)
+/// into a temp directory and points the source at it. The contract under
+/// test is the fail-safe behavior: parse errors and missing data must always
+/// degrade toward "no signal", never toward "unused".
+/// </summary>
+public sealed class ReportMateUsageDataSourceTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ReportMateUsageDataSourceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cimian-usage-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static string DateKey(int daysAgo) =>
+        DateTime.Now.AddDays(-daysAgo).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private void WriteUserFile(string username, string json) =>
+        File.WriteAllText(Path.Combine(_dir, username + ".json"), json);
+
+    private static string TrackerJson(
+        string exePath, int lastUsedDaysAgo,
+        double activeSeconds = 120, int startedDaysAgo = 60, int lastUpdatedDaysAgo = 0)
+    {
+        var exe = exePath.Replace(@"\", @"\\");
+        return $$"""
+            {
+              "SchemaVersion": 1,
+              "Username": "user",
+              "StartedAt": "{{DateTime.UtcNow.AddDays(-startedDaysAgo):O}}",
+              "LastUpdatedAt": "{{DateTime.UtcNow.AddDays(-lastUpdatedDaysAgo):O}}",
+              "ByAppByDate": {
+                "{{exe}}": {
+                  "{{DateKey(lastUsedDaysAgo)}}": { "ForegroundSeconds": 300, "ActiveSeconds": {{activeSeconds}} }
+                }
+              }
+            }
+            """;
+    }
+
+    // ── availability ────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsAvailable_False_WhenDirectoryMissing()
+    {
+        var source = new ReportMateUsageDataSource(Path.Combine(_dir, "does-not-exist"));
+        Assert.False(source.IsAvailable);
+    }
+
+    [Fact]
+    public void IsAvailable_False_WhenDirectoryEmpty()
+    {
+        var source = new ReportMateUsageDataSource(_dir);
+        Assert.False(source.IsAvailable);
+    }
+
+    [Fact]
+    public void IsAvailable_True_WithOneParseableFile()
+    {
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 3));
+        var source = new ReportMateUsageDataSource(_dir);
+        Assert.True(source.IsAvailable);
+    }
+
+    // ── lookups ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TryGetLastUsed_ExactPath_CaseInsensitive()
+    {
+        WriteUserFile("alice", TrackerJson(@"C:\Program Files\StaleApp\staleapp.exe", lastUsedDaysAgo: 5));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.TryGetLastUsed(@"C:\PROGRAM FILES\STALEAPP\STALEAPP.EXE", out var lastUsed));
+        var daysSince = (DateTime.UtcNow - lastUsed).TotalDays;
+        Assert.InRange(daysSince, 3.5, 6.5); // day granularity + TZ slop
+    }
+
+    [Fact]
+    public void TryGetLastUsed_FallsBackToBasename_WhenPathDiffers()
+    {
+        // Tracker observed the (x86) layout; pkginfo recorded the 64-bit path.
+        WriteUserFile("alice", TrackerJson(@"C:\Program Files (x86)\StaleApp\staleapp.exe", lastUsedDaysAgo: 5));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.TryGetLastUsed(@"C:\Program Files\StaleApp\staleapp.exe", out _));
+    }
+
+    [Fact]
+    public void TryGetLastUsed_False_ForUnknownExecutable()
+    {
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 3));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.False(source.TryGetLastUsed(@"C:\Apps\never-seen.exe", out var lastUsed));
+        Assert.Equal(default, lastUsed);
+    }
+
+    [Fact]
+    public void TryGetLastUsed_TakesMax_AcrossUsers()
+    {
+        // Bob used the app yesterday; Alice last touched it 40 days ago.
+        // Device-wide answer must be Bob's — the app is NOT stale.
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\shared.exe", lastUsedDaysAgo: 40));
+        WriteUserFile("bob", TrackerJson(@"C:\Apps\shared.exe", lastUsedDaysAgo: 1));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.TryGetLastUsed(@"C:\Apps\shared.exe", out var lastUsed));
+        Assert.InRange((DateTime.UtcNow - lastUsed).TotalDays, -0.5, 2.5);
+    }
+
+    [Fact]
+    public void TryGetLastUsed_IgnoresZeroCounterDays()
+    {
+        // A recent date row with all-zero counters is bookkeeping, not usage:
+        // last-used must resolve to the older day with real activity.
+        var json = $$"""
+            {
+              "SchemaVersion": 1,
+              "Username": "alice",
+              "StartedAt": "{{DateTime.UtcNow.AddDays(-60):O}}",
+              "LastUpdatedAt": "{{DateTime.UtcNow:O}}",
+              "ByAppByDate": {
+                "C:\\Apps\\tool.exe": {
+                  "{{DateKey(30)}}": { "ForegroundSeconds": 500, "ActiveSeconds": 200 },
+                  "{{DateKey(1)}}": { "ForegroundSeconds": 0, "ActiveSeconds": 0 }
+                }
+              }
+            }
+            """;
+        WriteUserFile("alice", json);
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.TryGetLastUsed(@"C:\Apps\tool.exe", out var lastUsed));
+        Assert.InRange((DateTime.UtcNow - lastUsed).TotalDays, 28.5, 31.5);
+    }
+
+    // ── robustness ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void MalformedFile_IsSkipped_OthersStillParsed()
+    {
+        WriteUserFile("corrupt", "{ this is not json ");
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 3));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.IsAvailable);
+        Assert.True(source.TryGetLastUsed(@"C:\Apps\tool.exe", out _));
+    }
+
+    [Fact]
+    public void EmptyByAppByDate_StillCountsTowardAvailabilityAndHistory()
+    {
+        // Fresh user, tracker running but nothing used yet: the file proves
+        // tracking has been active since StartedAt, so history accrues even
+        // though no app rows exist.
+        var json = $$"""
+            {
+              "SchemaVersion": 1,
+              "Username": "fresh",
+              "StartedAt": "{{DateTime.UtcNow.AddDays(-20):O}}",
+              "LastUpdatedAt": "{{DateTime.UtcNow:O}}",
+              "ByAppByDate": {}
+            }
+            """;
+        WriteUserFile("fresh", json);
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.True(source.IsAvailable);
+        Assert.InRange(source.GetHistoryDays(), 19, 21);
+    }
+
+    // ── guards ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetHistoryDays_SpansEarliestRecord()
+    {
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 10, startedDaysAgo: 45));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.InRange(source.GetHistoryDays(), 44, 46);
+    }
+
+    [Fact]
+    public void GetDataFreshnessDays_ReflectsLatestWrite()
+    {
+        // Telemetry last written 9 days ago (e.g. device idle, no logons):
+        // callers with a 7-day staleness threshold must refuse to act.
+        WriteUserFile("alice", TrackerJson(@"C:\Apps\tool.exe", lastUsedDaysAgo: 12, lastUpdatedDaysAgo: 9));
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.InRange(source.GetDataFreshnessDays(), 8, 10);
+    }
+
+    [Fact]
+    public void Guards_AreFailSafe_WhenNoFiles()
+    {
+        var source = new ReportMateUsageDataSource(_dir);
+
+        Assert.Equal(0, source.GetHistoryDays());
+        Assert.Equal(int.MaxValue, source.GetDataFreshnessDays());
+    }
+}

--- a/tests/Shared/UsageStaleSchemaTests.cs
+++ b/tests/Shared/UsageStaleSchemaTests.cs
@@ -1,7 +1,6 @@
 using Cimian.Core.Services;
 using Xunit;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Cimian.Tests.Shared;
 

--- a/tests/Shared/UsageStaleSchemaTests.cs
+++ b/tests/Shared/UsageStaleSchemaTests.cs
@@ -1,0 +1,120 @@
+using Cimian.Core.Services;
+using Xunit;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// Schema tests for the stale-usage removal fields
+/// (days_untouched_before_uninstall, usage_tracked_paths,
+/// minimum_usage_history_days). The same YAML keys must round-trip through
+/// every model that carries them: cimiimport's PkgsInfo, makecatalogs'
+/// PkgsInfo, and the engine's CatalogItem. A field landing in one model but
+/// not another silently strips it during the import → catalog → client
+/// pipeline, so each model gets its own deserialization pin.
+/// </summary>
+public class UsageStaleSchemaTests
+{
+    private const string PkginfoYaml = """
+        name: StaleApp
+        version: '1.0'
+        unattended_uninstall: true
+        days_untouched_before_uninstall: 30
+        usage_tracked_paths:
+        - C:\Program Files\StaleApp\staleapp.exe
+        - C:\Program Files\StaleApp\helper.exe
+        minimum_usage_history_days: 14
+        """;
+
+    private static IDeserializer PlainDeserializer() => new DeserializerBuilder()
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    [Fact]
+    public void CimiimportPkgsInfo_Deserializes_UsageStaleFields()
+    {
+        var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Cimiimport.Models.PkgsInfo>(PkginfoYaml);
+
+        Assert.Equal(30, pkg.DaysUntouchedBeforeUninstall);
+        Assert.Equal(2, pkg.UsageTrackedPaths?.Count);
+        Assert.Equal(14, pkg.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void MakecatalogsPkgsInfo_Deserializes_UsageStaleFields()
+    {
+        var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(PkginfoYaml);
+
+        Assert.Equal(30, pkg.DaysUntouchedBeforeUninstall);
+        Assert.Equal(2, pkg.UsageTrackedPaths?.Count);
+        Assert.Equal(14, pkg.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void EngineCatalogItem_Deserializes_UsageStaleFields()
+    {
+        var item = PlainDeserializer().Deserialize<Cimian.CLI.managedsoftwareupdate.Models.CatalogItem>(PkginfoYaml);
+
+        Assert.True(item.UnattendedUninstall);
+        Assert.Equal(30, item.DaysUntouchedBeforeUninstall);
+        Assert.Equal(2, item.UsageTrackedPaths?.Count);
+        Assert.Equal(14, item.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void EngineCatalogItem_FieldsDefaultNull_WhenAbsent()
+    {
+        // Absence must read as "feature disabled", never zero — the engine
+        // treats null/<=0 as opt-out, so a default of 0 is equivalent, but
+        // null is the canonical not-configured signal for reporting.
+        const string minimal = """
+            name: PlainApp
+            version: '1.0'
+            """;
+
+        var item = PlainDeserializer().Deserialize<Cimian.CLI.managedsoftwareupdate.Models.CatalogItem>(minimal);
+
+        Assert.Null(item.DaysUntouchedBeforeUninstall);
+        Assert.Null(item.UsageTrackedPaths);
+        Assert.Null(item.MinimumUsageHistoryDays);
+    }
+
+    [Fact]
+    public void MakecatalogsPkgsInfo_RoundTrips_UsageStaleFields()
+    {
+        var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(PkginfoYaml);
+        var yaml = new SerializerBuilder().Build().Serialize(pkg);
+        var again = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(yaml);
+
+        Assert.Equal(30, again.DaysUntouchedBeforeUninstall);
+        Assert.Equal(pkg.UsageTrackedPaths, again.UsageTrackedPaths);
+        Assert.Equal(14, again.MinimumUsageHistoryDays);
+    }
+}
+
+/// <summary>
+/// Contract pins for NoOpUsageDataSource: every answer must push callers
+/// down their fail-safe path (skip the stale-usage pass entirely).
+/// </summary>
+public class NoOpUsageDataSourceTests
+{
+    private readonly NoOpUsageDataSource _source = new();
+
+    [Fact]
+    public void IsAvailable_IsFalse() => Assert.False(_source.IsAvailable);
+
+    [Fact]
+    public void TryGetLastUsed_ReturnsFalse_ForAnyPath()
+    {
+        Assert.False(_source.TryGetLastUsed(@"C:\Program Files\Any\any.exe", out var lastUsed));
+        Assert.Equal(default, lastUsed);
+    }
+
+    [Fact]
+    public void GetHistoryDays_IsZero() => Assert.Equal(0, _source.GetHistoryDays());
+
+    [Fact]
+    public void GetDataFreshnessDays_IsMaxValue_SoAnyStalenessThresholdRejects()
+        => Assert.Equal(int.MaxValue, _source.GetDataFreshnessDays());
+}


### PR DESCRIPTION
## Summary

PR 3 of 3 for Munki-style "uninstall if unused for N days" (stacked: #50 → #51 → this; merge in order). Wires the schema (#50) and the ReportMate source (#51) into `UpdateEngine`. **Default OFF.**

## Config.yaml (all default-safe)

| Key | Default | Meaning |
|---|---|---|
| `UsageStaleUninstallEnabled` | `false` | Master switch — fleets opt in here, packages opt in via pkginfo |
| `UsageStaleUninstallMinimumHistoryDays` | `14` | Global fresh-image guard when a package doesn''t set its own |
| `UsageStaleUninstallMaxSourceStalenessDays` | `7` | Skip the whole pass when telemetry is idle (no logons for weeks must not drive removals) |

## Design

**`StaleUsageEvaluator`** (new) holds the per-package decision ladder as pure logic — opt-in → unattended → uninstallable → tracked exes → history → data → threshold. First failed gate wins, so reports attribute skips to the real cause. Fully unit-testable without registry or manifest plumbing.

**`IdentifyStaleUsageItems`** runs right after the AutoRemove block in `IdentifyActions`, mirroring `IdentifyAutoRemoveItems`:

- Candidates come from the `ManagedInstalls` registry (things Cimian actually installed)
- Anything still named by a manifest is **skipped** — uninstalling a manifested item would just reinstall next run; admin intent wins
- Anything AutoRemove already queued is not double-queued
- Queued items flow into `toUninstall` **before** the `install_window` / `blocking_applications` / user-active filters, so stale removals inherit the same deferral machinery as every other uninstall

**Self-serve items are deliberately untouched** in this pass — removing those also requires clearing the self-serve manifest entry or they reinstall (`SelfServiceManifestService.AddRemovalRequestAsync` exists for a follow-up).

## Reporting

Outcomes surface via `SessionLogger.LogStatusCheck` with the #50 reason codes: `stale_usage_uninstall` (needsAction), plus `stale_usage_skipped_no_data` / `stale_usage_skipped_insufficient_history` so "considered but refused" is queryable from items.json.

## Tests

14 evaluator tests pinning the guard-ladder order, per-package history override beating the global, multi-exe newest-usage veto (one live exe saves the package), and installs-array exe resolution (`path` + `key_path`, explicit `usage_tracked_paths` take precedence). All green.

Suite: 779/780 — the 1 failure is the pre-existing `ScriptServiceTests` stderr-marker failure present on clean `origin/main`.

## Rollout

1. Merge #50 → #51 → this
2. Pilot ring: flip `UsageStaleUninstallEnabled: true` on one config, opt in a single known-safe pkginfo with `days_untouched_before_uninstall: 30`
3. Watch items.json for `stale_usage_*` reason codes before widening