### PR TITLE
Drain git pull pipes and bound the wait in cimiimport

### DIFF
--- a/shared/import/Services/ImportService.cs
+++ b/shared/import/Services/ImportService.cs
@@ -764,19 +764,37 @@ public class ImportService
                 RedirectStandardError = true,
                 CreateNoWindow = true
             };
+            // Never block on a credential prompt — fail the pull instead.
+            psi.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
+            psi.EnvironmentVariables["GCM_INTERACTIVE"] = "never";
 
             using var process = Process.Start(psi);
             if (process != null)
             {
-                process.WaitForExit();
+                // Drain both pipes concurrently — a redirected stream nobody
+                // reads deadlocks the child once its output fills the pipe
+                // buffer (git fetch progress alone is enough).
+                var stdout = process.StandardOutput.ReadToEndAsync();
+                var stderr = process.StandardError.ReadToEndAsync();
+
+                if (!process.WaitForExit(120_000))
+                {
+                    try { process.Kill(entireProcessTree: true); } catch { }
+                    Console.WriteLine("[WARN] Git pull timed out after 120s — continuing without pull");
+                    return;
+                }
+
                 if (process.ExitCode == 0)
                 {
                     Console.WriteLine("Git pull completed successfully");
                 }
                 else
                 {
-                    Console.WriteLine("[WARN] Git pull may have had issues");
+                    var detail = stderr.GetAwaiter().GetResult().Trim();
+                    if (detail.Length > 200) detail = detail[..200];
+                    Console.WriteLine($"[WARN] Git pull may have had issues{(detail.Length > 0 ? $": {detail}" : "")}");
                 }
+                _ = stdout.GetAwaiter().GetResult();
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Problem

`RunGitPull` redirects stdout and stderr but never reads either stream before `WaitForExit()`. Once `git pull` writes more than the pipe buffer (fetch progress alone is enough), git blocks on the full pipe and cimiimport blocks in `WaitForExit()` â€” a permanent deadlock. This hung the cimian-autopkg-run public-projects import for 2 hours (run 12569) until the job timeout killed it.

## Changes

- Drain both pipes concurrently via `ReadToEndAsync()` started before the wait.
- Bound the wait at 120s; on timeout, kill the process tree and continue without the pull (the pull is an optimization, not a correctness requirement).
- Set `GIT_TERMINAL_PROMPT=0` / `GCM_INTERACTIVE=never` so git can never sit on a credential prompt in unattended contexts.
- Surface trimmed stderr in the warning when the pull fails, instead of the uninformative "may have had issues".


