### PR TITLE
stale-usage: intent-based scoping and default-on

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -129,28 +129,12 @@ public class PkgsInfo
     public bool UnattendedUninstall { get; set; }
 
     /// <summary>
-    /// Opt-in stale-usage removal: uninstall this package when none of its
-    /// tracked executables have been used for this many days. Requires
-    /// unattended_uninstall and usage data (ReportMate usagetracker).
-    /// Null or &lt;= 0 disables the feature for this package.
+    /// Opt-in unused-software removal (Munki parity: unused_software_removal_info).
+    /// Requires unattended_uninstall and usage data (ReportMate usagetracker).
+    /// Null disables the feature for this package.
     /// </summary>
-    [YamlMember(Alias = "days_untouched_before_uninstall")]
-    public int? DaysUntouchedBeforeUninstall { get; set; }
-
-    /// <summary>
-    /// Executable paths whose usage gates stale-usage removal. When empty,
-    /// the client falls back to .exe entries in the installs array.
-    /// </summary>
-    [YamlMember(Alias = "usage_tracked_paths")]
-    public List<string>? UsageTrackedPaths { get; set; }
-
-    /// <summary>
-    /// Minimum days of usage history that must exist on the device before
-    /// stale-usage removal may act (guards freshly imaged machines).
-    /// Null defers to the client's global default.
-    /// </summary>
-    [YamlMember(Alias = "minimum_usage_history_days")]
-    public int? MinimumUsageHistoryDays { get; set; }
+    [YamlMember(Alias = "unused_software_removal_info")]
+    public UnusedSoftwareRemovalInfo? UnusedSoftwareRemovalInfo { get; set; }
 
     [YamlMember(Alias = "minimum_os_version")]
     public string? MinOSVersion { get; set; }
@@ -199,6 +183,22 @@ public class PkgsInfo
     /// </summary>
     [YamlIgnore]
     public string FilePath { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Munki-parity unused-software removal opt-in (paths is the Windows analog
+/// of Munki's bundle_ids; minimum_history_days is a Cimian extension).
+/// </summary>
+public class UnusedSoftwareRemovalInfo
+{
+    [YamlMember(Alias = "removal_days")]
+    public int? RemovalDays { get; set; }
+
+    [YamlMember(Alias = "paths")]
+    public List<string>? Paths { get; set; }
+
+    [YamlMember(Alias = "minimum_history_days")]
+    public int? MinimumHistoryDays { get; set; }
 }
 
 /// <summary>

--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -129,7 +129,7 @@ public class PkgsInfo
     public bool UnattendedUninstall { get; set; }
 
     /// <summary>
-    /// Opt-in unused-software removal (Munki parity: unused_software_removal_info).
+    /// Opt-in unused-software removal (unused_software_removal_info).
     /// Requires unattended_uninstall and usage data (ReportMate usagetracker).
     /// Null disables the feature for this package.
     /// </summary>
@@ -186,8 +186,8 @@ public class PkgsInfo
 }
 
 /// <summary>
-/// Munki-parity unused-software removal opt-in (paths is the Windows analog
-/// of Munki's bundle_ids; minimum_history_days is a Cimian extension).
+/// Unused-software removal opt-in (paths gate removal by recorded usage;
+/// minimum_history_days is a Cimian extension).
 /// </summary>
 public class UnusedSoftwareRemovalInfo
 {

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -137,15 +137,15 @@ public class PkgsInfo
     public bool UnattendedUninstall { get; set; }
 
     /// <summary>
-    /// Opt-in unused-software removal (Munki parity: unused_software_removal_info).
+    /// Opt-in unused-software removal (unused_software_removal_info).
     /// </summary>
     [YamlMember(Alias = "unused_software_removal_info", Order = 27, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public UnusedSoftwareRemovalInfo? UnusedSoftwareRemovalInfo { get; set; }
 }
 
 /// <summary>
-/// Munki-parity unused-software removal opt-in (paths is the Windows analog
-/// of Munki's bundle_ids; minimum_history_days is a Cimian extension).
+/// Unused-software removal opt-in (paths gate removal by recorded usage;
+/// minimum_history_days is a Cimian extension).
 /// </summary>
 public class UnusedSoftwareRemovalInfo
 {

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -137,25 +137,26 @@ public class PkgsInfo
     public bool UnattendedUninstall { get; set; }
 
     /// <summary>
-    /// Opt-in stale-usage removal: uninstall when none of the tracked
-    /// executables have been used for this many days.
+    /// Opt-in unused-software removal (Munki parity: unused_software_removal_info).
     /// </summary>
-    [YamlMember(Alias = "days_untouched_before_uninstall", Order = 27, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
-    public int? DaysUntouchedBeforeUninstall { get; set; }
+    [YamlMember(Alias = "unused_software_removal_info", Order = 27, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public UnusedSoftwareRemovalInfo? UnusedSoftwareRemovalInfo { get; set; }
+}
 
-    /// <summary>
-    /// Executable paths whose usage gates stale-usage removal. When empty,
-    /// the client falls back to .exe entries in the installs array.
-    /// </summary>
-    [YamlMember(Alias = "usage_tracked_paths", Order = 28, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
-    public List<string>? UsageTrackedPaths { get; set; }
+/// <summary>
+/// Munki-parity unused-software removal opt-in (paths is the Windows analog
+/// of Munki's bundle_ids; minimum_history_days is a Cimian extension).
+/// </summary>
+public class UnusedSoftwareRemovalInfo
+{
+    [YamlMember(Alias = "removal_days", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public int? RemovalDays { get; set; }
 
-    /// <summary>
-    /// Minimum days of usage history required on the device before
-    /// stale-usage removal may act.
-    /// </summary>
-    [YamlMember(Alias = "minimum_usage_history_days", Order = 29, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
-    public int? MinimumUsageHistoryDays { get; set; }
+    [YamlMember(Alias = "paths", DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    public List<string>? Paths { get; set; }
+
+    [YamlMember(Alias = "minimum_history_days", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public int? MinimumHistoryDays { get; set; }
 }
 
 /// <summary>

--- a/cli/makepkginfo/Program.cs
+++ b/cli/makepkginfo/Program.cs
@@ -102,19 +102,19 @@ class Program
             "Set 'OnDemand: true' - items that can be run multiple times");
 
         var daysUntouchedOption = new Option<int?>(
-            "--days_untouched_before_uninstall",
-            "Uninstall when no tracked executable has been used for this many days (requires --unattended_uninstall and usage data)");
+            "--unused_removal_days",
+            "Emit unused_software_removal_info.removal_days: uninstall when no tracked executable has been used for this many days (requires --unattended_uninstall and usage data)");
 
         var usageTrackedPathOption = new Option<string[]>(
-            "--usage_tracked_path",
-            "Executable path whose usage gates stale-usage removal (can be specified multiple times; defaults to .exe entries in installs)")
+            "--unused_path",
+            "Emit unused_software_removal_info.paths entry: executable whose usage gates removal (can be specified multiple times; defaults to .exe entries in installs)")
         {
             AllowMultipleArgumentsPerToken = true
         };
 
         var minUsageHistoryOption = new Option<int?>(
-            "--minimum_usage_history_days",
-            "Minimum days of usage history required on a device before stale-usage removal may act");
+            "--unused_minimum_history_days",
+            "Emit unused_software_removal_info.minimum_history_days: minimum days of usage history required on a device before removal may act");
 
         var newPkgOption = new Option<bool>(
             "--new",
@@ -255,9 +255,9 @@ class Program
                     UnattendedInstall = unattendedInstall,
                     UnattendedUninstall = unattendedUninstall,
                     OnDemand = onDemand,
-                    DaysUntouchedBeforeUninstall = daysUntouched,
-                    UsageTrackedPaths = usageTrackedPaths?.Length > 0 ? usageTrackedPaths.ToList() : null,
-                    MinimumUsageHistoryDays = minUsageHistory,
+                    UnusedRemovalDays = daysUntouched,
+                    UnusedPaths = usageTrackedPaths?.Length > 0 ? usageTrackedPaths.ToList() : null,
+                    UnusedMinimumHistoryDays = minUsageHistory,
                     MinOSVersion = minOSVersion,
                     MaxOSVersion = maxOSVersion,
                     MinCimianVersion = minCimianVersion,

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -188,9 +188,7 @@ public class PkgInfoBuilder
             MinOSVersion = options.MinOSVersion,
             MaxOSVersion = options.MaxOSVersion,
             MinCimianVersion = options.MinCimianVersion,
-            DaysUntouchedBeforeUninstall = options.DaysUntouchedBeforeUninstall,
-            UsageTrackedPaths = options.UsageTrackedPaths,
-            MinimumUsageHistoryDays = options.MinimumUsageHistoryDays,
+            UnusedSoftwareRemovalInfo = BuildUnusedRemovalInfo(options),
             Installs = installs
         };
 
@@ -387,6 +385,27 @@ public class PkgInfoBuilder
             return null;
         }
     }
+
+    /// <summary>
+    /// Assembles unused_software_removal_info from the flat CLI options;
+    /// null (key omitted) when none of them were supplied.
+    /// </summary>
+    private static UnusedSoftwareRemovalInfo? BuildUnusedRemovalInfo(PkgsInfoOptions options)
+    {
+        if (options.UnusedRemovalDays is null
+            && (options.UnusedPaths is null || options.UnusedPaths.Count == 0)
+            && options.UnusedMinimumHistoryDays is null)
+        {
+            return null;
+        }
+
+        return new UnusedSoftwareRemovalInfo
+        {
+            RemovalDays = options.UnusedRemovalDays,
+            Paths = options.UnusedPaths,
+            MinimumHistoryDays = options.UnusedMinimumHistoryDays,
+        };
+    }
 }
 
 /// <summary>
@@ -404,9 +423,9 @@ public class PkgsInfoOptions
     public bool UnattendedInstall { get; set; }
     public bool UnattendedUninstall { get; set; }
     public bool OnDemand { get; set; }
-    public int? DaysUntouchedBeforeUninstall { get; set; }
-    public List<string>? UsageTrackedPaths { get; set; }
-    public int? MinimumUsageHistoryDays { get; set; }
+    public int? UnusedRemovalDays { get; set; }
+    public List<string>? UnusedPaths { get; set; }
+    public int? UnusedMinimumHistoryDays { get; set; }
     public string? MinOSVersion { get; set; }
     public string? MaxOSVersion { get; set; }
     public string? MinCimianVersion { get; set; }

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -430,7 +430,7 @@ public class CatalogItem
     public DateTime? ForceInstallAfterDate { get; set; }
 
     /// <summary>
-    /// Opt-in unused-software removal (Munki parity: unused_software_removal_info).
+    /// Opt-in unused-software removal (unused_software_removal_info).
     /// Requires UnattendedUninstall and an available usage data source.
     /// Null disables the feature for this package.
     /// </summary>
@@ -472,9 +472,8 @@ public class CatalogItem
 }
 
 /// <summary>
-/// Munki-parity unused-software removal opt-in. Munki's dict carries
-/// bundle_ids + removal_days; on Windows the analog of bundle_ids is
-/// absolute executable paths.
+/// Unused-software removal opt-in. The dict carries removal_days plus the
+/// absolute executable paths whose recorded usage gates removal.
 /// </summary>
 public class UnusedSoftwareRemovalInfo
 {
@@ -486,9 +485,8 @@ public class UnusedSoftwareRemovalInfo
     public int? RemovalDays { get; set; }
 
     /// <summary>
-    /// Executable paths whose usage gates removal (Windows analog of Munki's
-    /// bundle_ids). When empty, the client falls back to .exe entries in the
-    /// installs array.
+    /// Executable paths whose usage gates removal. When empty, the client
+    /// falls back to .exe entries in the installs array.
     /// </summary>
     [YamlMember(Alias = "paths")]
     public List<string>? Paths { get; set; }

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -95,10 +95,12 @@ public class CimianConfig
 
     /// <summary>
     /// Master switch for stale-usage removal (days_untouched_before_uninstall).
-    /// Off by default: packages opt in via pkginfo, fleets opt in here.
+    /// On by default — harmless fleet-wide because every package must still
+    /// opt in via pkginfo, and the pass only ever touches self-serve/optional
+    /// installs and orphans, never admin-manifested items.
     /// </summary>
     [YamlMember(Alias = "UsageStaleUninstallEnabled")]
-    public bool UsageStaleUninstallEnabled { get; set; }
+    public bool UsageStaleUninstallEnabled { get; set; } = true;
 
     /// <summary>
     /// Global fallback for minimum_usage_history_days when a package doesn't
@@ -319,6 +321,13 @@ public class ManifestItem
     public string Version { get; set; } = string.Empty;
     public string Action { get; set; } = string.Empty; // install, update, uninstall, profile, app, optional
     public string SourceManifest { get; set; } = string.Empty;
+    /// <summary>
+    /// True when this item's action was set by the user-writable
+    /// SelfServeManifest (install request or promoted optional). SourceManifest
+    /// keeps the server manifest that listed the item, so this flag is the only
+    /// way to tell user intent from admin intent after the merge.
+    /// </summary>
+    public bool IsSelfServe { get; set; }
     public string InstallerLocation { get; set; } = string.Empty;
     public List<string> SupportedArch { get; set; } = new();
     public List<string> ManagedInstalls { get; set; } = new();

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -94,7 +94,7 @@ public class CimianConfig
     public bool AutoRemove { get; set; }
 
     /// <summary>
-    /// Master switch for stale-usage removal (days_untouched_before_uninstall).
+    /// Master switch for unused-software removal (unused_software_removal_info).
     /// On by default — harmless fleet-wide because every package must still
     /// opt in via pkginfo, and the pass only ever touches self-serve/optional
     /// installs and orphans, never admin-manifested items.
@@ -103,7 +103,7 @@ public class CimianConfig
     public bool UsageStaleUninstallEnabled { get; set; } = true;
 
     /// <summary>
-    /// Global fallback for minimum_usage_history_days when a package doesn't
+    /// Global fallback for unused_software_removal_info.minimum_history_days when a package doesn't
     /// set its own: refuse stale removal on devices with less usage history.
     /// </summary>
     [YamlMember(Alias = "UsageStaleUninstallMinimumHistoryDays")]
@@ -430,27 +430,12 @@ public class CatalogItem
     public DateTime? ForceInstallAfterDate { get; set; }
 
     /// <summary>
-    /// Opt-in stale-usage removal: uninstall when none of the tracked
-    /// executables have been used for this many days. Requires
-    /// UnattendedUninstall and an available usage data source.
-    /// Null or &lt;= 0 disables the feature for this package.
+    /// Opt-in unused-software removal (Munki parity: unused_software_removal_info).
+    /// Requires UnattendedUninstall and an available usage data source.
+    /// Null disables the feature for this package.
     /// </summary>
-    [YamlMember(Alias = "days_untouched_before_uninstall")]
-    public int? DaysUntouchedBeforeUninstall { get; set; }
-
-    /// <summary>
-    /// Executable paths whose usage gates stale-usage removal. When empty,
-    /// the client falls back to .exe entries in the installs array.
-    /// </summary>
-    [YamlMember(Alias = "usage_tracked_paths")]
-    public List<string>? UsageTrackedPaths { get; set; }
-
-    /// <summary>
-    /// Minimum days of usage history required on this device before
-    /// stale-usage removal may act. Null defers to the global default.
-    /// </summary>
-    [YamlMember(Alias = "minimum_usage_history_days")]
-    public int? MinimumUsageHistoryDays { get; set; }
+    [YamlMember(Alias = "unused_software_removal_info")]
+    public UnusedSoftwareRemovalInfo? UnusedSoftwareRemovalInfo { get; set; }
 
     [YamlMember(Alias = "restart_action")]
     public string? RestartAction { get; set; }
@@ -484,6 +469,36 @@ public class CatalogItem
         || Installs.Any(i =>
             (i.EffectiveType() == "msix" || i.EffectiveType() == "appx")
             && !string.IsNullOrWhiteSpace(i.IdentityName)));
+}
+
+/// <summary>
+/// Munki-parity unused-software removal opt-in. Munki's dict carries
+/// bundle_ids + removal_days; on Windows the analog of bundle_ids is
+/// absolute executable paths.
+/// </summary>
+public class UnusedSoftwareRemovalInfo
+{
+    /// <summary>
+    /// Uninstall when none of the tracked executables have been used for
+    /// this many days. &lt;= 0 disables the feature for this package.
+    /// </summary>
+    [YamlMember(Alias = "removal_days")]
+    public int? RemovalDays { get; set; }
+
+    /// <summary>
+    /// Executable paths whose usage gates removal (Windows analog of Munki's
+    /// bundle_ids). When empty, the client falls back to .exe entries in the
+    /// installs array.
+    /// </summary>
+    [YamlMember(Alias = "paths")]
+    public List<string>? Paths { get; set; }
+
+    /// <summary>
+    /// Cimian extension: minimum days of usage history required on the device
+    /// before removal may act. Null defers to the global default.
+    /// </summary>
+    [YamlMember(Alias = "minimum_history_days")]
+    public int? MinimumHistoryDays { get; set; }
 }
 
 /// <summary>

--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -572,21 +572,28 @@ public class ManifestService
         {
             if (string.IsNullOrWhiteSpace(name)) continue;
 
-            var existing = items.FirstOrDefault(i => string.Equals(i.Name, name, StringComparison.OrdinalIgnoreCase));
-            if (existing == null)
+            // Match against every entry for the name, not just the first: the same
+            // item can be optional in one manifest and managed in another, and a
+            // self-serve promotion must not outrank (or masquerade as) admin intent
+            // when the lists are later deduplicated.
+            var matches = items.Where(i => string.Equals(i.Name, name, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (matches.Count == 0)
             {
                 items.Add(new ManifestItem
                 {
                     Name = name,
                     Action = "install",
-                    SourceManifest = selfServeSource
+                    SourceManifest = selfServeSource,
+                    IsSelfServe = true
                 });
                 SetItemSource(name, selfServeSource, "managed_installs");
                 ConsoleLogger.Debug($"SelfServe: added install request item: {name}");
             }
-            else if (string.Equals(existing.Action, "optional", StringComparison.OrdinalIgnoreCase))
+            else if (matches.All(i => string.Equals(i.Action, "optional", StringComparison.OrdinalIgnoreCase)))
             {
+                var existing = matches[0];
                 existing.Action = "install";
+                existing.IsSelfServe = true;
                 SetItemSource(name, selfServeSource, "managed_installs");
                 ConsoleLogger.Debug($"SelfServe: promoted optional to install item: {name} originalSource: {existing.SourceManifest}");
             }

--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -568,6 +568,14 @@ public class ManifestService
 
         const string selfServeSource = "SelfServeManifest";
 
+        // Actions that mandate the item's presence/absence. A self-serve request
+        // can never override these. "optional" and "update" are deliberately NOT
+        // here: optional_installs offers the item, and managed_updates only says
+        // "patch if present" — the user remains the authority on presence for
+        // the common optional_installs + managed_updates combo.
+        static bool IsPresenceMandating(ManifestItem i) =>
+            i.Action?.ToLowerInvariant() is "install" or "uninstall" or "default" or "profile" or "app";
+
         foreach (var name in selfServe.ManagedInstalls)
         {
             if (string.IsNullOrWhiteSpace(name)) continue;
@@ -589,15 +597,21 @@ public class ManifestService
                 SetItemSource(name, selfServeSource, "managed_installs");
                 ConsoleLogger.Debug($"SelfServe: added install request item: {name}");
             }
-            else if (matches.All(i => string.Equals(i.Action, "optional", StringComparison.OrdinalIgnoreCase)))
+            else if (!matches.Any(IsPresenceMandating))
             {
-                var existing = matches[0];
-                existing.Action = "install";
-                existing.IsSelfServe = true;
-                SetItemSource(name, selfServeSource, "managed_installs");
-                ConsoleLogger.Debug($"SelfServe: promoted optional to install item: {name} originalSource: {existing.SourceManifest}");
+                var optional = matches.FirstOrDefault(i =>
+                    string.Equals(i.Action, "optional", StringComparison.OrdinalIgnoreCase));
+                if (optional != null)
+                {
+                    optional.Action = "install";
+                    optional.IsSelfServe = true;
+                    SetItemSource(name, selfServeSource, "managed_installs");
+                    ConsoleLogger.Debug($"SelfServe: promoted optional to install item: {name} originalSource: {optional.SourceManifest}");
+                }
+                // Only managed_updates entries: MSC never offers such an item,
+                // so an install request here is stale state — leave it alone.
             }
-            // If the item is already managed_installs / update / uninstall by server policy,
+            // If the item is already managed_installs / uninstall by server policy,
             // leave it alone — admin policy wins.
         }
 
@@ -605,8 +619,8 @@ public class ManifestService
         {
             if (string.IsNullOrWhiteSpace(name)) continue;
 
-            var existing = items.FirstOrDefault(i => string.Equals(i.Name, name, StringComparison.OrdinalIgnoreCase));
-            if (existing == null)
+            var matches = items.Where(i => string.Equals(i.Name, name, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (matches.Count == 0)
             {
                 items.Add(new ManifestItem
                 {
@@ -617,17 +631,26 @@ public class ManifestService
                 SetItemSource(name, selfServeSource, "managed_uninstalls");
                 ConsoleLogger.Debug($"SelfServe: added uninstall request item: {name}");
             }
-            else if (string.Equals(existing.Action, "optional", StringComparison.OrdinalIgnoreCase))
+            else if (!matches.Any(IsPresenceMandating))
             {
-                // Optional item — user is the only authority, so honor the removal request.
-                existing.Action = "uninstall";
-                SetItemSource(name, selfServeSource, "managed_uninstalls");
-                ConsoleLogger.Debug($"SelfServe: flipped optional to uninstall item: {name} originalSource: {existing.SourceManifest}");
+                // Optional item (possibly also under managed_updates) — the user
+                // is the authority on presence, so honor the removal request.
+                // Deduplication ranks uninstall above update, so the flipped
+                // entry wins even when an update entry remains.
+                var optional = matches.FirstOrDefault(i =>
+                    string.Equals(i.Action, "optional", StringComparison.OrdinalIgnoreCase));
+                if (optional != null)
+                {
+                    optional.Action = "uninstall";
+                    SetItemSource(name, selfServeSource, "managed_uninstalls");
+                    ConsoleLogger.Debug($"SelfServe: flipped optional to uninstall item: {name} originalSource: {optional.SourceManifest}");
+                }
             }
-            else if (!string.Equals(existing.Action, "uninstall", StringComparison.OrdinalIgnoreCase))
+            else if (!matches.Any(i => string.Equals(i.Action, "uninstall", StringComparison.OrdinalIgnoreCase)))
             {
-                // install / update from server policy — admin wins, suppress the user request.
-                ConsoleLogger.Info($"SelfServe: ignoring uninstall request for {name}; admin policy requires {existing.Action} (source: {existing.SourceManifest})");
+                var blocking = matches.First(IsPresenceMandating);
+                // install / default / profile / app from server policy — admin wins.
+                ConsoleLogger.Info($"SelfServe: ignoring uninstall request for {name}; admin policy requires {blocking.Action} (source: {blocking.SourceManifest})");
             }
         }
     }

--- a/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
+++ b/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
@@ -10,13 +10,13 @@ namespace Cimian.CLI.managedsoftwareupdate.Services;
 
 public enum StaleUsageOutcome
 {
-    /// <summary>days_untouched_before_uninstall absent or &lt;= 0.</summary>
+    /// <summary>unused_software_removal_info absent or removal_days &lt;= 0.</summary>
     NotOptedIn,
     /// <summary>Package has not approved silent removal (unattended_uninstall false).</summary>
     NotUnattended,
     /// <summary>No uninstall method defined — nothing the engine could run.</summary>
     NotUninstallable,
-    /// <summary>No usage_tracked_paths and no .exe in the installs array.</summary>
+    /// <summary>No unused_software_removal_info paths and no .exe in the installs array.</summary>
     NoTrackedExecutables,
     /// <summary>Device has less usage history than the package (or global) minimum.</summary>
     InsufficientHistory,
@@ -59,7 +59,7 @@ public enum StaleUsageScope
 
 /// <param name="Outcome">The decision.</param>
 /// <param name="DaysSinceLastUsed">Days since the newest usage across tracked exes (-1 when no data).</param>
-/// <param name="ThresholdDays">The package's days_untouched_before_uninstall.</param>
+/// <param name="ThresholdDays">The package's unused_software_removal_info removal_days.</param>
 public sealed record StaleUsageDecision(
     StaleUsageOutcome Outcome,
     double DaysSinceLastUsed = -1,
@@ -78,7 +78,7 @@ public static class StaleUsageEvaluator
         IUsageDataSource usage,
         int globalMinimumHistoryDays)
     {
-        var threshold = item.DaysUntouchedBeforeUninstall ?? 0;
+        var threshold = item.UnusedSoftwareRemovalInfo?.RemovalDays ?? 0;
         if (threshold <= 0)
         {
             return new StaleUsageDecision(StaleUsageOutcome.NotOptedIn);
@@ -100,7 +100,7 @@ public static class StaleUsageEvaluator
             return new StaleUsageDecision(StaleUsageOutcome.NoTrackedExecutables, ThresholdDays: threshold);
         }
 
-        var minHistory = item.MinimumUsageHistoryDays ?? globalMinimumHistoryDays;
+        var minHistory = item.UnusedSoftwareRemovalInfo?.MinimumHistoryDays ?? globalMinimumHistoryDays;
         if (usage.GetHistoryDays() < minHistory)
         {
             return new StaleUsageDecision(StaleUsageOutcome.InsufficientHistory, ThresholdDays: threshold);
@@ -159,15 +159,15 @@ public static class StaleUsageEvaluator
     }
 
     /// <summary>
-    /// usage_tracked_paths when present; otherwise every .exe mentioned in the
-    /// installs array (path or key_path — key_path is the MSI's primary
-    /// executable, which is exactly what a user launches).
+    /// unused_software_removal_info.paths when present; otherwise every .exe
+    /// mentioned in the installs array (path or key_path — key_path is the
+    /// MSI's primary executable, which is exactly what a user launches).
     /// </summary>
     internal static List<string> ResolveTrackedExecutables(CatalogItem item)
     {
-        if (item.UsageTrackedPaths is { Count: > 0 })
+        if (item.UnusedSoftwareRemovalInfo?.Paths is { Count: > 0 } paths)
         {
-            return item.UsageTrackedPaths
+            return paths
                 .Where(p => !string.IsNullOrWhiteSpace(p))
                 .ToList();
         }

--- a/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
+++ b/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
@@ -30,17 +30,17 @@ public enum StaleUsageOutcome
 
 /// <summary>
 /// Where an installed package sits in the manifest tree, which decides whether
-/// stale-usage removal may touch it. Munki parity: unused-software removal acts
-/// on self-serve (optional) installs, never on admin-managed software.
+/// stale-usage removal may touch it. Unused-software removal acts on
+/// self-serve (optional) installs, never on admin-managed software.
 /// </summary>
 public enum StaleUsageScope
 {
     /// <summary>Admin intent — managed_installs/default_installs/profile/app,
     /// or an explicit uninstall already in flight. Never stale-removed.</summary>
     Protected,
-    /// <summary>Installed via the user's SelfServeManifest (Munki's unused-removal
-    /// target). Removal must also clear the self-serve subscription or the next
-    /// run reinstalls it.</summary>
+    /// <summary>Installed via the user's SelfServeManifest — the primary
+    /// removal target. Removal must also clear the self-serve subscription or
+    /// the next run reinstalls it.</summary>
     SelfServe,
     /// <summary>In optional_installs but not currently self-serve subscribed
     /// (e.g. installed before subscription tracking, or admin demoted it from

--- a/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
+++ b/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
@@ -28,6 +28,29 @@ public enum StaleUsageOutcome
     Stale,
 }
 
+/// <summary>
+/// Where an installed package sits in the manifest tree, which decides whether
+/// stale-usage removal may touch it. Munki parity: unused-software removal acts
+/// on self-serve (optional) installs, never on admin-managed software.
+/// </summary>
+public enum StaleUsageScope
+{
+    /// <summary>Admin intent — managed_installs/updates/default_installs/profile/app,
+    /// or an explicit uninstall already in flight. Never stale-removed.</summary>
+    Protected,
+    /// <summary>Installed via the user's SelfServeManifest (Munki's unused-removal
+    /// target). Removal must also clear the self-serve subscription or the next
+    /// run reinstalls it.</summary>
+    SelfServe,
+    /// <summary>In optional_installs but not currently self-serve subscribed
+    /// (e.g. installed before subscription tracking, or admin demoted it from
+    /// managed). Plain uninstall sticks; the item stays offered in MSC.</summary>
+    Optional,
+    /// <summary>Installed by Cimian but in no manifest at all — AutoRemove's
+    /// territory, also eligible here for fleets that keep AutoRemove off.</summary>
+    Orphan,
+}
+
 /// <param name="Outcome">The decision.</param>
 /// <param name="DaysSinceLastUsed">Days since the newest usage across tracked exes (-1 when no data).</param>
 /// <param name="ThresholdDays">The package's days_untouched_before_uninstall.</param>
@@ -99,6 +122,30 @@ public static class StaleUsageEvaluator
         return daysSince > threshold
             ? new StaleUsageDecision(StaleUsageOutcome.Stale, daysSince, threshold)
             : new StaleUsageDecision(StaleUsageOutcome.RecentlyUsed, daysSince, threshold);
+    }
+
+    /// <summary>
+    /// Classifies an installed package by its (deduplicated, self-serve-merged)
+    /// manifest entry. Null means no manifest references the name at all.
+    /// </summary>
+    public static StaleUsageScope ClassifyScope(ManifestItem? manifestEntry)
+    {
+        if (manifestEntry is null)
+        {
+            return StaleUsageScope.Orphan;
+        }
+
+        var action = manifestEntry.Action?.ToLowerInvariant();
+        if (action == "optional")
+        {
+            return StaleUsageScope.Optional;
+        }
+        if (action == "install" && manifestEntry.IsSelfServe)
+        {
+            return StaleUsageScope.SelfServe;
+        }
+
+        return StaleUsageScope.Protected;
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
+++ b/cli/managedsoftwareupdate/Services/StaleUsageEvaluator.cs
@@ -35,7 +35,7 @@ public enum StaleUsageOutcome
 /// </summary>
 public enum StaleUsageScope
 {
-    /// <summary>Admin intent — managed_installs/updates/default_installs/profile/app,
+    /// <summary>Admin intent — managed_installs/default_installs/profile/app,
     /// or an explicit uninstall already in flight. Never stale-removed.</summary>
     Protected,
     /// <summary>Installed via the user's SelfServeManifest (Munki's unused-removal
@@ -46,6 +46,12 @@ public enum StaleUsageScope
     /// (e.g. installed before subscription tracking, or admin demoted it from
     /// managed). Plain uninstall sticks; the item stays offered in MSC.</summary>
     Optional,
+    /// <summary>Only in managed_updates — "patch IF present", which expresses no
+    /// presence intent, so removal doesn't fight policy and nothing reinstalls
+    /// it (updates only apply to installed items). Covers the provision-then-
+    /// keep-patched pattern (e.g. Firefox installed by a provisioning manifest,
+    /// kept current by managed_updates afterwards).</summary>
+    ManagedUpdate,
     /// <summary>Installed by Cimian but in no manifest at all — AutoRemove's
     /// territory, also eligible here for fleets that keep AutoRemove off.</summary>
     Orphan,
@@ -143,6 +149,10 @@ public static class StaleUsageEvaluator
         if (action == "install" && manifestEntry.IsSelfServe)
         {
             return StaleUsageScope.SelfServe;
+        }
+        if (action == "update")
+        {
+            return StaleUsageScope.ManagedUpdate;
         }
 
         return StaleUsageScope.Protected;

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -429,7 +429,10 @@ public class UpdateEngine : IDisposable
                 // reload _config, and the source's lazy snapshot should reflect
                 // this run's on-disk data, not engine-construction time.
                 var usageSource = new ReportMateUsageDataSource();
-                var staleUsageItems = await IdentifyStaleUsageItemsAsync(manifestItems, catalogMap, toUninstall, usageSource);
+                // Anything already queued this run — including a pending update for a
+                // managed_updates item — defers stale evaluation to the next run.
+                var queuedThisRun = toUninstall.Concat(toInstall).Concat(toUpdate).ToList();
+                var staleUsageItems = await IdentifyStaleUsageItemsAsync(manifestItems, catalogMap, queuedThisRun, usageSource);
                 if (staleUsageItems.Count > 0)
                 {
                     ConsoleLogger.Info($"StaleUsage: {staleUsageItems.Count} package(s) untouched past their threshold");
@@ -1230,12 +1233,19 @@ public class UpdateEngine : IDisposable
                         // Self-serve and optional items must also drop any self-serve
                         // subscription — same effect as the user clicking Remove in
                         // MSC — or the next run's merge would reinstall the item.
-                        // Check-only must not mutate state, so only report there.
-                        if (scope is StaleUsageScope.SelfServe or StaleUsageScope.Optional)
+                        // ManagedUpdate items only get lingering install requests
+                        // cleared (no removal request: the admin's update policy
+                        // would veto-log it every run). Check-only must not mutate
+                        // state, so only report there.
+                        if (scope != StaleUsageScope.Orphan)
                         {
                             if (_checkOnly)
                             {
                                 ConsoleLogger.Info($"    StaleUsage: would clear self-serve subscription for {catalogItem.Name} (check-only)");
+                            }
+                            else if (scope == StaleUsageScope.ManagedUpdate)
+                            {
+                                await new SelfServiceManifestService().RemoveRequestAsync(catalogItem.Name);
                             }
                             else
                             {

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1198,6 +1198,12 @@ public class UpdateEngine : IDisposable
             alreadyQueued.Select(i => i.Name),
             StringComparer.OrdinalIgnoreCase);
 
+        // One service for the whole pass: its YAML serializers and file lock are
+        // instance-scoped, so reusing a single instance both avoids rebuilding
+        // that state per item and keeps every subscription mutation behind one
+        // semaphore. Only constructed when the pass actually has work to do.
+        SelfServiceManifestService? selfServiceManifest = null;
+
         try
         {
             using var managedKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(
@@ -1245,11 +1251,13 @@ public class UpdateEngine : IDisposable
                             }
                             else if (scope == StaleUsageScope.ManagedUpdate)
                             {
-                                await new SelfServiceManifestService().RemoveRequestAsync(catalogItem.Name);
+                                selfServiceManifest ??= new SelfServiceManifestService();
+                                await selfServiceManifest.RemoveRequestAsync(catalogItem.Name);
                             }
                             else
                             {
-                                await new SelfServiceManifestService().AddRemovalRequestAsync(catalogItem.Name);
+                                selfServiceManifest ??= new SelfServiceManifestService();
+                                await selfServiceManifest.AddRemovalRequestAsync(catalogItem.Name);
                                 ConsoleLogger.Info($"    StaleUsage: cleared self-serve subscription for {catalogItem.Name} (still available in MSC)");
                             }
                         }

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1160,7 +1160,7 @@ public class UpdateEngine : IDisposable
     /// opted in via unused_software_removal_info, unattended-uninstallable,
     /// and untouched by every user on the device past the threshold per the
     /// usage data source. Candidates come from the ManagedInstalls registry,
-    /// scoped per <see cref="StaleUsageEvaluator.ClassifyScope"/> (Munki parity):
+    /// scoped per <see cref="StaleUsageEvaluator.ClassifyScope"/>:
     /// admin-manifested items are never touched; self-serve installs get their
     /// subscription cleared (so the removal sticks and the item stays offered
     /// in MSC), and unsubscribed optional items and orphans uninstall directly.

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -429,7 +429,7 @@ public class UpdateEngine : IDisposable
                 // reload _config, and the source's lazy snapshot should reflect
                 // this run's on-disk data, not engine-construction time.
                 var usageSource = new ReportMateUsageDataSource();
-                var staleUsageItems = IdentifyStaleUsageItems(manifestItems, catalogMap, toUninstall, usageSource);
+                var staleUsageItems = await IdentifyStaleUsageItemsAsync(manifestItems, catalogMap, toUninstall, usageSource);
                 if (staleUsageItems.Count > 0)
                 {
                     ConsoleLogger.Info($"StaleUsage: {staleUsageItems.Count} package(s) untouched past their threshold");
@@ -1156,14 +1156,13 @@ public class UpdateEngine : IDisposable
     /// Identifies Cimian-installed packages eligible for stale-usage removal:
     /// opted in via days_untouched_before_uninstall, unattended-uninstallable,
     /// and untouched by every user on the device past the threshold per the
-    /// usage data source. Mirrors <see cref="IdentifyAutoRemoveItems"/>: only
-    /// packages in the ManagedInstalls registry are candidates, and anything
-    /// still named by a manifest is skipped — uninstalling a manifested item
-    /// would just reinstall next run (admin intent wins). Self-serve items are
-    /// deliberately untouched in this pass; removing those requires clearing
-    /// the self-serve manifest entry too (follow-up).
+    /// usage data source. Candidates come from the ManagedInstalls registry,
+    /// scoped per <see cref="StaleUsageEvaluator.ClassifyScope"/> (Munki parity):
+    /// admin-manifested items are never touched; self-serve installs get their
+    /// subscription cleared (so the removal sticks and the item stays offered
+    /// in MSC), and unsubscribed optional items and orphans uninstall directly.
     /// </summary>
-    private List<CatalogItem> IdentifyStaleUsageItems(
+    private async Task<List<CatalogItem>> IdentifyStaleUsageItemsAsync(
         List<ManifestItem> manifestItems,
         Dictionary<string, CatalogItem> catalogMap,
         List<CatalogItem> alreadyQueued,
@@ -1185,9 +1184,13 @@ public class UpdateEngine : IDisposable
             return stale;
         }
 
-        var manifestedNames = new HashSet<string>(
-            manifestItems.Select(m => m.Name).Where(n => !string.IsNullOrEmpty(n)),
-            StringComparer.OrdinalIgnoreCase);
+        // manifestItems is already deduplicated, so one entry per name carries
+        // the winning action (and the IsSelfServe flag from the merge).
+        var manifestByName = new Dictionary<string, ManifestItem>(StringComparer.OrdinalIgnoreCase);
+        foreach (var mi in manifestItems)
+        {
+            if (!string.IsNullOrEmpty(mi.Name)) manifestByName.TryAdd(mi.Name, mi);
+        }
         var queuedNames = new HashSet<string>(
             alreadyQueued.Select(i => i.Name),
             StringComparer.OrdinalIgnoreCase);
@@ -1200,7 +1203,11 @@ public class UpdateEngine : IDisposable
 
             foreach (var name in managedKey.GetSubKeyNames())
             {
-                if (manifestedNames.Contains(name) || queuedNames.Contains(name)) continue;
+                if (queuedNames.Contains(name)) continue;
+
+                var scope = StaleUsageEvaluator.ClassifyScope(manifestByName.GetValueOrDefault(name));
+                if (scope == StaleUsageScope.Protected) continue;
+
                 if (!catalogMap.TryGetValue(name.ToLowerInvariant(), out var catalogItem)) continue;
 
                 var decision = StaleUsageEvaluator.Evaluate(
@@ -1210,15 +1217,32 @@ public class UpdateEngine : IDisposable
                 {
                     case StaleUsageOutcome.Stale:
                         ConsoleLogger.Info(
-                            $"    -> StaleUsage: {catalogItem.Name} untouched {decision.DaysSinceLastUsed:F0} day(s) (threshold {decision.ThresholdDays}) - queuing uninstall");
+                            $"    -> StaleUsage: {catalogItem.Name} ({scope}) untouched {decision.DaysSinceLastUsed:F0} day(s) (threshold {decision.ThresholdDays}) - queuing uninstall");
                         // "pending" (not a custom status) so NormalizeItemStatus maps it
                         // for downstream consumers; the reason code marks it a removal.
                         _sessionLogger?.LogStatusCheck(
                             catalogItem.Name, catalogItem.Version, "pending",
-                            $"untouched {decision.DaysSinceLastUsed:F0} day(s), threshold {decision.ThresholdDays}, source {usageSource.SourceName}",
+                            $"untouched {decision.DaysSinceLastUsed:F0} day(s), threshold {decision.ThresholdDays}, source {usageSource.SourceName}, scope {scope}",
                             StatusReasonCode.StaleUsageUninstall,
                             DetectionMethod.ReportMateUsage,
                             needsAction: true);
+
+                        // Self-serve and optional items must also drop any self-serve
+                        // subscription — same effect as the user clicking Remove in
+                        // MSC — or the next run's merge would reinstall the item.
+                        // Check-only must not mutate state, so only report there.
+                        if (scope is StaleUsageScope.SelfServe or StaleUsageScope.Optional)
+                        {
+                            if (_checkOnly)
+                            {
+                                ConsoleLogger.Info($"    StaleUsage: would clear self-serve subscription for {catalogItem.Name} (check-only)");
+                            }
+                            else
+                            {
+                                await new SelfServiceManifestService().AddRemovalRequestAsync(catalogItem.Name);
+                                ConsoleLogger.Info($"    StaleUsage: cleared self-serve subscription for {catalogItem.Name} (still available in MSC)");
+                            }
+                        }
                         stale.Add(catalogItem);
                         break;
 

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -419,7 +419,7 @@ public class UpdateEngine : IDisposable
 
             // Stale-usage removal: queue uninstall for opted-in packages whose
             // tracked executables nobody on the device has used within
-            // days_untouched_before_uninstall. Peer of AutoRemove, not a
+            // unused_software_removal_info. Peer of AutoRemove, not a
             // dependency walker — and placed before the downstream filters so
             // install_window / blocking_applications / unattended gating apply
             // to these uninstalls the same as any other.
@@ -1157,7 +1157,7 @@ public class UpdateEngine : IDisposable
 
     /// <summary>
     /// Identifies Cimian-installed packages eligible for stale-usage removal:
-    /// opted in via days_untouched_before_uninstall, unattended-uninstallable,
+    /// opted in via unused_software_removal_info, unattended-uninstallable,
     /// and untouched by every user on the device past the threshold per the
     /// usage data source. Candidates come from the ManagedInstalls registry,
     /// scoped per <see cref="StaleUsageEvaluator.ClassifyScope"/> (Munki parity):

--- a/shared/core/Models/StatusReasonCode.cs
+++ b/shared/core/Models/StatusReasonCode.cs
@@ -135,13 +135,13 @@ public static class StatusReasonCode
     /// <summary>Auto run deferred this item because a user is active — either it is not unattended-eligible, or its restart_action would interrupt the session</summary>
     public const string DeferredUserActive = "deferred_user_active";
 
-    /// <summary>Package queued for removal: no tracked executable used within days_untouched_before_uninstall</summary>
+    /// <summary>Package queued for removal: no tracked executable used within unused_software_removal_info.removal_days</summary>
     public const string StaleUsageUninstall = "stale_usage_uninstall";
 
     /// <summary>Stale-usage check skipped: no usage data exists for any tracked executable</summary>
     public const string StaleUsageSkippedNoData = "stale_usage_skipped_no_data";
 
-    /// <summary>Stale-usage check skipped: device has fewer days of usage history than minimum_usage_history_days</summary>
+    /// <summary>Stale-usage check skipped: device has fewer days of usage history than the required minimum_history_days</summary>
     public const string StaleUsageSkippedInsufficientHistory = "stale_usage_skipped_insufficient_history";
 
     #endregion

--- a/shared/core/Services/IUsageDataSource.cs
+++ b/shared/core/Services/IUsageDataSource.cs
@@ -1,5 +1,5 @@
 // IUsageDataSource.cs - Abstraction over per-device application usage data
-// Backs the stale-usage removal feature (days_untouched_before_uninstall):
+// Backs the unused-software removal feature (unused_software_removal_info):
 // the engine asks "when was this executable last used on this device?" and
 // refuses to act when the source cannot answer confidently.
 

--- a/shared/import/Models/ImportModels.cs
+++ b/shared/import/Models/ImportModels.cs
@@ -48,14 +48,8 @@ public class PkgsInfo
     [YamlMember(Alias = "unattended_uninstall")]
     public bool UnattendedUninstall { get; set; }
 
-    [YamlMember(Alias = "days_untouched_before_uninstall")]
-    public int? DaysUntouchedBeforeUninstall { get; set; }
-
-    [YamlMember(Alias = "usage_tracked_paths")]
-    public List<string>? UsageTrackedPaths { get; set; }
-
-    [YamlMember(Alias = "minimum_usage_history_days")]
-    public int? MinimumUsageHistoryDays { get; set; }
+    [YamlMember(Alias = "unused_software_removal_info")]
+    public UnusedSoftwareRemovalInfo? UnusedSoftwareRemovalInfo { get; set; }
 
     [YamlMember(Alias = "requires")]
     public List<string>? Requires { get; set; }
@@ -267,4 +261,20 @@ public class AllCatalog
 {
     [YamlMember(Alias = "items")]
     public List<PkgsInfo> Items { get; set; } = [];
+}
+
+/// <summary>
+/// Munki-parity unused-software removal opt-in (paths is the Windows analog
+/// of Munki's bundle_ids; minimum_history_days is a Cimian extension).
+/// </summary>
+public class UnusedSoftwareRemovalInfo
+{
+    [YamlMember(Alias = "removal_days")]
+    public int? RemovalDays { get; set; }
+
+    [YamlMember(Alias = "paths")]
+    public List<string>? Paths { get; set; }
+
+    [YamlMember(Alias = "minimum_history_days")]
+    public int? MinimumHistoryDays { get; set; }
 }

--- a/shared/import/Models/ImportModels.cs
+++ b/shared/import/Models/ImportModels.cs
@@ -264,8 +264,8 @@ public class AllCatalog
 }
 
 /// <summary>
-/// Munki-parity unused-software removal opt-in (paths is the Windows analog
-/// of Munki's bundle_ids; minimum_history_days is a Cimian extension).
+/// Unused-software removal opt-in (paths gate removal by recorded usage;
+/// minimum_history_days is a Cimian extension).
 /// </summary>
 public class UnusedSoftwareRemovalInfo
 {

--- a/tests/Makepkginfo/PkgInfoBuilderTests.cs
+++ b/tests/Makepkginfo/PkgInfoBuilderTests.cs
@@ -187,23 +187,24 @@ public class PkgInfoBuilderTests
                 Catalogs = new List<string> { "Testing" },
                 UnattendedInstall = true,
                 UnattendedUninstall = true,
-                DaysUntouchedBeforeUninstall = 30,
-                UsageTrackedPaths = new List<string> { @"C:\Program Files\StaleApp\staleapp.exe" },
-                MinimumUsageHistoryDays = 14,
+                UnusedRemovalDays = 30,
+                UnusedPaths = new List<string> { @"C:\Program Files\StaleApp\staleapp.exe" },
+                UnusedMinimumHistoryDays = 14,
             };
 
             var pkgsinfo = _builder.BuildFromInstaller(tempFile, options);
 
             Assert.True(pkgsinfo.UnattendedUninstall);
-            Assert.Equal(30, pkgsinfo.DaysUntouchedBeforeUninstall);
-            Assert.Equal(options.UsageTrackedPaths, pkgsinfo.UsageTrackedPaths);
-            Assert.Equal(14, pkgsinfo.MinimumUsageHistoryDays);
+            Assert.Equal(30, pkgsinfo.UnusedSoftwareRemovalInfo?.RemovalDays);
+            Assert.Equal(options.UnusedPaths, pkgsinfo.UnusedSoftwareRemovalInfo?.Paths);
+            Assert.Equal(14, pkgsinfo.UnusedSoftwareRemovalInfo?.MinimumHistoryDays);
 
             var yaml = _builder.SerializePkgsInfo(pkgsinfo);
             Assert.Contains("unattended_uninstall: true", yaml);
-            Assert.Contains("days_untouched_before_uninstall: 30", yaml);
-            Assert.Contains("usage_tracked_paths:", yaml);
-            Assert.Contains("minimum_usage_history_days: 14", yaml);
+            Assert.Contains("unused_software_removal_info:", yaml);
+            Assert.Contains("removal_days: 30", yaml);
+            Assert.Contains("paths:", yaml);
+            Assert.Contains("minimum_history_days: 14", yaml);
         }
         finally
         {

--- a/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
+++ b/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
@@ -185,4 +185,48 @@ public class StaleUsageEvaluatorTests
 
         Assert.Equal(new[] { Exe }, exes);
     }
+
+    // ── manifest scoping (Munki parity) ─────────────────────────────────
+    // Unused-software removal acts on self-serve/optional installs and
+    // orphans, never on anything an admin manifest mandates.
+
+    [Fact]
+    public void ClassifyScope_Orphan_WhenNoManifestEntry()
+        => Assert.Equal(StaleUsageScope.Orphan, StaleUsageEvaluator.ClassifyScope(null));
+
+    [Fact]
+    public void ClassifyScope_Optional_WhenUnsubscribedOptionalInstall()
+    {
+        var entry = new ManifestItem { Name = "StaleApp", Action = "optional" };
+        Assert.Equal(StaleUsageScope.Optional, StaleUsageEvaluator.ClassifyScope(entry));
+    }
+
+    [Fact]
+    public void ClassifyScope_SelfServe_WhenUserInstalledViaSelfServeManifest()
+    {
+        var entry = new ManifestItem { Name = "StaleApp", Action = "install", IsSelfServe = true };
+        Assert.Equal(StaleUsageScope.SelfServe, StaleUsageEvaluator.ClassifyScope(entry));
+    }
+
+    [Theory]
+    [InlineData("install")]   // managed_installs — admin mandates presence
+    [InlineData("update")]    // managed_updates — presence is user/other-channel managed
+    [InlineData("default")]   // default_installs — enforced like an install
+    [InlineData("uninstall")] // already being removed
+    [InlineData("profile")]
+    [InlineData("app")]
+    public void ClassifyScope_Protected_ForAdminManagedActions(string action)
+    {
+        var entry = new ManifestItem { Name = "StaleApp", Action = action };
+        Assert.Equal(StaleUsageScope.Protected, StaleUsageEvaluator.ClassifyScope(entry));
+    }
+
+    [Fact]
+    public void ClassifyScope_Protected_WhenAdminInstall_EvenIfUserAlsoRequestedIt()
+    {
+        // The merge never sets IsSelfServe on an item the server already
+        // manages; this pins the contract from the classifier's side too.
+        var entry = new ManifestItem { Name = "StaleApp", Action = "install", IsSelfServe = false };
+        Assert.Equal(StaleUsageScope.Protected, StaleUsageEvaluator.ClassifyScope(entry));
+    }
 }

--- a/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
+++ b/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
@@ -189,7 +189,7 @@ public class StaleUsageEvaluatorTests
         Assert.Equal(new[] { Exe }, exes);
     }
 
-    // ── manifest scoping (Munki parity) ─────────────────────────────────
+    // ── manifest scoping ────────────────────────────────────────────────
     // Unused-software removal acts on self-serve/optional installs and
     // orphans, never on anything an admin manifest mandates.
 

--- a/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
+++ b/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
@@ -37,8 +37,11 @@ public class StaleUsageEvaluatorTests
         Version = "1.0",
         UnattendedUninstall = unattended,
         Uninstallable = true,
-        DaysUntouchedBeforeUninstall = threshold,
-        UsageTrackedPaths = new List<string> { Exe },
+        UnusedSoftwareRemovalInfo = new UnusedSoftwareRemovalInfo
+        {
+            RemovalDays = threshold,
+            Paths = new List<string> { Exe },
+        },
         Installs = new List<InstallCheckItem>
         {
             new() { Type = "msi", ProductCode = "{11111111-2222-3333-4444-555555555555}" },
@@ -84,7 +87,7 @@ public class StaleUsageEvaluatorTests
     public void NoTrackedExecutables_WhenNoPathsAndNoExeInstalls()
     {
         var item = Item();
-        item.UsageTrackedPaths = null; // fall back to installs — which has only the MSI row
+        item.UnusedSoftwareRemovalInfo!.Paths = null; // fall back to installs — which has only the MSI row
         var decision = StaleUsageEvaluator.Evaluate(item, SourceWithUsage(365), 14);
         Assert.Equal(StaleUsageOutcome.NoTrackedExecutables, decision.Outcome);
     }
@@ -104,7 +107,7 @@ public class StaleUsageEvaluatorTests
         var source = SourceWithUsage(100);
         source.HistoryDays = 20; // passes the global 14, fails the package's 45
         var item = Item();
-        item.MinimumUsageHistoryDays = 45;
+        item.UnusedSoftwareRemovalInfo!.MinimumHistoryDays = 45;
         var decision = StaleUsageEvaluator.Evaluate(item, source, 14);
         Assert.Equal(StaleUsageOutcome.InsufficientHistory, decision.Outcome);
     }
@@ -146,7 +149,7 @@ public class StaleUsageEvaluatorTests
         source.Data[helper] = DateTime.UtcNow.AddDays(-5);
 
         var item = Item(threshold: 30);
-        item.UsageTrackedPaths = new List<string> { Exe, helper };
+        item.UnusedSoftwareRemovalInfo!.Paths = new List<string> { Exe, helper };
 
         var decision = StaleUsageEvaluator.Evaluate(item, source, 14);
         Assert.Equal(StaleUsageOutcome.RecentlyUsed, decision.Outcome);
@@ -158,7 +161,7 @@ public class StaleUsageEvaluatorTests
     public void ResolveTrackedExecutables_FallsBackToInstallsExes()
     {
         var item = Item();
-        item.UsageTrackedPaths = null;
+        item.UnusedSoftwareRemovalInfo!.Paths = null;
         item.Installs.Add(new InstallCheckItem { Type = "file", Path = Exe });
         item.Installs.Add(new InstallCheckItem
         {

--- a/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
+++ b/tests/Managedsoftwareupdate/StaleUsageEvaluatorTests.cs
@@ -208,9 +208,18 @@ public class StaleUsageEvaluatorTests
         Assert.Equal(StaleUsageScope.SelfServe, StaleUsageEvaluator.ClassifyScope(entry));
     }
 
+    [Fact]
+    public void ClassifyScope_ManagedUpdate_WhenOnlyInManagedUpdates()
+    {
+        // managed_updates says "patch if present" — no presence intent, so a
+        // stale removal doesn't fight policy and nothing reinstalls the item.
+        // This is the provision-then-keep-patched pattern (e.g. Firefox).
+        var entry = new ManifestItem { Name = "StaleApp", Action = "update" };
+        Assert.Equal(StaleUsageScope.ManagedUpdate, StaleUsageEvaluator.ClassifyScope(entry));
+    }
+
     [Theory]
     [InlineData("install")]   // managed_installs — admin mandates presence
-    [InlineData("update")]    // managed_updates — presence is user/other-channel managed
     [InlineData("default")]   // default_installs — enforced like an install
     [InlineData("uninstall")] // already being removed
     [InlineData("profile")]

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -25,6 +25,13 @@ public class UpdateModelsTests
         Assert.False(config.NoPreflight);
         Assert.False(config.NoPostflight);
         Assert.False(config.CheckOnly);
+
+        // Stale-usage removal is on by default: safe fleet-wide because every
+        // package must still opt in via days_untouched_before_uninstall and
+        // admin-manifested items are always protected.
+        Assert.True(config.UsageStaleUninstallEnabled);
+        Assert.Equal(14, config.UsageStaleUninstallMinimumHistoryDays);
+        Assert.Equal(7, config.UsageStaleUninstallMaxSourceStalenessDays);
     }
 
     [Fact]

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -27,7 +27,7 @@ public class UpdateModelsTests
         Assert.False(config.CheckOnly);
 
         // Stale-usage removal is on by default: safe fleet-wide because every
-        // package must still opt in via days_untouched_before_uninstall and
+        // package must still opt in via unused_software_removal_info and
         // admin-manifested items are always protected.
         Assert.True(config.UsageStaleUninstallEnabled);
         Assert.Equal(14, config.UsageStaleUninstallMinimumHistoryDays);

--- a/tests/Shared/UsageStaleSchemaTests.cs
+++ b/tests/Shared/UsageStaleSchemaTests.cs
@@ -5,13 +5,13 @@ using YamlDotNet.Serialization;
 namespace Cimian.Tests.Shared;
 
 /// <summary>
-/// Schema tests for the stale-usage removal fields
-/// (days_untouched_before_uninstall, usage_tracked_paths,
-/// minimum_usage_history_days). The same YAML keys must round-trip through
-/// every model that carries them: cimiimport's PkgsInfo, makecatalogs'
-/// PkgsInfo, and the engine's CatalogItem. A field landing in one model but
-/// not another silently strips it during the import → catalog → client
-/// pipeline, so each model gets its own deserialization pin.
+/// Schema tests for unused_software_removal_info (Munki-parity dict:
+/// removal_days + paths, plus Cimian's minimum_history_days extension).
+/// The same YAML structure must round-trip through every model that carries
+/// it: cimiimport's PkgsInfo, makecatalogs' PkgsInfo, and the engine's
+/// CatalogItem. A field landing in one model but not another silently strips
+/// it during the import → catalog → client pipeline, so each model gets its
+/// own deserialization pin.
 /// </summary>
 public class UsageStaleSchemaTests
 {
@@ -19,11 +19,12 @@ public class UsageStaleSchemaTests
         name: StaleApp
         version: '1.0'
         unattended_uninstall: true
-        days_untouched_before_uninstall: 30
-        usage_tracked_paths:
-        - C:\Program Files\StaleApp\staleapp.exe
-        - C:\Program Files\StaleApp\helper.exe
-        minimum_usage_history_days: 14
+        unused_software_removal_info:
+          removal_days: 30
+          paths:
+          - C:\Program Files\StaleApp\staleapp.exe
+          - C:\Program Files\StaleApp\helper.exe
+          minimum_history_days: 14
         """;
 
     private static IDeserializer PlainDeserializer() => new DeserializerBuilder()
@@ -31,42 +32,41 @@ public class UsageStaleSchemaTests
         .Build();
 
     [Fact]
-    public void CimiimportPkgsInfo_Deserializes_UsageStaleFields()
+    public void CimiimportPkgsInfo_Deserializes_UnusedRemovalInfo()
     {
         var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Cimiimport.Models.PkgsInfo>(PkginfoYaml);
 
-        Assert.Equal(30, pkg.DaysUntouchedBeforeUninstall);
-        Assert.Equal(2, pkg.UsageTrackedPaths?.Count);
-        Assert.Equal(14, pkg.MinimumUsageHistoryDays);
+        Assert.Equal(30, pkg.UnusedSoftwareRemovalInfo?.RemovalDays);
+        Assert.Equal(2, pkg.UnusedSoftwareRemovalInfo?.Paths?.Count);
+        Assert.Equal(14, pkg.UnusedSoftwareRemovalInfo?.MinimumHistoryDays);
     }
 
     [Fact]
-    public void MakecatalogsPkgsInfo_Deserializes_UsageStaleFields()
+    public void MakecatalogsPkgsInfo_Deserializes_UnusedRemovalInfo()
     {
         var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(PkginfoYaml);
 
-        Assert.Equal(30, pkg.DaysUntouchedBeforeUninstall);
-        Assert.Equal(2, pkg.UsageTrackedPaths?.Count);
-        Assert.Equal(14, pkg.MinimumUsageHistoryDays);
+        Assert.Equal(30, pkg.UnusedSoftwareRemovalInfo?.RemovalDays);
+        Assert.Equal(2, pkg.UnusedSoftwareRemovalInfo?.Paths?.Count);
+        Assert.Equal(14, pkg.UnusedSoftwareRemovalInfo?.MinimumHistoryDays);
     }
 
     [Fact]
-    public void EngineCatalogItem_Deserializes_UsageStaleFields()
+    public void EngineCatalogItem_Deserializes_UnusedRemovalInfo()
     {
         var item = PlainDeserializer().Deserialize<Cimian.CLI.managedsoftwareupdate.Models.CatalogItem>(PkginfoYaml);
 
         Assert.True(item.UnattendedUninstall);
-        Assert.Equal(30, item.DaysUntouchedBeforeUninstall);
-        Assert.Equal(2, item.UsageTrackedPaths?.Count);
-        Assert.Equal(14, item.MinimumUsageHistoryDays);
+        Assert.Equal(30, item.UnusedSoftwareRemovalInfo?.RemovalDays);
+        Assert.Equal(2, item.UnusedSoftwareRemovalInfo?.Paths?.Count);
+        Assert.Equal(14, item.UnusedSoftwareRemovalInfo?.MinimumHistoryDays);
     }
 
     [Fact]
     public void EngineCatalogItem_FieldsDefaultNull_WhenAbsent()
     {
-        // Absence must read as "feature disabled", never zero — the engine
-        // treats null/<=0 as opt-out, so a default of 0 is equivalent, but
-        // null is the canonical not-configured signal for reporting.
+        // Absence must read as "feature disabled" — null is the canonical
+        // not-configured signal for the engine and for reporting.
         const string minimal = """
             name: PlainApp
             version: '1.0'
@@ -74,21 +74,19 @@ public class UsageStaleSchemaTests
 
         var item = PlainDeserializer().Deserialize<Cimian.CLI.managedsoftwareupdate.Models.CatalogItem>(minimal);
 
-        Assert.Null(item.DaysUntouchedBeforeUninstall);
-        Assert.Null(item.UsageTrackedPaths);
-        Assert.Null(item.MinimumUsageHistoryDays);
+        Assert.Null(item.UnusedSoftwareRemovalInfo);
     }
 
     [Fact]
-    public void MakecatalogsPkgsInfo_RoundTrips_UsageStaleFields()
+    public void MakecatalogsPkgsInfo_RoundTrips_UnusedRemovalInfo()
     {
         var pkg = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(PkginfoYaml);
         var yaml = new SerializerBuilder().Build().Serialize(pkg);
         var again = PlainDeserializer().Deserialize<Cimian.CLI.Makecatalogs.Models.PkgsInfo>(yaml);
 
-        Assert.Equal(30, again.DaysUntouchedBeforeUninstall);
-        Assert.Equal(pkg.UsageTrackedPaths, again.UsageTrackedPaths);
-        Assert.Equal(14, again.MinimumUsageHistoryDays);
+        Assert.Equal(30, again.UnusedSoftwareRemovalInfo?.RemovalDays);
+        Assert.Equal(pkg.UnusedSoftwareRemovalInfo?.Paths, again.UnusedSoftwareRemovalInfo?.Paths);
+        Assert.Equal(14, again.UnusedSoftwareRemovalInfo?.MinimumHistoryDays);
     }
 }
 

--- a/tests/Shared/UsageStaleSchemaTests.cs
+++ b/tests/Shared/UsageStaleSchemaTests.cs
@@ -5,8 +5,8 @@ using YamlDotNet.Serialization;
 namespace Cimian.Tests.Shared;
 
 /// <summary>
-/// Schema tests for unused_software_removal_info (Munki-parity dict:
-/// removal_days + paths, plus Cimian's minimum_history_days extension).
+/// Schema tests for unused_software_removal_info (removal_days + paths,
+/// plus Cimian's minimum_history_days extension).
 /// The same YAML structure must round-trip through every model that carries
 /// it: cimiimport's PkgsInfo, makecatalogs' PkgsInfo, and the engine's
 /// CatalogItem. A field landing in one model but not another silently strips


### PR DESCRIPTION
## What

1. **`UsageStaleUninstallEnabled` defaults to `true`.** Safe fleet-wide: every package must still opt in via `unused_software_removal_info` in its pkginfo, and the pass never touches admin-mandated software.

2. **Intent-based scoping** (`StaleUsageEvaluator.ClassifyScope`):

| Scope | Source | Action when stale |
|---|---|---|
| Protected | managed_installs / default_installs / profiles / apps / pending uninstall | never removed |
| SelfServe | user installed via MSC (SelfServeManifest) | `AddRemovalRequestAsync` + uninstall — same effect as clicking Remove in MSC; item stays offered |
| Optional | in optional_installs, not subscribed | removal request + uninstall (nothing reinstalls it) |
| ManagedUpdate | only in managed_updates ("patch if present" — no presence intent) | uninstall; lingering install requests cleared via `RemoveRequestAsync` |
| Orphan | in no manifest (AutoRemove territory) | uninstall |

Managed installs are exempt, the primary target is self-serve optional installs, and removal drops the self-serve choice so it persists while the item remains reinstallable. ManagedUpdate extends that to the provision-then-keep-patched pattern (e.g. Firefox: installed by ProvisioningStaff, kept current via managed_updates).

3. **Munki-parity schema.** Opt-in uses Munki's own key, `unused_software_removal_info: { removal_days, paths, minimum_history_days }` — `paths` is the Windows analog of Munki's `bundle_ids`; `minimum_history_days` is a Cimian extension. The earlier flat keys (`days_untouched_before_uninstall` etc.) shipped only in v0.0.8 with the feature off and no pkginfo using them, so this is a clean rename with no back-compat aliases.

4. **`ManifestItem.IsSelfServe`** distinguishes user intent from admin intent after the self-serve merge. The merge checks **all** entries for a name before promoting optional to install, so an item optional in one manifest but managed in another can never be misclassified as self-serve.

5. Check-only never writes the self-serve manifest; items already queued for install/update this run defer stale evaluation to the next run.

## Tests

ClassifyScope pins, config-default pins, and schema round-trip pins across every pkginfo model. Full suite green locally except the pre-existing `ScriptServiceTests` stderr-marker case that passes in CI.