### PR TITLE
cimiimport --emit-installs and wrapper-MSI display_name fallback

### DIFF
--- a/cli/cimiimport/Program.cs
+++ b/cli/cimiimport/Program.cs
@@ -86,6 +86,10 @@ public class Program
             "--nointeractive",
             "Run with no prompts (use defaults or fail)");
 
+        var emitInstallsOption = new Option<bool>(
+            "--emit-installs",
+            "Print the auto-generated 'installs' array for the installer as YAML to stdout and exit (no repo import)");
+
         var extractIconOption = new Option<bool>(
             "--extract-icon",
             "Enable icon extraction from installer (EXPERIMENTAL)");
@@ -114,6 +118,7 @@ public class Program
         rootCommand.AddOption(configOption);
         rootCommand.AddOption(configAutoOption);
         rootCommand.AddOption(noInteractiveOption);
+        rootCommand.AddOption(emitInstallsOption);
         rootCommand.AddOption(extractIconOption);
         rootCommand.AddOption(iconOutputOption);
         rootCommand.AddOption(skipIconOption);
@@ -137,6 +142,7 @@ public class Program
             var configRequested = context.ParseResult.GetValueForOption(configOption);
             var configAuto = context.ParseResult.GetValueForOption(configAutoOption);
             var noInteractive = context.ParseResult.GetValueForOption(noInteractiveOption);
+            var emitInstalls = context.ParseResult.GetValueForOption(emitInstallsOption);
             var extractIcon = context.ParseResult.GetValueForOption(extractIconOption);
             var iconOutput = context.ParseResult.GetValueForOption(iconOutputOption);
             var skipIcon = context.ParseResult.GetValueForOption(skipIconOption);
@@ -206,6 +212,15 @@ public class Program
                 InstallCheck = installCheckScript,
                 UninstallCheck = uninstallCheckScript
             };
+
+            // Handle --emit-installs: print the auto-generated installs array
+            // and exit without touching the repo (no git pull, no makecatalogs).
+            if (emitInstalls)
+            {
+                var emitService = new ImportService();
+                context.ExitCode = emitService.EmitInstalls(packagePath, config, installsArray.ToList()) ? 0 : 1;
+                return;
+            }
 
             // Check for git repo and pull
             var importService = new ImportService();

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -522,6 +522,19 @@ public class InstallCheckItem
     [YamlMember(Alias = "upgrade_code")]
     public string? UpgradeCode { get; set; }
 
+    /// <summary>
+    /// ARP (Add/Remove Programs) DisplayName fallback for wrapper MSIs (empty
+    /// File table; payload installed by an embedded setup.exe, e.g. Mozilla
+    /// Firefox). Such products may not keep their Windows Installer
+    /// registration, so when the declared ProductCode/UpgradeCode lookups miss,
+    /// status checks and post-install verification fall back to a substring
+    /// match against Uninstall-hive DisplayNames. Opt-in per entry — emitted by
+    /// cimiimport only for wrapper-shaped MSIs, so codes stay authoritative for
+    /// normal MSIs (no fuzzy matching of unrelated products).
+    /// </summary>
+    [YamlMember(Alias = "display_name")]
+    public string? DisplayName { get; set; }
+
     /// <summary>MSIX/APPX package identity name (from AppxManifest Identity/@Name)</summary>
     [YamlMember(Alias = "identity_name")]
     public string? IdentityName { get; set; }

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -1712,6 +1712,22 @@ exit 0
                         }
                     }
 
+                    // Wrapper MSIs (empty File table; payload installed by an embedded
+                    // setup.exe, e.g. Mozilla Firefox) can complete successfully without
+                    // leaving Windows Installer registration -- the product maintains a
+                    // plain ARP entry instead. When the pkginfo entry opts in via
+                    // display_name, accept an Uninstall-hive DisplayName hit as proof of
+                    // installation so the run doesn't loop on "MSI not registered".
+                    if (!msiFound && !string.IsNullOrEmpty(install.DisplayName))
+                    {
+                        var arpVersion = FindArpVersionByDisplayName(install.DisplayName);
+                        if (!string.IsNullOrEmpty(arpVersion))
+                        {
+                            ConsoleLogger.Debug($"MSI verification via ARP display_name successful for {item.Name}: {arpVersion}");
+                            msiFound = true;
+                        }
+                    }
+
                     if (!msiFound)
                     {
                         var reason = $"MSI not registered in Windows Installer (ProductCode={install.ProductCode}, UpgradeCode={install.UpgradeCode})";
@@ -1767,6 +1783,52 @@ exit 0
             catch { /* continue to next view */ }
         }
         return null;
+    }
+
+    /// <summary>
+    /// Looks up a DisplayVersion by ARP DisplayName in the Uninstall registry
+    /// (64-bit and 32-bit views). Exact match first, then substring in either
+    /// direction — wrapper MSIs register names like "Mozilla Firefox (x64
+    /// en-US)" while the pkginfo hint carries the stable prefix. Mirrors
+    /// StatusService.FindVersionByDisplayName so detection and post-install
+    /// verification agree on what counts as installed.
+    /// </summary>
+    private static string? FindArpVersionByDisplayName(string displayName)
+    {
+        if (string.IsNullOrEmpty(displayName))
+            return null;
+
+        string? substringHit = null;
+        foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
+        {
+            try
+            {
+                using var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, view);
+                using var uninstallKey = baseKey.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall");
+                if (uninstallKey == null) continue;
+
+                foreach (var subkeyName in uninstallKey.GetSubKeyNames())
+                {
+                    using var subKey = uninstallKey.OpenSubKey(subkeyName);
+                    var regDisplayName = subKey?.GetValue("DisplayName")?.ToString();
+                    var regVersion = subKey?.GetValue("DisplayVersion")?.ToString();
+                    if (string.IsNullOrEmpty(regDisplayName) || string.IsNullOrEmpty(regVersion))
+                        continue;
+
+                    if (string.Equals(regDisplayName, displayName, StringComparison.OrdinalIgnoreCase))
+                        return regVersion;
+
+                    if (substringHit == null
+                        && (regDisplayName.Contains(displayName, StringComparison.OrdinalIgnoreCase)
+                            || displayName.Contains(regDisplayName, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        substringHit = regVersion;
+                    }
+                }
+            }
+            catch { /* continue to next view */ }
+        }
+        return substringHit;
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -563,7 +563,7 @@ public class StatusService
                             msiInstalled = true;
                             msiInstalledVersion = fallbackVersion;
                             ConsoleLogger.Info($"Found app via display_name fallback item: {item.Name} displayName: {displayNameToSearch} installedVersion: {fallbackVersion}");
-                            
+
                             // Check version match
                             if (!string.IsNullOrEmpty(catalogVersion))
                             {
@@ -574,6 +574,27 @@ public class StatusService
                             {
                                 msiVersionMatch = true;
                             }
+                        }
+                    }
+
+                    // Wrapper MSIs (empty File table; payload installed by an embedded
+                    // setup.exe, e.g. Mozilla Firefox) may drop their Windows Installer
+                    // registration after in-app self-update -- the updater maintains a
+                    // plain ARP entry instead, so the declared codes miss forever and
+                    // every run reinstalls. When the pkginfo entry carries an explicit
+                    // display_name, treat an ARP DisplayName hit as installed. Opt-in
+                    // per entry: codes stay authoritative for normal MSIs, preserving
+                    // the no-fuzzy-matching guard above.
+                    if (!msiInstalled && !string.IsNullOrEmpty(installItem.DisplayName))
+                    {
+                        var arpVersion = FindVersionByDisplayName(installItem.DisplayName);
+                        if (!string.IsNullOrEmpty(arpVersion))
+                        {
+                            msiInstalled = true;
+                            msiInstalledVersion = arpVersion;
+                            msiVersionMatch = string.IsNullOrEmpty(catalogVersion)
+                                || CatalogService.CompareVersions(catalogVersion, arpVersion) <= 0;
+                            ConsoleLogger.Info($"Found app via installs[].display_name fallback item: {item.Name} displayName: {installItem.DisplayName} installedVersion: {arpVersion}");
                         }
                     }
 

--- a/shared/import/Models/ImportModels.cs
+++ b/shared/import/Models/ImportModels.cs
@@ -162,6 +162,17 @@ public class InstallItem
     [YamlMember(Alias = "upgrade_code")]
     public string? UpgradeCode { get; set; }
 
+    /// <summary>
+    /// ARP (Add/Remove Programs) DisplayName fallback for wrapper MSIs (empty
+    /// File table; payload installed by an embedded setup.exe, e.g. Mozilla
+    /// Firefox). Such products may not keep their Windows Installer
+    /// registration, so managedsoftwareupdate falls back to an Uninstall-hive
+    /// DisplayName match when the declared codes miss. Only emitted when the
+    /// MSI is wrapper-shaped — codes stay authoritative for normal MSIs.
+    /// </summary>
+    [YamlMember(Alias = "display_name")]
+    public string? DisplayName { get; set; }
+
     /// <summary>MSIX/APPX package identity name (from AppxManifest Identity/@Name).</summary>
     [YamlMember(Alias = "identity_name")]
     public string? IdentityName { get; set; }
@@ -224,6 +235,14 @@ public class InstallerMetadata
     /// tables. Empty when unresolvable.
     /// </summary>
     public string KeyPath { get; set; } = "";
+
+    /// <summary>
+    /// ARP DisplayName hint for wrapper MSIs (empty File table). Populated by
+    /// PopulateMsiBom from the MSI ProductName with the version and trailing
+    /// tokens stripped; carried onto the type=msi installs entry as
+    /// display_name. Empty for normal MSIs.
+    /// </summary>
+    public string ArpDisplayName { get; set; } = "";
 }
 
 /// <summary>

--- a/shared/import/Services/ImportService.cs
+++ b/shared/import/Services/ImportService.cs
@@ -566,6 +566,11 @@ public class ImportService
             // Third-party MSIs leave KeyPath empty here — those packages get up
             // to 3 companion type=file entries appended further down via
             // metadata.Installs (see PopulateMsiBom).
+            // DisplayName is the wrapper-MSI escape hatch: PopulateMsiBom sets
+            // ArpDisplayName only when the File table carries no payload, and
+            // the runtime falls back to an ARP DisplayName lookup when the
+            // declared codes miss (Firefox-style products that drop their
+            // Windows Installer registration after self-update).
             finalInstalls =
             [
                 new InstallItem
@@ -573,6 +578,7 @@ public class ImportService
                     Type = "msi",
                     ProductCode = productCode,
                     UpgradeCode = upgradeCode,
+                    DisplayName = string.IsNullOrWhiteSpace(metadata.ArpDisplayName) ? null : metadata.ArpDisplayName,
                     KeyPath = string.IsNullOrWhiteSpace(metadata.KeyPath) ? null : metadata.KeyPath
                 }
             ];

--- a/shared/import/Services/ImportService.cs
+++ b/shared/import/Services/ImportService.cs
@@ -163,80 +163,7 @@ public class ImportService
         var repoSubPath = await prompter.AskRepoSubdirAsync(defaultRepoSub, cancellationToken).ConfigureAwait(false);
 
         // Step 10: Build installs array
-        List<InstallItem> finalInstalls;
-        if (installsPaths.Count > 0)
-        {
-            finalInstalls = BuildInstallsArray(installsPaths, prompter);
-        }
-        else if (metadata.InstallerType == "exe")
-        {
-            var fallbackExe = $@"C:\Program Files\{pkgsInfo.Name}\{pkgsInfo.Name}.exe";
-            prompter.ReportInfo($"Using fallback .exe => {fallbackExe}");
-            finalInstalls =
-            [
-                new InstallItem
-                {
-                    Type = "file",
-                    Path = fallbackExe,
-                    Version = pkgsInfo.Version
-                }
-            ];
-        }
-        else if (metadata.InstallerType == "msix" && !string.IsNullOrEmpty(metadata.IdentityName))
-        {
-            // MSIX packages are detected via Get-AppxProvisionedPackage filtered by Identity.Name
-            prompter.ReportInfo($"Using MSIX identity => {metadata.IdentityName}");
-            finalInstalls =
-            [
-                new InstallItem
-                {
-                    Type = "msix",
-                    IdentityName = metadata.IdentityName,
-                    Version = pkgsInfo.Version
-                }
-            ];
-        }
-        else if (metadata.InstallerType == "msi"
-            && (!string.IsNullOrEmpty(metadata.ProductCode) || !string.IsNullOrEmpty(metadata.UpgradeCode)))
-        {
-            // MSI packages are verified by querying Windows Installer for the ProductCode
-            // (per-version) or UpgradeCode (stable). Without an installs[] entry of type=msi
-            // the runtime verifier emits "No installs array for X — cannot verify".
-            var productCode = string.IsNullOrEmpty(metadata.ProductCode) ? null : metadata.ProductCode.Trim();
-            var upgradeCode = string.IsNullOrEmpty(metadata.UpgradeCode) ? null : metadata.UpgradeCode.Trim();
-            var codeSummary = !string.IsNullOrEmpty(productCode)
-                ? (!string.IsNullOrEmpty(upgradeCode) ? $"ProductCode={productCode}, UpgradeCode={upgradeCode}" : $"ProductCode={productCode}")
-                : $"UpgradeCode={upgradeCode}";
-            prompter.ReportInfo($"Using MSI {codeSummary}");
-            // Version is intentionally omitted — StatusService falls back to the
-            // top-level pkginfo version when the installs entry has none, and the
-            // MSI's per-version identity is already the ProductCode.
-            //
-            // KeyPath is populated by ExtractMsiMetadata for cimipkg-built MSIs
-            // (either an explicit build-info override or the BOM heuristic pick).
-            // Third-party MSIs leave KeyPath empty here — those packages get up
-            // to 3 companion type=file entries appended further down via
-            // metadata.Installs (see PopulateMsiBom).
-            finalInstalls =
-            [
-                new InstallItem
-                {
-                    Type = "msi",
-                    ProductCode = productCode,
-                    UpgradeCode = upgradeCode,
-                    KeyPath = string.IsNullOrWhiteSpace(metadata.KeyPath) ? null : metadata.KeyPath
-                }
-            ];
-        }
-        else
-        {
-            finalInstalls = [];
-        }
-
-        if (metadata.Installs.Count > 0)
-        {
-            finalInstalls.AddRange(metadata.Installs);
-        }
+        var finalInstalls = BuildFinalInstallsArray(metadata, pkgsInfo.Name, pkgsInfo.Version, installsPaths, prompter);
         pkgsInfo.Installs = finalInstalls.Count > 0 ? finalInstalls : null;
 
         // Auto-generate an MSIX uninstaller entry when the importer didn't receive
@@ -568,6 +495,128 @@ public class ImportService
         }
 
         return normalized;
+    }
+
+    /// <summary>
+    /// Assembles the final auto-generated installs array for an installer:
+    /// explicit -i paths win; otherwise an installer-type-specific identity
+    /// entry (exe fallback path, MSIX identity, MSI ProductCode/UpgradeCode),
+    /// with any BOM-derived companion file checks from
+    /// <see cref="InstallerMetadata.Installs"/> (see
+    /// <see cref="MetadataExtractor"/> PopulateMsiBom) appended on top.
+    /// </summary>
+    public List<InstallItem> BuildFinalInstallsArray(
+        InstallerMetadata metadata,
+        string packageName,
+        string packageVersion,
+        List<string> installsPaths,
+        IImportPrompter prompter)
+    {
+        List<InstallItem> finalInstalls;
+        if (installsPaths.Count > 0)
+        {
+            finalInstalls = BuildInstallsArray(installsPaths, prompter);
+        }
+        else if (metadata.InstallerType == "exe")
+        {
+            var fallbackExe = $@"C:\Program Files\{packageName}\{packageName}.exe";
+            prompter.ReportInfo($"Using fallback .exe => {fallbackExe}");
+            finalInstalls =
+            [
+                new InstallItem
+                {
+                    Type = "file",
+                    Path = fallbackExe,
+                    Version = packageVersion
+                }
+            ];
+        }
+        else if (metadata.InstallerType == "msix" && !string.IsNullOrEmpty(metadata.IdentityName))
+        {
+            // MSIX packages are detected via Get-AppxProvisionedPackage filtered by Identity.Name
+            prompter.ReportInfo($"Using MSIX identity => {metadata.IdentityName}");
+            finalInstalls =
+            [
+                new InstallItem
+                {
+                    Type = "msix",
+                    IdentityName = metadata.IdentityName,
+                    Version = packageVersion
+                }
+            ];
+        }
+        else if (metadata.InstallerType == "msi"
+            && (!string.IsNullOrEmpty(metadata.ProductCode) || !string.IsNullOrEmpty(metadata.UpgradeCode)))
+        {
+            // MSI packages are verified by querying Windows Installer for the ProductCode
+            // (per-version) or UpgradeCode (stable). Without an installs[] entry of type=msi
+            // the runtime verifier emits "No installs array for X — cannot verify".
+            var productCode = string.IsNullOrEmpty(metadata.ProductCode) ? null : metadata.ProductCode.Trim();
+            var upgradeCode = string.IsNullOrEmpty(metadata.UpgradeCode) ? null : metadata.UpgradeCode.Trim();
+            var codeSummary = !string.IsNullOrEmpty(productCode)
+                ? (!string.IsNullOrEmpty(upgradeCode) ? $"ProductCode={productCode}, UpgradeCode={upgradeCode}" : $"ProductCode={productCode}")
+                : $"UpgradeCode={upgradeCode}";
+            prompter.ReportInfo($"Using MSI {codeSummary}");
+            // Version is intentionally omitted — StatusService falls back to the
+            // top-level pkginfo version when the installs entry has none, and the
+            // MSI's per-version identity is already the ProductCode.
+            //
+            // KeyPath is populated by ExtractMsiMetadata for cimipkg-built MSIs
+            // (either an explicit build-info override or the BOM heuristic pick).
+            // Third-party MSIs leave KeyPath empty here — those packages get up
+            // to 3 companion type=file entries appended further down via
+            // metadata.Installs (see PopulateMsiBom).
+            finalInstalls =
+            [
+                new InstallItem
+                {
+                    Type = "msi",
+                    ProductCode = productCode,
+                    UpgradeCode = upgradeCode,
+                    KeyPath = string.IsNullOrWhiteSpace(metadata.KeyPath) ? null : metadata.KeyPath
+                }
+            ];
+        }
+        else
+        {
+            finalInstalls = [];
+        }
+
+        if (metadata.Installs.Count > 0)
+        {
+            finalInstalls.AddRange(metadata.Installs);
+        }
+        return finalInstalls;
+    }
+
+    /// <summary>
+    /// Implements <c>--emit-installs</c>: extracts installer metadata (including
+    /// the MSI bill-of-materials walk) and writes the auto-generated installs
+    /// array as YAML to stdout without importing anything. Status messages go to
+    /// stderr so stdout stays machine-parseable — autopkg's CimianInfoCreator
+    /// consumes this instead of reimplementing the generation logic.
+    /// </summary>
+    public bool EmitInstalls(string packagePath, ImportConfiguration config, List<string> installsPaths)
+    {
+        var prompter = new NoInteractivePrompter(Console.Error);
+        if (!File.Exists(packagePath))
+        {
+            prompter.ReportError($"Package '{packagePath}' does not exist");
+            return false;
+        }
+
+        var metadata = _metadataExtractor.ExtractMetadata(packagePath, config);
+        if (string.IsNullOrEmpty(metadata.ID))
+        {
+            metadata.ID = Path.GetFileNameWithoutExtension(packagePath);
+        }
+
+        var sanitizedName = MetadataExtractor.SanitizeName(metadata.ID);
+        var installs = BuildFinalInstallsArray(metadata, sanitizedName, metadata.Version, installsPaths, prompter);
+
+        var doc = new Dictionary<string, List<InstallItem>> { ["installs"] = installs };
+        Console.Write(YamlUtils.Serializer.Serialize(doc));
+        return true;
     }
 
     /// <summary>

--- a/shared/import/Services/MetadataExtractor.cs
+++ b/shared/import/Services/MetadataExtractor.cs
@@ -226,8 +226,22 @@ public partial class MetadataExtractor
             // to not emit a check we can't make pass than to ship an install
             // loop. Files with version metadata get the full file-version check;
             // unversioned binaries fall back to ARP-only verification.
-            foreach (var f in exes.Where(f => !string.IsNullOrWhiteSpace(f.Version))
-                                  .Take(ThirdPartyFileCheckCap))
+            var versionedExes = exes.Where(f => !string.IsNullOrWhiteSpace(f.Version)).ToList();
+
+            if (versionedExes.Count == 0)
+            {
+                // Wrapper MSI (e.g. Mozilla Firefox): the File table carries no
+                // payload — the real installer is an embedded binary run by a
+                // custom action, so there is nothing to emit type=file checks
+                // from, and the product may not keep its Windows Installer
+                // registration (the in-app updater maintains a plain ARP entry
+                // instead). Emit an ARP DisplayName hint so the runtime can fall
+                // back to an Uninstall-hive lookup when the codes miss.
+                metadata.ArpDisplayName = DeriveArpDisplayName(metadata.Title);
+                return;
+            }
+
+            foreach (var f in versionedExes.Take(ThirdPartyFileCheckCap))
             {
                 metadata.Installs.Add(new InstallItem
                 {
@@ -241,6 +255,30 @@ public partial class MetadataExtractor
         {
             // BOM read failure is non-fatal; ProductCode/UpgradeCode-only verification stands.
         }
+    }
+
+    /// <summary>
+    /// Derives an ARP DisplayName hint from an MSI ProductName by truncating at
+    /// the first version-shaped token. ProductNames of wrapper MSIs embed the
+    /// version and locale ("Mozilla Firefox 151.0.4 x64 en-US"), while the ARP
+    /// entry the product actually maintains carries a stable prefix
+    /// ("Mozilla Firefox (x64 en-US)") — the runtime's DisplayName lookup
+    /// matches on substring, so the prefix is the reliable part.
+    /// </summary>
+    public static string DeriveArpDisplayName(string productName)
+    {
+        if (string.IsNullOrWhiteSpace(productName))
+            return "";
+
+        var kept = new List<string>();
+        foreach (var token in productName.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (System.Text.RegularExpressions.Regex.IsMatch(token, @"^v?\d+(\.\d+)+$"))
+                break;
+            kept.Add(token);
+        }
+
+        return kept.Count > 0 ? string.Join(' ', kept) : productName.Trim();
     }
 
     /// <summary>

--- a/shared/import/Services/NoInteractivePrompter.cs
+++ b/shared/import/Services/NoInteractivePrompter.cs
@@ -11,6 +11,18 @@ namespace Cimian.CLI.Cimiimport.Services;
 /// </summary>
 public sealed class NoInteractivePrompter : IImportPrompter
 {
+    private readonly TextWriter _status;
+
+    /// <summary>
+    /// Status messages go to <paramref name="statusWriter"/> (default stdout).
+    /// --emit-installs passes <see cref="Console.Error"/> so stdout carries
+    /// only the machine-parseable YAML.
+    /// </summary>
+    public NoInteractivePrompter(TextWriter? statusWriter = null)
+    {
+        _status = statusWriter ?? Console.Out;
+    }
+
     /// <summary>Auto-apply template when one exists (prior CLI behaviour).</summary>
     public Task<bool> AskUseTemplateAsync(PkgsInfo existingPkg, CancellationToken cancellationToken = default)
         => Task.FromResult(true);
@@ -37,9 +49,9 @@ public sealed class NoInteractivePrompter : IImportPrompter
     public Task<bool> ConfirmImportAsync(PkgsInfo finalPkginfo, CancellationToken cancellationToken = default)
         => Task.FromResult(true);
 
-    public void ReportInfo(string message) => Console.WriteLine(message);
+    public void ReportInfo(string message) => _status.WriteLine(message);
 
-    public void ReportWarning(string message) => Console.WriteLine($"[WARN] {message}");
+    public void ReportWarning(string message) => _status.WriteLine($"[WARN] {message}");
 
-    public void ReportError(string message) => Console.WriteLine($"[ERROR] {message}");
+    public void ReportError(string message) => _status.WriteLine($"[ERROR] {message}");
 }

--- a/tests/CLI/Cimiimport/MetadataExtractorTests.cs
+++ b/tests/CLI/Cimiimport/MetadataExtractorTests.cs
@@ -434,7 +434,7 @@ public class MetadataExtractorTests
             }
             
             var metadata = _extractor.ExtractMetadata(pkgPath, _config);
-            
+
             // The filename contains "arm64", so that should take priority over the x64 in build-info.yaml
             Assert.Equal("arm64", metadata.Architecture);
             Assert.Contains("arm64", metadata.SupportedArch);
@@ -446,6 +446,29 @@ public class MetadataExtractorTests
                 Directory.Delete(tempDir, true);
             }
         }
+    }
+
+    // ─── DeriveArpDisplayName: wrapper-MSI ARP hint derivation ──────────────
+
+    [Theory]
+    [InlineData("Mozilla Firefox 151.0.4 x64 en-US", "Mozilla Firefox")]
+    [InlineData("Mozilla Firefox ESR 140.3.1 x64 en-US", "Mozilla Firefox ESR")]
+    [InlineData("Some Tool v2.1.0 Setup", "Some Tool")]
+    [InlineData("PlainName", "PlainName")]
+    [InlineData("App 2024", "App 2024")] // bare year is not version-shaped (needs a dot)
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    public void DeriveArpDisplayName_StripsVersionAndTrailingTokens(string productName, string expected)
+    {
+        Assert.Equal(expected, MetadataExtractor.DeriveArpDisplayName(productName));
+    }
+
+    [Fact]
+    public void DeriveArpDisplayName_LeadingVersionToken_FallsBackToFullName()
+    {
+        // Degenerate ProductName starting with a version token: truncating would
+        // yield an empty hint, so the full name passes through instead.
+        Assert.Equal("7.1.2 Oddball", MetadataExtractor.DeriveArpDisplayName("7.1.2 Oddball"));
     }
 
     [Fact]


### PR DESCRIPTION
## What

1. `cimiimport --emit-installs <pkg>`: prints the auto-generated `installs` array as YAML to stdout (status messages to stderr) without touching the repo. Lets autopkg processors reuse cimiimport's canonical installs generation (MSI identity entry + BOM-derived file checks) instead of reimplementing it.

2. Wrapper-MSI handling: MSIs whose File table carries no payload (the real installer is an embedded binary run by a custom action, e.g. Mozilla Firefox) get a `display_name` hint on their `type: msi` installs entry, derived from ProductName with version/locale tokens stripped. managedsoftwareupdate falls back to an ARP DisplayName lookup in both status detection and post-install verification when the declared ProductCode/UpgradeCode miss. Opt-in per entry, so codes stay authoritative for normal MSIs.

## Why

Wrapper MSIs may not keep their Windows Installer registration (in-app updaters maintain a plain ARP entry), so ProductCode-based verification fails forever and the client reinstalls on every run.

## Testing

- 751/752 tests pass (the one failure is pre-existing on main, environment-dependent ScriptService stderr-marker test).
- New unit tests for the display-name derivation heuristic.
- Verified against the Firefox enterprise MSI: emits `display_name: Mozilla Firefox` alongside the codes; normal MSIs unchanged.