### PR TITLE
Address review feedback on emit-installs wrapper-MSI handling

### DIFF
--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -1787,11 +1787,13 @@ exit 0
 
     /// <summary>
     /// Looks up a DisplayVersion by ARP DisplayName in the Uninstall registry
-    /// (64-bit and 32-bit views). Exact match first, then substring in either
-    /// direction — wrapper MSIs register names like "Mozilla Firefox (x64
-    /// en-US)" while the pkginfo hint carries the stable prefix. Mirrors
-    /// StatusService.FindVersionByDisplayName so detection and post-install
-    /// verification agree on what counts as installed.
+    /// (64-bit and 32-bit views). Exact match first, then one-way substring:
+    /// only registry names that CONTAIN the hint count — wrapper MSIs register
+    /// names like "Mozilla Firefox (x64 en-US)" while the pkginfo hint carries
+    /// the stable prefix. The reverse direction (hint contains registry name)
+    /// is unsafe: a long hint would collapse onto an unrelated short product
+    /// name. Mirrors StatusService.FindVersionByDisplayName so detection and
+    /// post-install verification agree on what counts as installed.
     /// </summary>
     private static string? FindArpVersionByDisplayName(string displayName)
     {
@@ -1819,8 +1821,7 @@ exit 0
                         return regVersion;
 
                     if (substringHit == null
-                        && (regDisplayName.Contains(displayName, StringComparison.OrdinalIgnoreCase)
-                            || displayName.Contains(regDisplayName, StringComparison.OrdinalIgnoreCase)))
+                        && regDisplayName.Contains(displayName, StringComparison.OrdinalIgnoreCase))
                     {
                         substringHit = regVersion;
                     }

--- a/shared/import/Services/MetadataExtractor.cs
+++ b/shared/import/Services/MetadataExtractor.cs
@@ -230,14 +230,24 @@ public partial class MetadataExtractor
 
             if (versionedExes.Count == 0)
             {
-                // Wrapper MSI (e.g. Mozilla Firefox): the File table carries no
-                // payload — the real installer is an embedded binary run by a
-                // custom action, so there is nothing to emit type=file checks
-                // from, and the product may not keep its Windows Installer
+                // Wrapper MSI (e.g. Mozilla Firefox): the File table is EMPTY —
+                // the real installer is an embedded binary run by a custom
+                // action, so there is nothing to emit type=file checks from,
+                // and the product may not keep its Windows Installer
                 // registration (the in-app updater maintains a plain ARP entry
                 // instead). Emit an ARP DisplayName hint so the runtime can fall
                 // back to an Uninstall-hive lookup when the codes miss.
-                metadata.ArpDisplayName = DeriveArpDisplayName(metadata.Title);
+                //
+                // Gate strictly on the File table being empty: an MSI that DOES
+                // lay down payload (just nothing versioned, or no .exe at all)
+                // is not a wrapper — it keeps its registration, the codes are
+                // sufficient, and a fuzzy ARP fallback would only mask a
+                // genuinely missing install. Those get no file checks and no
+                // display_name.
+                if (!MsiBomReader.HasInstalledFiles(db))
+                {
+                    metadata.ArpDisplayName = DeriveArpDisplayName(metadata.Title);
+                }
                 return;
             }
 

--- a/shared/import/Services/MsiBomReader.cs
+++ b/shared/import/Services/MsiBomReader.cs
@@ -71,6 +71,27 @@ public static class MsiBomReader
     }
 
     /// <summary>
+    /// True when the MSI's File table has at least one row. Wrapper MSIs
+    /// (payload embedded in the Binary table, installed by a custom action)
+    /// have an empty File table. Fails soft to true on read errors so an
+    /// unreadable MSI is never misclassified as a wrapper.
+    /// </summary>
+    public static bool HasInstalledFiles(Database db)
+    {
+        try
+        {
+            using var view = db.OpenView("SELECT `File` FROM `File`");
+            view.Execute();
+            using var record = view.Fetch();
+            return record != null;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Enumerates files installed by the MSI whose extension matches one of
     /// <paramref name="extensions"/> (default: <c>.exe</c>). Returns absolute
     /// target paths sorted by FileSize descending — callers can take the top


### PR DESCRIPTION
Follow-up to #55, addressing the code review comments:

1. Wrapper-MSI detection now requires the File table to actually be empty (new `MsiBomReader.HasInstalledFiles`). An MSI that lays down payload with no versioned exes is not a wrapper — it keeps its Windows Installer registration, so it gets no `display_name` hint and no fuzzy ARP fallback.
2. `FindArpVersionByDisplayName` substring matching is now one-way only (registry name contains the hint), matching `StatusService.FindVersionByDisplayName` — the reverse direction could collapse a long hint onto an unrelated short product name.
3. XML doc updated to describe the one-way semantics.

Verified: Firefox enterprise MSI (File table genuinely empty) still emits `display_name: Mozilla Firefox`; 156 affected tests pass.