### PR TITLE
MSC improvements: per-row stages, removal UX, failure surfacing (WIP)

### DIFF
--- a/cli/cimiwatcher/Services/FileWatcherService.cs
+++ b/cli/cimiwatcher/Services/FileWatcherService.cs
@@ -24,6 +24,13 @@ public class FileWatcherService : BackgroundService
     private DateTime _lastSeenHeadless = DateTime.MinValue;
     private bool _isPaused;
 
+    // 1 while a triggered managedsoftwareupdate process is running. New flag
+    // files are NOT consumed during that window — managedsoftwareupdate holds
+    // an instance lock, so a second launch would just exit with code 1. The
+    // flag stays on disk (MSC keeps merging additional --item requests into
+    // it) and is consumed on the first poll after the current run exits.
+    private int _updateRunning;
+
     public FileWatcherService(ILogger<FileWatcherService> logger)
     {
         _logger = logger;
@@ -92,11 +99,22 @@ public class FileWatcherService : BackgroundService
             // Check if this is a new file or if it was modified since last seen
             if (lastSeen == DateTime.MinValue || modTime > lastSeen)
             {
+                // Serialize runs: claim the slot before consuming. If a run is
+                // active, leave the flag file untouched (and lastSeen unchanged)
+                // so this poll re-fires once the current run completes.
+                if (Interlocked.CompareExchange(ref _updateRunning, 1, 0) != 0)
+                {
+                    _logger.LogDebug(
+                        "{UpdateType} flag file detected but an update is already running - deferring consumption",
+                        updateType);
+                    return;
+                }
+
                 _logger.LogInformation("{UpdateType} flag file detected - triggering update", updateType);
                 lastSeen = modTime;
-                
+
                 // Trigger update in background
-                _ = Task.Run(() => TriggerBootstrapUpdateAsync(flagFile, updateType, withGUI, cancellationToken), 
+                _ = Task.Run(() => TriggerBootstrapUpdateAsync(flagFile, updateType, withGUI, cancellationToken),
                     cancellationToken);
             }
         }
@@ -106,7 +124,22 @@ public class FileWatcherService : BackgroundService
         }
     }
 
-    private async Task TriggerBootstrapUpdateAsync(string flagFile, string updateType, bool withGUI, 
+    private async Task TriggerBootstrapUpdateAsync(string flagFile, string updateType, bool withGUI,
+        CancellationToken cancellationToken)
+    {
+        // The caller claimed _updateRunning; release it on every exit path so
+        // the next poll can consume a queued flag file.
+        try
+        {
+            await RunBootstrapUpdateAsync(flagFile, updateType, withGUI, cancellationToken);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _updateRunning, 0);
+        }
+    }
+
+    private async Task RunBootstrapUpdateAsync(string flagFile, string updateType, bool withGUI,
         CancellationToken cancellationToken)
     {
         lock (_lock)

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -422,6 +422,13 @@ public class CatalogItem
     public bool IsUninstallable() => Uninstallable && (
         Uninstaller.Count > 0
         || Check.Registry.Name != null
+        // exe-based app installers (NSIS, Inno, etc.) register their own
+        // uninstaller in the Windows uninstall registry, so the engine can remove
+        // them via that UninstallString without an explicit uninstaller block.
+        // This is the removal *mechanism* — orthogonal to unattended_uninstall,
+        // which only governs whether removal may run silently in the background.
+        // An admin opts a package out of removal entirely with `uninstallable: false`.
+        || string.Equals(Installer?.Type, "exe", StringComparison.OrdinalIgnoreCase)
         // Self-uninstallable MSI (canonical): installs[] entry of type=msi with a
         // ProductCode. EffectiveType() handles both explicit type=msi and typeless
         // entries that carry product_code/upgrade_code so a hand-written pkginfo

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -298,6 +298,14 @@ public class ManifestItem
     public string Version { get; set; } = string.Empty;
     public string Action { get; set; } = string.Empty; // install, update, uninstall, profile, app, optional
     public string SourceManifest { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True when this item came from a manifest's optional_installs and the user's
+    /// self-serve request changed its Action (install or uninstall). Optional items
+    /// stay visible in the software list for their whole lifecycle — this flag lets
+    /// InstallInfo keep the optional record alongside the pending action record.
+    /// </summary>
+    public bool PromotedFromOptional { get; set; }
     public string InstallerLocation { get; set; } = string.Empty;
     public List<string> SupportedArch { get; set; } = new();
     public List<string> ManagedInstalls { get; set; } = new();

--- a/cli/managedsoftwareupdate/Program.cs
+++ b/cli/managedsoftwareupdate/Program.cs
@@ -231,6 +231,7 @@ public class Program
                 skipPreflight: options.NoPreflight,
                 skipPostflight: options.NoPostflight,
                 showStatus: options.ShowStatus,
+                statusPort: options.StatusPort,
                 itemFilter: options.Items);
 
             return result;
@@ -1136,6 +1137,10 @@ public class Options
 
     [Option("show-status", Required = false, HelpText = "Show status window during operations")]
     public bool ShowStatus { get; set; }
+
+    [Option("status-port", Required = false, Default = 19847,
+        HelpText = "TCP port of the GUI status listener (default 19847 = login window). Managed Software Center passes its own port so the two listeners never collide.")]
+    public int StatusPort { get; set; } = 19847;
 
     // Verbosity options (note: -v, -vv, -vvv handled by preprocessing)
     // Keep the Option for help text purposes but it won't be used for parsing

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -1528,11 +1528,11 @@ try {{
         var target = !string.IsNullOrEmpty(item.DisplayName) ? item.DisplayName : item.Name;
         if (string.IsNullOrEmpty(target)) return null;
 
-        var bases = new[]
-        {
-            RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64),
-            RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
-        };
+        // `using` so the base-key handles are released on every exit path; left
+        // open these leak unmanaged registry handles across repeated removals.
+        using var base64 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        using var base32 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
+        var bases = new[] { base64, base32 };
         const string uninstallPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
 
         // Two passes: exact display-name match first, then contains.

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -757,6 +757,18 @@ public class InstallerService
                     };
                     result = await UninstallMsixAsync(item, synthetic, cancellationToken);
                 }
+                // Last resort for exe/NSIS/Inno apps that carry no explicit
+                // uninstaller block, product_code, or msix identity: drive the app's
+                // own uninstaller via the standard Windows uninstall registry entry.
+                // This is what makes an installed optional app (e.g. an NSIS-packaged
+                // player) removable without per-package uninstall metadata. Note this
+                // is gated on the installer *type*, not unattended_uninstall — a
+                // user-initiated Remove must work even for packages that opt out of
+                // silent background removal.
+                else if (string.Equals(item.Installer?.Type, "exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    result = await UninstallViaRegistryAsync(item, cancellationToken);
+                }
             }
         }
 
@@ -1366,7 +1378,22 @@ try {{
             CreateNoWindow = true
         };
 
-        return await RunProcessWithTimeoutAsync(startInfo, "uninstall", cancellationToken);
+        var result = await RunProcessWithTimeoutAsync(startInfo, "uninstall", cancellationToken);
+
+        // An uninstall whose product is already gone is a success, not a failure.
+        // msiexec returns 1605 (ERROR_UNKNOWN_PRODUCT) or 1614 (ERROR_PRODUCT_UNINSTALLED)
+        // when the ProductCode isn't installed — exactly the end state we want. Without
+        // this, a removal of an already-absent product (e.g. a Cimian-managed item the
+        // user uninstalled by hand) fails forever and stays stuck in Pending Removals.
+        if (!result.Success
+            && TryExtractMsiExitCode(result.Output, out var code)
+            && (code == 1605 || code == 1614))
+        {
+            ConsoleLogger.Info($"MSI product already absent (msiexec exit {code}) — treating uninstall as success");
+            return (true, $"Product already not installed (msiexec exit {code})");
+        }
+
+        return result;
     }
 
     private async Task<(bool Success, string Output)> UninstallExeAsync(
@@ -1401,6 +1428,192 @@ try {{
         }
 
         return await _scriptService.ExecuteScriptAsync(uninstaller.Command, cancellationToken);
+    }
+
+    /// <summary>
+    /// Removes an app that has no explicit uninstaller metadata by driving the
+    /// uninstaller the app itself registered in the Windows uninstall registry.
+    /// Prefers QuietUninstallString (already silent); otherwise runs UninstallString
+    /// and appends silent switches inferred from the uninstaller engine (NSIS "/S",
+    /// Inno "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART") or the pkginfo's uninstaller
+    /// switches when present. Reached for exe-type installers (see UninstallAsync) --
+    /// keyed on the install mechanism, not unattended_uninstall: a user-initiated
+    /// Remove must work even for packages that opt out of silent background removal.
+    /// </summary>
+    private async Task<(bool Success, string Output)> UninstallViaRegistryAsync(
+        CatalogItem item,
+        CancellationToken cancellationToken)
+    {
+        var resolved = ResolveRegistryUninstall(item);
+        if (resolved == null)
+        {
+            return (false,
+                $"No uninstall information found in the Windows registry for {item.Name}. " +
+                "Add an uninstaller block or uninstall_script to the package.");
+        }
+
+        var (command, isQuiet) = resolved.Value;
+        var (exe, embeddedArgs) = SplitCommandLine(command);
+        if (string.IsNullOrWhiteSpace(exe))
+        {
+            return (false, $"Unparseable uninstall command for {item.Name}: {command}");
+        }
+
+        // msiexec entries can slip through here when the product wasn't matched by
+        // product_code earlier; normalise to a silent removal.
+        if (Path.GetFileNameWithoutExtension(exe).Equals("msiexec", StringComparison.OrdinalIgnoreCase))
+        {
+            embeddedArgs = embeddedArgs.Replace("/I", "/X", StringComparison.OrdinalIgnoreCase);
+            if (!embeddedArgs.Contains("/qn", StringComparison.OrdinalIgnoreCase)) embeddedArgs += " /qn";
+            if (!embeddedArgs.Contains("/norestart", StringComparison.OrdinalIgnoreCase)) embeddedArgs += " /norestart";
+            isQuiet = true;
+        }
+
+        var args = new List<string>();
+        if (!string.IsNullOrWhiteSpace(embeddedArgs)) args.Add(embeddedArgs.Trim());
+
+        if (!isQuiet)
+        {
+            if (item.Uninstaller.Count > 0 && item.Uninstaller[0].Switches.Count > 0)
+            {
+                args.Add(string.Join(" ", item.Uninstaller[0].GetAllArgs()));
+            }
+            else
+            {
+                args.Add(InferRegistrySilentSwitch(exe));
+            }
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = exe,
+            Arguments = string.Join(" ", args).Trim(),
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        ConsoleLogger.Info($"Removing {item.Name} via registry uninstaller: {exe} {startInfo.Arguments}".TrimEnd());
+        _sessionLogger?.Log("INFO", $"Uninstalling {item.Name} via registry UninstallString");
+        return await RunProcessWithTimeoutAsync(startInfo, "uninstall", cancellationToken);
+    }
+
+    /// <summary>
+    /// Picks the silent switch for an app's own registry uninstaller from its
+    /// executable name. Inno Setup uninstallers are named unins###.exe (the
+    /// literal "unins" followed by digits) and take /VERYSILENT; everything else
+    /// is treated as NSIS and takes /S — the common case for app installers.
+    ///
+    /// The digit check matters: "uninstall.exe" (the typical NSIS name) also
+    /// starts with "unins", so a prefix-only test misclassifies NSIS as Inno and
+    /// hands it /VERYSILENT, which NSIS silently ignores — the app is never
+    /// removed when the uninstaller runs as SYSTEM with no UI to fall back to.
+    /// </summary>
+    internal static string InferRegistrySilentSwitch(string uninstallerExePath)
+    {
+        var name = Path.GetFileNameWithoutExtension(uninstallerExePath ?? string.Empty).ToLowerInvariant();
+        var isInno = name.StartsWith("unins") && name.Length > 5 && char.IsDigit(name[5]);
+        return isInno ? "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART" : "/S";
+    }
+
+    /// <summary>
+    /// Finds the app's Windows uninstall entry by display name (exact, then a
+    /// registry-name-contains match — never the reverse, which would let a short
+    /// name adopt an unrelated app) and returns its uninstall command. Searches
+    /// both 64- and 32-bit views. Returns (command, isQuiet) or null if not found.
+    /// </summary>
+    private (string Command, bool IsQuiet)? ResolveRegistryUninstall(CatalogItem item)
+    {
+        var target = !string.IsNullOrEmpty(item.DisplayName) ? item.DisplayName : item.Name;
+        if (string.IsNullOrEmpty(target)) return null;
+
+        var bases = new[]
+        {
+            RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64),
+            RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
+        };
+        const string uninstallPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
+
+        // Two passes: exact display-name match first, then contains.
+        foreach (var exact in new[] { true, false })
+        {
+            foreach (var baseKey in bases)
+            {
+                try
+                {
+                    using var root = baseKey.OpenSubKey(uninstallPath);
+                    if (root == null) continue;
+
+                    foreach (var subName in root.GetSubKeyNames())
+                    {
+                        using var sub = root.OpenSubKey(subName);
+                        var name = sub?.GetValue("DisplayName")?.ToString();
+                        if (string.IsNullOrEmpty(name)) continue;
+
+                        var match = exact
+                            ? string.Equals(name, target, StringComparison.OrdinalIgnoreCase)
+                            : name.Contains(target, StringComparison.OrdinalIgnoreCase);
+                        if (!match) continue;
+
+                        var quiet = sub!.GetValue("QuietUninstallString")?.ToString();
+                        if (!string.IsNullOrWhiteSpace(quiet))
+                        {
+                            ConsoleLogger.Debug($"Resolved QuietUninstallString for {item.Name} via '{name}'");
+                            return (quiet!, true);
+                        }
+
+                        var uninstallString = sub.GetValue("UninstallString")?.ToString();
+                        if (!string.IsNullOrWhiteSpace(uninstallString))
+                        {
+                            ConsoleLogger.Debug($"Resolved UninstallString for {item.Name} via '{name}'");
+                            return (uninstallString!, false);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ConsoleLogger.Debug($"Registry uninstall search error for {item.Name}: {ex.Message}");
+                }
+            }
+        }
+
+        ConsoleLogger.Debug($"No registry uninstall entry found for {item.Name} (searched display name '{target}')");
+        return null;
+    }
+
+    /// <summary>
+    /// Splits a registry uninstall command into its executable path and the
+    /// remaining argument string. Handles a quoted exe ("C:\..\unins000.exe" /X)
+    /// and the bare form (C:\..\uninstall.exe).
+    /// </summary>
+    private static (string Exe, string Args) SplitCommandLine(string command)
+    {
+        command = command.Trim();
+        if (command.StartsWith("\""))
+        {
+            var end = command.IndexOf('"', 1);
+            if (end > 0)
+            {
+                var exe = command.Substring(1, end - 1);
+                var rest = command.Length > end + 1 ? command.Substring(end + 1).Trim() : string.Empty;
+                return (exe, rest);
+            }
+            return (command.Trim('"'), string.Empty);
+        }
+
+        // Unquoted: an .exe path may contain spaces, so split at the first token
+        // boundary that follows the ".exe" extension rather than the first space.
+        var idx = command.IndexOf(".exe", StringComparison.OrdinalIgnoreCase);
+        if (idx >= 0)
+        {
+            var cut = idx + 4;
+            var exe = command.Substring(0, cut);
+            var rest = command.Length > cut ? command.Substring(cut).Trim() : string.Empty;
+            return (exe, rest);
+        }
+
+        return (command, string.Empty);
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -587,6 +587,7 @@ public class ManifestService
             else if (string.Equals(existing.Action, "optional", StringComparison.OrdinalIgnoreCase))
             {
                 existing.Action = "install";
+                existing.PromotedFromOptional = true;
                 SetItemSource(name, selfServeSource, "managed_installs");
                 ConsoleLogger.Debug($"SelfServe: promoted optional to install item: {name} originalSource: {existing.SourceManifest}");
             }
@@ -614,6 +615,7 @@ public class ManifestService
             {
                 // Optional item — user is the only authority, so honor the removal request.
                 existing.Action = "uninstall";
+                existing.PromotedFromOptional = true;
                 SetItemSource(name, selfServeSource, "managed_uninstalls");
                 ConsoleLogger.Debug($"SelfServe: flipped optional to uninstall item: {name} originalSource: {existing.SourceManifest}");
             }

--- a/cli/managedsoftwareupdate/Services/ScriptService.cs
+++ b/cli/managedsoftwareupdate/Services/ScriptService.cs
@@ -23,14 +23,29 @@ public class ScriptService
     //   CIMIAN-WARNING: <message>
     // on stdout or stderr. The runner extracts the message into ScriptResult.WarningMessage,
     // which higher layers map to ItemRecord.currentStatus = "Warning" with last_warning set.
+    // The marker is matched anywhere on a line (not just at line-start): PowerShell
+    // prefixes Write-Error output when it renders to stderr, so a start-anchored
+    // pattern would never catch a marker emitted via stderr. Windows PowerShell's
+    // NormalView even echoes the offending command, putting the marker on the line
+    // twice ("Write-Error 'CIMIAN-WARNING: x' : CIMIAN-WARNING: x"); the leading
+    // greedy ".*" walks to the LAST occurrence on the line so we capture the
+    // rendered message, not the echoed source.
     private static readonly Regex CimianWarningMarker = new(
-        @"^\s*CIMIAN-WARNING:\s*(.+?)\s*$",
+        @".*CIMIAN-WARNING:\s*(.+?)\s*$",
         RegexOptions.Compiled | RegexOptions.Multiline);
+
+    // pwsh 7 colorizes Write-Error output with ANSI escape sequences even when
+    // stderr is redirected, so the marker arrives wrapped (e.g.
+    // "<ESC>[31;1mWrite-Error: <ESC>[31;1mCIMIAN-WARNING: reason<ESC>[0m").
+    // Strip those before matching so the captured message is clean.
+    private static readonly Regex AnsiEscape = new(
+        @"\x1B\[[0-9;]*[A-Za-z]", RegexOptions.Compiled);
 
     private static string? ExtractWarningMarker(string output)
     {
         if (string.IsNullOrEmpty(output)) return null;
-        var match = CimianWarningMarker.Match(output);
+        var clean = AnsiEscape.Replace(output, string.Empty);
+        var match = CimianWarningMarker.Match(clean);
         return match.Success ? match.Groups[1].Value.Trim() : null;
     }
 

--- a/cli/managedsoftwareupdate/Services/StatusReporter.cs
+++ b/cli/managedsoftwareupdate/Services/StatusReporter.cs
@@ -28,6 +28,15 @@ public class StatusReporter : IDisposable
     private bool _disposed;
     private bool _connected;
     private readonly int _verbosity;
+    private Task? _commandReadTask;
+    private CancellationTokenSource? _commandReadCts;
+
+    /// <summary>
+    /// Raised when the GUI sends a stop command over the status connection.
+    /// The engine links this to its cancellation token so the user's Cancel
+    /// button gracefully aborts between items.
+    /// </summary>
+    public event Action? StopRequested;
 
     /// <summary>
     /// Creates a new StatusReporter that will connect to the GUI on first message
@@ -74,6 +83,10 @@ public class StatusReporter : IDisposable
                     _stream = _client.GetStream();
                     _writer = new StreamWriter(_stream, Encoding.UTF8) { AutoFlush = true };
                     _connected = true;
+
+                    // The TCP stream is duplex: listen for commands (stop) from
+                    // the GUI without blocking the write path.
+                    StartCommandReader();
 
                     if (_verbosity >= 2)
                     {
@@ -146,6 +159,57 @@ public class StatusReporter : IDisposable
             Data = text,
             Error = true
         });
+    }
+
+    /// <summary>
+    /// Report a per-item lifecycle stage so the GUI can render live status on
+    /// each row: pending, downloading, downloaded, installing, installed,
+    /// removing, removed, failed.
+    /// </summary>
+    public void ItemStatus(string itemName, string stage)
+    {
+        SendMessage(new StatusMessage
+        {
+            Type = "itemStatus",
+            Item = itemName,
+            Data = stage
+        });
+    }
+
+    private void StartCommandReader()
+    {
+        if (_commandReadTask is { IsCompleted: false }) return;
+
+        _commandReadCts = new CancellationTokenSource();
+        var token = _commandReadCts.Token;
+        var stream = _stream;
+        if (stream == null) return;
+
+        _commandReadTask = Task.Run(async () =>
+        {
+            try
+            {
+                using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
+                while (!token.IsCancellationRequested)
+                {
+                    var line = await reader.ReadLineAsync(token).ConfigureAwait(false);
+                    if (line == null) break; // GUI disconnected
+
+                    if (line.Contains("\"stop\"", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (_verbosity >= 1)
+                        {
+                            ConsoleLogger.Info("Stop requested from GUI");
+                        }
+                        StopRequested?.Invoke();
+                    }
+                }
+            }
+            catch
+            {
+                // Reader dies with the connection; writes detect that separately.
+            }
+        }, token);
     }
 
     /// <summary>
@@ -228,6 +292,9 @@ public class StatusReporter : IDisposable
             try { Quit(); } catch { }
         }
 
+        _commandReadCts?.Cancel();
+        _commandReadCts?.Dispose();
+
         lock (_lock)
         {
             CleanupConnection();
@@ -248,6 +315,10 @@ internal class StatusMessage
     [JsonPropertyName("data")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Data { get; set; }
+
+    [JsonPropertyName("item")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Item { get; set; }
 
     [JsonPropertyName("percent")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/cli/managedsoftwareupdate/Services/StatusReporter.cs
+++ b/cli/managedsoftwareupdate/Services/StatusReporter.cs
@@ -16,7 +16,7 @@ namespace Cimian.CLI.managedsoftwareupdate.Services;
 /// </summary>
 public class StatusReporter : IDisposable
 {
-    private const int DefaultPort = 19847;
+    public const int DefaultPort = 19847;
     private const string DefaultHost = "127.0.0.1";
     private const int ConnectionTimeoutMs = 2000;
     private const int MaxRetries = 10;
@@ -28,6 +28,7 @@ public class StatusReporter : IDisposable
     private bool _disposed;
     private bool _connected;
     private readonly int _verbosity;
+    private readonly int _port;
     private Task? _commandReadTask;
     private CancellationTokenSource? _commandReadCts;
 
@@ -42,9 +43,17 @@ public class StatusReporter : IDisposable
     /// Creates a new StatusReporter that will connect to the GUI on first message
     /// </summary>
     /// <param name="verbosity">Verbosity level for console output</param>
-    public StatusReporter(int verbosity = 0)
+    /// <param name="port">
+    /// TCP port of the GUI status listener. Defaults to 19847 (the login-window
+    /// CimianStatus listener). Managed Software Center runs its own listener on a
+    /// separate port and passes it via --status-port so the two never collide —
+    /// e.g. when a locked machine has the login window up while a user session's
+    /// MSC is also running.
+    /// </param>
+    public StatusReporter(int verbosity = 0, int port = DefaultPort)
     {
         _verbosity = verbosity;
+        _port = port;
     }
 
     /// <summary>
@@ -71,7 +80,7 @@ public class StatusReporter : IDisposable
                     _client = new TcpClient();
                     
                     // Try to connect with timeout
-                    var connectTask = _client.ConnectAsync(DefaultHost, DefaultPort);
+                    var connectTask = _client.ConnectAsync(DefaultHost, _port);
                     if (!connectTask.Wait(ConnectionTimeoutMs))
                     {
                         _client.Dispose();
@@ -90,7 +99,7 @@ public class StatusReporter : IDisposable
 
                     if (_verbosity >= 2)
                     {
-                        ConsoleLogger.Debug($"Connected to GUI status server on port {DefaultPort}");
+                        ConsoleLogger.Debug($"Connected to GUI status server on port {_port}");
                     }
 
                     return true;

--- a/cli/managedsoftwareupdate/Services/StatusReporter.cs
+++ b/cli/managedsoftwareupdate/Services/StatusReporter.cs
@@ -164,15 +164,18 @@ public class StatusReporter : IDisposable
     /// <summary>
     /// Report a per-item lifecycle stage so the GUI can render live status on
     /// each row: pending, downloading, downloaded, installing, installed,
-    /// removing, removed, failed.
+    /// removing, removed, failed. For the "failed" stage, <paramref name="detail"/>
+    /// carries the failure reason (e.g. "Exit code 1603") so the GUI can surface
+    /// the exact code to the user.
     /// </summary>
-    public void ItemStatus(string itemName, string stage)
+    public void ItemStatus(string itemName, string stage, string? detail = null)
     {
         SendMessage(new StatusMessage
         {
             Type = "itemStatus",
             Item = itemName,
-            Data = stage
+            Data = stage,
+            Message = detail
         });
     }
 
@@ -315,6 +318,10 @@ internal class StatusMessage
     [JsonPropertyName("data")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Data { get; set; }
+
+    [JsonPropertyName("message")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Message { get; set; }
 
     [JsonPropertyName("item")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -2630,12 +2630,17 @@ public class UpdateEngine : IDisposable
                             ? _statusService.CheckStatus(cat, action, _config.CachePath)
                             : null;
                         var installScheduled = toUpdateNames.Contains(key) || toInstallNames.Contains(key);
-                        var installPending = installScheduled && (installCheck?.NeedsAction ?? true);
+                        var needsAction = installCheck?.NeedsAction ?? installScheduled;
+
+                        // Targeted runs (--item) schedule only the filtered subset, but a
+                        // queued self-serve item outside the filter is still pending — keep
+                        // its record so the Updates list survives partial writes.
+                        var installPending = needsAction && (installScheduled || mi.PromotedFromOptional);
 
                         if (installPending)
                         {
                             // Needs install or update this session — full record on managed_installs.
-                            var isUpdate = toUpdateNames.Contains(key);
+                            var isUpdate = toUpdateNames.Contains(key) || (installCheck?.IsUpdate ?? false);
                             var item = BuildInstallInfoItem(mi.Name, cat);
                             item.Status = isUpdate ? "update-available" : "will-be-installed";
                             item.WillBeInstalled = true;
@@ -2664,7 +2669,9 @@ public class UpdateEngine : IDisposable
                         var removalCheck = cat != null
                             ? _statusService.CheckStatus(cat, "uninstall", _config.CachePath)
                             : null;
-                        var removalPending = toUninstallNames.Contains(key) && (removalCheck?.NeedsAction ?? true);
+                        var removalScheduled = toUninstallNames.Contains(key);
+                        var removalPending = (removalCheck?.NeedsAction ?? removalScheduled)
+                            && (removalScheduled || mi.PromotedFromOptional);
 
                         if (removalPending)
                         {

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -218,6 +218,7 @@ public class UpdateEngine : IDisposable
         bool skipPreflight = false,
         bool skipPostflight = false,
         bool showStatus = false,
+        int statusPort = StatusReporter.DefaultPort,
         IEnumerable<string>? itemFilter = null,
         CancellationToken cancellationToken = default)
     {
@@ -243,7 +244,7 @@ public class UpdateEngine : IDisposable
         // Initialize status reporter if --show-status is set
         if (_showStatus)
         {
-            _statusReporter = new StatusReporter(verbosity);
+            _statusReporter = new StatusReporter(verbosity, statusPort);
             // GUI Cancel button: stop gracefully before the next item.
             _statusReporter.StopRequested += () => _userStop.Cancel();
             _statusReporter.TryConnect();
@@ -430,11 +431,31 @@ public class UpdateEngine : IDisposable
                 toInstall = itemFilterService.FilterCatalogItems(toInstall);
                 toUpdate = itemFilterService.FilterCatalogItems(toUpdate);
                 toUninstall = itemFilterService.FilterCatalogItems(toUninstall);
-                
+
                 // Log if everything was filtered out
                 if (toInstall.Count == 0 && toUpdate.Count == 0 && toUninstall.Count == 0)
                 {
                     ConsoleLogger.Warn("No pending actions match the --item filter");
+                }
+
+                // A self-serve click drives --item: the user explicitly asked for
+                // these item(s). Any that produced no action are already in the
+                // desired state, but with no signal the GUI navigates to Updates and
+                // sits empty ("nothing happened"). Emit a terminal stage per
+                // already-satisfied request so its row shows a confirming check
+                // (Installed/Removed) instead of silence. Intent comes from the
+                // manifest Action the self-serve merge set (install vs uninstall).
+                // No-op without --show-status (no reporter).
+                var actionedNames = new HashSet<string>(
+                    toInstall.Concat(toUpdate).Concat(toUninstall).Select(c => c.Name),
+                    StringComparer.OrdinalIgnoreCase);
+                foreach (var requested in itemFilterService.Items)
+                {
+                    if (actionedNames.Contains(requested)) continue;
+                    var mi = manifestItems.FirstOrDefault(m =>
+                        string.Equals(m.Name, requested, StringComparison.OrdinalIgnoreCase));
+                    var alreadyRemoved = string.Equals(mi?.Action, "uninstall", StringComparison.OrdinalIgnoreCase);
+                    ReportItemStatus(requested, alreadyRemoved ? "removed" : "installed");
                 }
             }
 

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -438,11 +438,22 @@ public class UpdateEngine : IDisposable
                 }
             }
 
+            // Emit an early "pending" stage for every item this session will act on,
+            // so the GUI shows a per-row spinner immediately — through dependency
+            // resolution and downloads — instead of each row looking idle
+            // ("Will be installed") until the install loop finally reaches it. The
+            // per-item pending/downloading/installing/installed stages then update
+            // each row in place. No-op when --show-status is off (no reporter).
+            foreach (var ci in toInstall.Concat(toUpdate))
+                ReportItemStatus(ci.Name, "pending");
+            foreach (var ci in toUninstall)
+                ReportItemStatus(ci.Name, "pending");
+
             // Resolve dependencies and update_for items (Go parity: process.go dependency resolution).
             // Walks both `requires` and `update_for` to the transitive closure so that a stale
             // dep gets surfaced even when its parent is already at the catalog version
             // (e.g. ManageUsersPrefs current, ManageUsers stale).
-            ResolveDependencies(manifestItems, catalogMap, toUpdate);
+            ResolveDependencies(manifestItems, catalogMap, toUpdate, itemFilterService);
 
             // Print hierarchy and tables in checkonly mode (matches Go behavior - always shows this)
             if (_checkOnly)
@@ -743,6 +754,10 @@ public class UpdateEngine : IDisposable
                 _sessionLogger?.Log("INFO", $"Removing {toUninstall.Count} items...");
                 uninstallOutcomes = await PerformUninstallsAsync(toUninstall, cancellationToken);
                 uninstallSuccess = uninstallOutcomes.All(o => o.Success);
+
+                // Consume satisfied self-serve removal requests so they are not
+                // re-queued and shown as pending every run (clean_up_managed_uninstalls).
+                await CleanUpSelfServeUninstallsAsync(uninstallOutcomes);
             }
 
             // Combine install + uninstall outcomes keyed by lower-invariant name so
@@ -789,7 +804,7 @@ public class UpdateEngine : IDisposable
                 CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName, loopSuppressedByName);
 
                 // Write InstallInfo.yaml for MSC GUI (post-install: actions completed)
-                WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
+                WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName.Values);
 
                 EndSessionWithSummary("completed", toInstall.Count, toUpdate.Count, toUninstall.Count,
                     toInstall.Count + toUpdate.Count + toUninstall.Count, 0, manifestItems);
@@ -816,7 +831,7 @@ public class UpdateEngine : IDisposable
                 CollectSessionItems(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName, loopSuppressedByName);
 
                 // Write InstallInfo.yaml for MSC GUI (post-install: reflects final state)
-                WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap);
+                WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName.Values);
 
                 EndSessionWithSummary("partial_failure", toInstall.Count, toUpdate.Count, toUninstall.Count,
                     successCount, failCount, manifestItems);
@@ -883,6 +898,20 @@ public class UpdateEngine : IDisposable
         foreach (var item in manifestItems)
         {
             if (string.IsNullOrEmpty(item.Name)) continue;
+
+            // Go parity: pkg/filter applies the --item filter to manifestItems
+            // BEFORE status checking, so a targeted run only status-checks the
+            // named items (their dependency closure is resolved and checked
+            // separately by ResolveDependencies). Skipping the rest here turns a
+            // self-serve install from a full ~85-item CheckStatus sweep — the
+            // "starting from scratch / taking forever" slowness — into a handful
+            // of checks. Non-targeted managed items default to "Installed" in the
+            // session report (SessionItemStatusResolver), which is what they were.
+            if (itemFilterService?.HasFilter == true
+                && !itemFilterService.Items.Contains(item.Name))
+            {
+                continue;
+            }
 
             var key = item.Name.ToLowerInvariant();
             
@@ -1159,7 +1188,8 @@ public class UpdateEngine : IDisposable
     private void ResolveDependencies(
         List<ManifestItem> manifestItems,
         Dictionary<string, CatalogItem> catalogMap,
-        List<CatalogItem> itemsToProcess)
+        List<CatalogItem> itemsToProcess,
+        ItemFilterService? itemFilterService = null)
     {
         LogInfo("Resolving dependencies (requires and update_for)...");
 
@@ -1187,8 +1217,13 @@ public class UpdateEngine : IDisposable
         // Seeds: every manifest item whose intent is install/update. Action comes
         // from manifest intent (managed_installs/managed_updates), not current
         // install state, so up-to-date items are still walked for stale deps.
+        // On a targeted (--item) run, only seed the dependency walk from the
+        // named items. Otherwise ResolveDependencies would rebuild the full
+        // closure from every install/update manifest item and CheckStatus each
+        // one — re-introducing the very sweep the IdentifyActions filter skips.
         var seedNames = manifestItems
             .Where(m => m.Action?.ToLowerInvariant() == "install" || m.Action?.ToLowerInvariant() == "update")
+            .Where(m => itemFilterService?.HasFilter != true || itemFilterService.Items.Contains(m.Name))
             .Select(m => m.Name)
             .ToList();
 
@@ -1387,7 +1422,10 @@ public class UpdateEngine : IDisposable
                 outcomes,
                 cancellationToken);
 
-            ReportItemStatus(item.Name, success ? "installed" : "failed");
+            var failureDetail = success ? null : SummarizeFailure(
+                outcomes.LastOrDefault(o =>
+                    string.Equals(o.Name, item.Name, StringComparison.OrdinalIgnoreCase) && !o.Success)?.ErrorMessage);
+            ReportItemStatus(item.Name, success ? "installed" : "failed", failureDetail);
 
             if (success)
             {
@@ -1803,7 +1841,7 @@ public class UpdateEngine : IDisposable
         ReportItemStatus(item.Name, "removing");
         var (success, output) = await _installerService.UninstallAsync(item, cancellationToken);
         outcomes.Add(new ItemOutcome(item.Name, item.Version, "remove", success, success ? null : output, DateTime.UtcNow));
-        ReportItemStatus(item.Name, success ? "removed" : "failed");
+        ReportItemStatus(item.Name, success ? "removed" : "failed", success ? null : SummarizeFailure(output));
 
         if (success)
         {
@@ -2455,9 +2493,47 @@ public class UpdateEngine : IDisposable
     /// downloaded, installing, installed, removing, removed, failed) so the
     /// Updates list can render live status on each row.
     /// </summary>
-    private void ReportItemStatus(string itemName, string stage)
+    private void ReportItemStatus(string itemName, string stage, string? detail = null)
     {
-        _statusReporter?.ItemStatus(itemName, stage);
+        _statusReporter?.ItemStatus(itemName, stage, detail);
+    }
+
+    /// <summary>
+    /// Condenses an installer's raw failure output into a short, user-readable
+    /// reason for the GUI and problem_items — exit code first, with a plain-English
+    /// gloss for the common MSI codes so users can report a meaningful issue
+    /// instead of "Will be installed" that never changes.
+    /// </summary>
+    private static string? SummarizeFailure(string? rawOutput)
+    {
+        if (string.IsNullOrWhiteSpace(rawOutput)) return null;
+
+        var firstLine = rawOutput
+            .Split('\n')
+            .Select(l => l.Trim())
+            .FirstOrDefault(l => l.Length > 0) ?? rawOutput.Trim();
+
+        var match = System.Text.RegularExpressions.Regex.Match(firstLine, @"-?\d{3,5}");
+        if (match.Success && int.TryParse(match.Value, out var code))
+        {
+            var gloss = code switch
+            {
+                1603 => "fatal error during installation (often a leftover/partial prior install)",
+                1618 => "another installation is already in progress",
+                1619 => "installer package could not be opened",
+                1620 => "installer package could not be opened (invalid)",
+                1622 => "error opening installation log file",
+                1625 => "installation forbidden by system policy",
+                1638 => "another version of this product is already installed",
+                1639 => "invalid command line argument",
+                3010 => "success, but a restart is required",
+                _ => null
+            };
+            return gloss != null ? $"Exit code {code} - {gloss}" : $"Exit code {code}";
+        }
+
+        // No numeric code (script/exe message) — surface a trimmed first line.
+        return firstLine.Length > 200 ? firstLine[..200] + "..." : firstLine;
     }
 
     /// <summary>
@@ -2641,7 +2717,8 @@ public class UpdateEngine : IDisposable
         List<CatalogItem> toInstall,
         List<CatalogItem> toUpdate,
         List<CatalogItem> toUninstall,
-        Dictionary<string, CatalogItem> catalogMap)
+        Dictionary<string, CatalogItem> catalogMap,
+        IReadOnlyCollection<ItemOutcome>? outcomes = null)
     {
         try
         {
@@ -2718,14 +2795,19 @@ public class UpdateEngine : IDisposable
                     case "uninstall":
                         info.ProcessedUninstalls.Add(mi.Name);
 
-                        // Same write-time freshness as installs: an item removed this
-                        // session is no longer a pending removal.
-                        var removalCheck = cat != null
-                            ? _statusService.CheckStatus(cat, "uninstall", _config.CachePath)
-                            : null;
+                        // An item is a pending removal only while it is still installed.
+                        // CheckStatus(install).NeedsAction == false means the item is
+                        // present (same signal BuildOptionalInstallRecord uses for the
+                        // Installed flag). Once the uninstall has actually taken it off
+                        // the system it is no longer pending, and CleanUpSelfServeUninstalls
+                        // (run after the removal phase) drops the managed_uninstalls entry
+                        // so it is not re-queued every run. Keying on real install state
+                        // avoids the inverted reading of an uninstall status check, where
+                        // "not verifiable" (NeedsAction) would read as "still pending".
                         var removalScheduled = toUninstallNames.Contains(key);
-                        var removalPending = (removalCheck?.NeedsAction ?? removalScheduled)
-                            && (removalScheduled || mi.PromotedFromOptional);
+                        var stillInstalled = cat != null
+                            && !_statusService.CheckStatus(cat, "install", _config.CachePath).NeedsAction;
+                        var removalPending = stillInstalled && (removalScheduled || mi.PromotedFromOptional);
 
                         if (removalPending)
                         {
@@ -2772,6 +2854,27 @@ public class UpdateEngine : IDisposable
                 LogInfo($"Featured items: {string.Join(", ", info.FeaturedItems)}");
             }
 
+            // Surface this session's install/uninstall failures as problem_items so
+            // the GUI shows them (with the exit code) until the next successful
+            // attempt — instead of silently reverting to "Will be installed". This
+            // is the durable, user-reportable record of every failure code.
+            if (outcomes != null)
+            {
+                foreach (var o in outcomes.Where(o => !o.Success))
+                {
+                    catalogMap.TryGetValue(o.Name.ToLowerInvariant(), out var pcat);
+                    info.ProblemItems.Add(new InstallInfoProblem
+                    {
+                        Name = o.Name,
+                        DisplayName = pcat?.DisplayName,
+                        Version = string.IsNullOrEmpty(o.Version) ? pcat?.Version : o.Version,
+                        ErrorMessage = SummarizeFailure(o.ErrorMessage)
+                            ?? $"{o.Action} failed",
+                        Note = o.ErrorMessage
+                    });
+                }
+            }
+
             // Serialize and write
             var yaml = YamlUtils.SerializeInstallInfo(info);
             var path = Path.Combine(Path.GetDirectoryName(_config.CachePath) ?? CimianPaths.ManagedInstallsRoot, "InstallInfo.yaml");
@@ -2783,6 +2886,48 @@ public class UpdateEngine : IDisposable
         {
             ConsoleLogger.Warn($"Failed to write InstallInfo.yaml: {ex.Message}");
             _sessionLogger?.Log("WARN", $"Failed to write InstallInfo.yaml: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Consumes self-serve removal requests that have been satisfied: once the
+    /// uninstaller for an item the user asked to remove has succeeded, its name is
+    /// dropped from SelfServeManifest.managed_uninstalls. Without this a completed
+    /// removal is re-queued every run and keeps showing as a pending removal.
+    /// Keyed on the uninstall outcome, not a post-removal status check: NSIS
+    /// uninstallers relaunch themselves from %TEMP% and the launched process exits
+    /// before file deletion finishes, so an immediate "is it still installed?" check
+    /// races the deletion. A failed removal (app still present) is retained and
+    /// retried next run. Mirrors the reference clean_up_managed_uninstalls.
+    /// </summary>
+    private async Task CleanUpSelfServeUninstallsAsync(List<ItemOutcome> uninstallOutcomes)
+    {
+        if (_config.SkipSelfService) return;
+
+        var removed = uninstallOutcomes
+            .Where(o => o.Success)
+            .Select(o => o.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (removed.Count == 0) return;
+
+        try
+        {
+            var svc = new SelfServiceManifestService();
+            var manifest = await svc.LoadAsync();
+            var before = manifest.ManagedUninstalls.Count;
+            manifest.ManagedUninstalls = manifest.ManagedUninstalls
+                .Where(n => !removed.Contains(n))
+                .ToList();
+            var cleared = before - manifest.ManagedUninstalls.Count;
+            if (cleared > 0)
+            {
+                await svc.SaveAsync(manifest);
+                LogInfo($"Self-serve: consumed {cleared} completed removal(s) from SelfServeManifest");
+            }
+        }
+        catch (Exception ex)
+        {
+            ConsoleLogger.Warn($"Self-serve uninstall cleanup failed: {ex.Message}");
         }
     }
 

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -2623,7 +2623,16 @@ public class UpdateEngine : IDisposable
                         if (action == "update")
                             info.ManagedUpdates.Add(mi.Name);
 
-                        if (toUpdateNames.Contains(key) || toInstallNames.Contains(key))
+                        // Re-check status at write time. The toInstall/toUpdate lists were
+                        // computed before the install phase ran, so an item installed this
+                        // session is no longer pending and must not be written as such.
+                        var installCheck = cat != null
+                            ? _statusService.CheckStatus(cat, action, _config.CachePath)
+                            : null;
+                        var installScheduled = toUpdateNames.Contains(key) || toInstallNames.Contains(key);
+                        var installPending = installScheduled && (installCheck?.NeedsAction ?? true);
+
+                        if (installPending)
                         {
                             // Needs install or update this session — full record on managed_installs.
                             var isUpdate = toUpdateNames.Contains(key);
@@ -2631,23 +2640,33 @@ public class UpdateEngine : IDisposable
                             item.Status = isUpdate ? "update-available" : "will-be-installed";
                             item.WillBeInstalled = true;
                             item.NeedsUpdate = isUpdate;
-
-                            if (cat != null)
-                            {
-                                var status = _statusService.CheckStatus(cat, action, _config.CachePath);
-                                item.InstalledVersion = status.InstalledVersion;
-                                item.Installed = !string.IsNullOrEmpty(status.InstalledVersion);
-                            }
-
+                            item.InstalledVersion = installCheck?.InstalledVersion;
+                            item.Installed = !string.IsNullOrEmpty(installCheck?.InstalledVersion);
                             info.ManagedInstalls.Add(item);
                         }
-                        // Else: already installed and up-to-date. No record is written;
-                        // the name on processed_installs is the only trace, matching Munki.
+                        // Else: already installed and up-to-date. No pending record is written;
+                        // the name on processed_installs is the only trace.
+
+                        // A user-requested optional item stays on the optional list for its
+                        // whole lifecycle; its status tracks the pending action.
+                        if (mi.PromotedFromOptional)
+                        {
+                            info.OptionalInstalls.Add(BuildOptionalInstallRecord(
+                                mi.Name, cat, installPending ? "will-be-installed" : null));
+                        }
                         break;
 
                     case "uninstall":
                         info.ProcessedUninstalls.Add(mi.Name);
-                        if (toUninstallNames.Contains(key))
+
+                        // Same write-time freshness as installs: an item removed this
+                        // session is no longer a pending removal.
+                        var removalCheck = cat != null
+                            ? _statusService.CheckStatus(cat, "uninstall", _config.CachePath)
+                            : null;
+                        var removalPending = toUninstallNames.Contains(key) && (removalCheck?.NeedsAction ?? true);
+
+                        if (removalPending)
                         {
                             var item = BuildInstallInfoItem(mi.Name, cat);
                             item.Status = "will-be-removed";
@@ -2655,39 +2674,25 @@ public class UpdateEngine : IDisposable
                             item.Installed = true;
                             info.Removals.Add(item);
                         }
+
+                        // A user-removed optional item stays offered on the optional list.
+                        if (mi.PromotedFromOptional)
+                        {
+                            info.OptionalInstalls.Add(BuildOptionalInstallRecord(
+                                mi.Name, cat, removalPending ? "will-be-removed" : null));
+                        }
                         break;
 
                     case "optional":
                         // Optional installs always appear — with installed/needs_update booleans
-                        var optItem = BuildInstallInfoItem(mi.Name, cat);
-                        if (cat != null)
-                        {
-                            var status = _statusService.CheckStatus(cat, "install", _config.CachePath);
-                            optItem.Installed = !status.NeedsAction;
-                            optItem.InstalledVersion = status.InstalledVersion;
-                            optItem.NeedsUpdate = status.IsUpdate;
-                            optItem.Status = status.NeedsAction
-                                ? (status.IsUpdate ? "update-available" : "not-installed")
-                                : "installed";
-
-                            // Check if installer is precached (already downloaded to local cache)
-                            if (!string.IsNullOrEmpty(cat.Installer?.Location))
-                            {
-                                var cachePath = _downloadService.GetCachePath(cat);
-                                optItem.Precached = File.Exists(cachePath);
-                            }
-                        }
-                        else
-                        {
-                            optItem.Status = "not-installed";
-                        }
-                        info.OptionalInstalls.Add(optItem);
+                        info.OptionalInstalls.Add(BuildOptionalInstallRecord(mi.Name, cat, null));
                         break;
 
                     case "default":
                         // Default installs: treated like managed_installs but only when not already installed.
                         // If already installed, they silently disappear (not re-enforced).
-                        if (toInstallNames.Contains(key))
+                        if (toInstallNames.Contains(key) &&
+                            (cat == null || _statusService.CheckStatus(cat, "install", _config.CachePath).NeedsAction))
                         {
                             var defItem = BuildInstallInfoItem(mi.Name, cat);
                             defItem.Status = "will-be-installed";
@@ -2736,6 +2741,42 @@ public class UpdateEngine : IDisposable
             ForceInstallAfterDate = cat?.ForceInstallAfterDate,
         };
         return item;
+    }
+
+    /// <summary>
+    /// Builds the optional_installs record for an item, with live install status.
+    /// <paramref name="pendingStatus"/> ("will-be-installed" / "will-be-removed")
+    /// overrides the natural status while a user-requested action is pending, so
+    /// the software list reflects the in-flight state instead of a stale snapshot.
+    /// </summary>
+    private InstallInfoItem BuildOptionalInstallRecord(string name, CatalogItem? cat, string? pendingStatus)
+    {
+        var optItem = BuildInstallInfoItem(name, cat);
+        if (cat != null)
+        {
+            var status = _statusService.CheckStatus(cat, "install", _config.CachePath);
+            optItem.Installed = !status.NeedsAction;
+            optItem.InstalledVersion = status.InstalledVersion;
+            optItem.NeedsUpdate = status.IsUpdate;
+            optItem.Status = pendingStatus ?? (status.NeedsAction
+                ? (status.IsUpdate ? "update-available" : "not-installed")
+                : "installed");
+
+            // Check if installer is precached (already downloaded to local cache)
+            if (!string.IsNullOrEmpty(cat.Installer?.Location))
+            {
+                var cachePath = _downloadService.GetCachePath(cat);
+                optItem.Precached = File.Exists(cachePath);
+            }
+        }
+        else
+        {
+            optItem.Status = pendingStatus ?? "not-installed";
+        }
+
+        optItem.WillBeInstalled = pendingStatus == "will-be-installed";
+        optItem.WillBeRemoved = pendingStatus == "will-be-removed";
+        return optItem;
     }
 
     internal static bool IsEligibleForAgentVersion(CatalogItem item, out string reason, out string reasonCode)

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -37,6 +37,10 @@ public class UpdateEngine : IDisposable
     private SessionLogger? _sessionLogger;
     private LoopGuard? _loopGuard;
 
+    // Cancelled when the GUI sends a stop command over the status connection.
+    // Checked between items so a user cancel aborts gracefully, never mid-install.
+    private readonly CancellationTokenSource _userStop = new();
+
     private int _verbosity;
     private bool _isBootstrap;
     private bool _checkOnly;
@@ -240,6 +244,8 @@ public class UpdateEngine : IDisposable
         if (_showStatus)
         {
             _statusReporter = new StatusReporter(verbosity);
+            // GUI Cancel button: stop gracefully before the next item.
+            _statusReporter.StopRequested += () => _userStop.Cancel();
             _statusReporter.TryConnect();
         }
 
@@ -1298,6 +1304,13 @@ public class UpdateEngine : IDisposable
         ReportStatus("Downloading...");
         ReportDetail($"Downloading {items.Count} items...");
         LogInfo($"Downloading {items.Count} items...");
+
+        // Seed every row in the GUI before work starts.
+        foreach (var item in items)
+        {
+            ReportItemStatus(item.Name, "pending");
+        }
+
         var downloadCount = 0;
         var downloadProgress = new Progress<(string ItemName, double Percent)>(p =>
         {
@@ -1310,10 +1323,21 @@ public class UpdateEngine : IDisposable
             {
                 // Starting a new item download
                 downloadCount++;
+                ReportItemStatus(p.ItemName, "downloading");
                 ReportDetail($"Downloading {label} ({downloadCount}/{items.Count})");
             }
         });
         var downloadedPaths = await _downloadService.DownloadItemsAsync(items, downloadProgress, cancellationToken);
+
+        // Anything with a resolved local path is on disk (downloaded now or
+        // already cached) — flip those rows to downloaded.
+        foreach (var item in items)
+        {
+            if (downloadedPaths.ContainsKey(item.Name))
+            {
+                ReportItemStatus(item.Name, "downloaded");
+            }
+        }
 
         // Track installed and scheduled items for dependency checking
         // Start with items that are already confirmed installed (from status checks)
@@ -1331,10 +1355,18 @@ public class UpdateEngine : IDisposable
         {
             if (cancellationToken.IsCancellationRequested) break;
 
+            if (_userStop.IsCancellationRequested)
+            {
+                LogInfo("Stop requested from GUI - aborting before next item");
+                ReportStatus("Cancelled");
+                break;
+            }
+
             itemIndex++;
             var progressPercent = (itemIndex * 100) / totalItems;
             var installLabel = !string.IsNullOrEmpty(item.Version)
                 ? $"{item.Name} {item.Version}" : item.Name;
+            ReportItemStatus(item.Name, "installing");
             ReportDetail($"Installing {installLabel} ({itemIndex}/{totalItems})");
             ReportPercent(progressPercent);
 
@@ -1342,6 +1374,7 @@ public class UpdateEngine : IDisposable
             if (installedItems.Contains(item.Name, StringComparer.OrdinalIgnoreCase))
             {
                 LogDetail($"Skipping {item.Name}: already installed as dependency");
+                ReportItemStatus(item.Name, "installed");
                 successCount++;
                 continue;
             }
@@ -1353,6 +1386,8 @@ public class UpdateEngine : IDisposable
                 downloadedPaths,
                 outcomes,
                 cancellationToken);
+
+            ReportItemStatus(item.Name, success ? "installed" : "failed");
 
             if (success)
             {
@@ -1765,8 +1800,10 @@ public class UpdateEngine : IDisposable
         }
 
         LogInfo($"Removing: {item.Name}");
+        ReportItemStatus(item.Name, "removing");
         var (success, output) = await _installerService.UninstallAsync(item, cancellationToken);
         outcomes.Add(new ItemOutcome(item.Name, item.Version, "remove", success, success ? null : output, DateTime.UtcNow));
+        ReportItemStatus(item.Name, success ? "removed" : "failed");
 
         if (success)
         {
@@ -1817,6 +1854,13 @@ public class UpdateEngine : IDisposable
         foreach (var item in items)
         {
             if (cancellationToken.IsCancellationRequested) break;
+
+            if (_userStop.IsCancellationRequested)
+            {
+                LogInfo("Stop requested from GUI - aborting before next removal");
+                ReportStatus("Cancelled");
+                break;
+            }
 
             // Skip if already removed (may have been removed as a dependent)
             if (!installedItems.Contains(item.Name, StringComparer.OrdinalIgnoreCase))
@@ -2404,6 +2448,16 @@ public class UpdateEngine : IDisposable
     private void ReportPercent(int percent)
     {
         _statusReporter?.Percent(percent);
+    }
+
+    /// <summary>
+    /// Reports a per-item lifecycle stage to the GUI (pending, downloading,
+    /// downloaded, installing, installed, removing, removed, failed) so the
+    /// Updates list can render live status on each row.
+    /// </summary>
+    private void ReportItemStatus(string itemName, string stage)
+    {
+        _statusReporter?.ItemStatus(itemName, stage);
     }
 
     /// <summary>

--- a/gui/ManagedSoftwareCenter/App.xaml.cs
+++ b/gui/ManagedSoftwareCenter/App.xaml.cs
@@ -35,7 +35,11 @@ public partial class App : Application
     public App()
     {
         this.InitializeComponent();
-        
+
+        // The App is constructed on the UI thread (Application.Start callback);
+        // capture its DispatcherQueue so background services can marshal events.
+        UiDispatcher.Initialize(Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread());
+
         this.UnhandledException += App_UnhandledException;
 
         // Configure dependency injection

--- a/gui/ManagedSoftwareCenter/App.xaml.cs
+++ b/gui/ManagedSoftwareCenter/App.xaml.cs
@@ -59,7 +59,12 @@ public partial class App : Application
         services.AddSingleton<IBrandingService, BrandingService>();
 
         // ViewModels
-        services.AddTransient<ShellViewModel>();
+        // ShellViewModel is app-wide shell state (progress overlay, badges,
+        // navigation requests). It MUST be a singleton: pages resolve it on
+        // construction, and a transient instance would be created after the
+        // operation-started event already fired — the new page would see
+        // IsInstalling=false and show stale content while a run is in flight.
+        services.AddSingleton<ShellViewModel>();
         services.AddTransient<SoftwareViewModel>();
         services.AddTransient<CategoriesViewModel>();
         services.AddTransient<MyItemsViewModel>();

--- a/gui/ManagedSoftwareCenter/App.xaml.cs
+++ b/gui/ManagedSoftwareCenter/App.xaml.cs
@@ -68,7 +68,10 @@ public partial class App : Application
         services.AddTransient<SoftwareViewModel>();
         services.AddTransient<CategoriesViewModel>();
         services.AddTransient<MyItemsViewModel>();
-        services.AddTransient<UpdatesViewModel>();
+        // UpdatesViewModel holds live per-item stage state streamed from the
+        // progress pipe — singleton so navigation doesn't drop mid-run state
+        // (and so it doesn't leak a pipe subscription per page visit).
+        services.AddSingleton<UpdatesViewModel>();
         services.AddTransient<HistoryViewModel>();
         services.AddTransient<ItemDetailViewModel>();
         services.AddTransient<ProgressViewModel>();

--- a/gui/ManagedSoftwareCenter/Controls/LogViewerControl.xaml
+++ b/gui/ManagedSoftwareCenter/Controls/LogViewerControl.xaml
@@ -28,12 +28,24 @@
                      HorizontalAlignment="Left"/>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4">
+                <CheckBox x:Name="ShowDebugToggle"
+                          Content="Debug"
+                          IsChecked="False"
+                          MinWidth="0"
+                          VerticalAlignment="Center"
+                          ToolTipService.ToolTip="Show DEBUG-level messages"
+                          Click="ShowDebugToggle_Click"/>
                 <ToggleButton x:Name="AutoScrollToggle"
                               IsChecked="True"
                               ToolTipService.ToolTip="Auto-scroll to bottom"
                               Click="AutoScrollToggle_Click">
                     <FontIcon Glyph="&#xE74B;" FontSize="14"/>
                 </ToggleButton>
+                <Button x:Name="CopyButton"
+                        Click="Copy_Click"
+                        ToolTipService.ToolTip="Copy log to clipboard">
+                    <FontIcon Glyph="&#xE8C8;" FontSize="14"/>
+                </Button>
                 <Button Click="Refresh_Click"
                         ToolTipService.ToolTip="Reload log">
                     <FontIcon Glyph="&#xE72C;" FontSize="14"/>

--- a/gui/ManagedSoftwareCenter/Controls/LogViewerControl.xaml
+++ b/gui/ManagedSoftwareCenter/Controls/LogViewerControl.xaml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- LogViewerControl.xaml - Reusable session log viewer (tail + filter).
+     Hosted by the View Log flyout on the Updates page and by the standalone
+     LogWindow. The pop-out button is only shown in flyout mode. -->
+<UserControl
+    x:Class="Cimian.GUI.ManagedSoftwareCenter.Controls.LogViewerControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Toolbar -->
+        <Grid Grid.Row="0" Padding="12,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBox x:Name="SearchBox"
+                     PlaceholderText="Filter log..."
+                     TextChanged="SearchBox_TextChanged"
+                     MaxWidth="300"
+                     HorizontalAlignment="Left"/>
+
+            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4">
+                <ToggleButton x:Name="AutoScrollToggle"
+                              IsChecked="True"
+                              ToolTipService.ToolTip="Auto-scroll to bottom"
+                              Click="AutoScrollToggle_Click">
+                    <FontIcon Glyph="&#xE74B;" FontSize="14"/>
+                </ToggleButton>
+                <Button Click="Refresh_Click"
+                        ToolTipService.ToolTip="Reload log">
+                    <FontIcon Glyph="&#xE72C;" FontSize="14"/>
+                </Button>
+                <Button Click="Clear_Click"
+                        ToolTipService.ToolTip="Clear display">
+                    <FontIcon Glyph="&#xE894;" FontSize="14"/>
+                </Button>
+                <Button x:Name="PopOutButton"
+                        Visibility="Collapsed"
+                        Click="PopOut_Click"
+                        ToolTipService.ToolTip="Open in separate window">
+                    <FontIcon Glyph="&#xE8A7;" FontSize="14"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <!-- Log Content -->
+        <ScrollViewer x:Name="LogScrollViewer" Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Auto">
+            <TextBlock x:Name="LogTextBlock"
+                       FontFamily="Cascadia Mono, Consolas, Courier New"
+                       FontSize="12"
+                       IsTextSelectionEnabled="True"
+                       TextWrapping="Wrap"
+                       Padding="12"
+                       Text="Loading log..."/>
+        </ScrollViewer>
+
+        <!-- Status Bar -->
+        <Grid Grid.Row="2" Padding="12,6"
+              Background="{ThemeResource LayerFillColorDefaultBrush}"
+              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+              BorderThickness="0,1,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock x:Name="StatusText"
+                       FontSize="11"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                       VerticalAlignment="Center"
+                       Text="Watching log file..."/>
+
+            <TextBlock x:Name="LineCountText"
+                       Grid.Column="1"
+                       FontSize="11"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                       VerticalAlignment="Center"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/gui/ManagedSoftwareCenter/Controls/LogViewerControl.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Controls/LogViewerControl.xaml.cs
@@ -1,0 +1,315 @@
+// LogViewerControl.xaml.cs - Reusable session log viewer
+// Finds the most recent session log, displays entries, and tails while visible.
+// Hosted by the View Log flyout (Updates page) and the standalone LogWindow.
+
+using System.IO;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Cimian.GUI.ManagedSoftwareCenter.Controls;
+
+public partial class LogViewerControl : UserControl
+{
+    private const string LogsBaseDir = @"C:\ProgramData\ManagedInstalls\logs";
+    private const int MaxLines = 5000;
+
+    private FileSystemWatcher? _fileWatcher;
+    private FileSystemWatcher? _dirWatcher;
+    private string? _currentLogPath;
+    private string _fullLogText = string.Empty;
+    private string _filterText = string.Empty;
+    private bool _autoScroll = true;
+    private long _lastFileSize;
+
+    /// <summary>Raised when the user clicks the pop-out button (flyout mode only).</summary>
+    public event EventHandler? PopOutRequested;
+
+    /// <summary>Shows the "open in separate window" toolbar button (flyout mode).</summary>
+    public bool ShowPopOutButton
+    {
+        get => PopOutButton.Visibility == Visibility.Visible;
+        set => PopOutButton.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public LogViewerControl()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>Loads the latest session log and starts tailing it.</summary>
+    public void Start()
+    {
+        FindAndLoadLatestLog();
+        StartWatching();
+    }
+
+    /// <summary>Stops tailing and releases the file watchers.</summary>
+    public void Stop()
+    {
+        _fileWatcher?.Dispose();
+        _fileWatcher = null;
+        _dirWatcher?.Dispose();
+        _dirWatcher = null;
+    }
+
+    /// <summary>Reloads the most recent session log (e.g. when re-shown).</summary>
+    public void RefreshLog() => FindAndLoadLatestLog();
+
+    /// <summary>
+    /// Finds the most recent install.log across all session directories
+    /// Session structure: logs/YYYY-MM-DD/HHMM/install.log
+    /// </summary>
+    private static string? FindLatestLogFile()
+    {
+        if (!Directory.Exists(LogsBaseDir)) return null;
+
+        // Get day directories sorted descending
+        var dayDirs = Directory.GetDirectories(LogsBaseDir)
+            .OrderByDescending(d => Path.GetFileName(d))
+            .Take(3); // only check last 3 days
+
+        foreach (var dayDir in dayDirs)
+        {
+            var sessionDirs = Directory.GetDirectories(dayDir)
+                .OrderByDescending(d => Path.GetFileName(d));
+
+            foreach (var sessionDir in sessionDirs)
+            {
+                var installLog = Path.Combine(sessionDir, "install.log");
+                if (File.Exists(installLog))
+                    return installLog;
+
+                var runLog = Path.Combine(sessionDir, "run.log");
+                if (File.Exists(runLog))
+                    return runLog;
+            }
+        }
+
+        return null;
+    }
+
+    private void FindAndLoadLatestLog()
+    {
+        _currentLogPath = FindLatestLogFile();
+        LoadLogFile();
+    }
+
+    private void LoadLogFile()
+    {
+        try
+        {
+            if (_currentLogPath == null || !File.Exists(_currentLogPath))
+            {
+                _fullLogText = Directory.Exists(LogsBaseDir)
+                    ? "No log sessions found. Run 'Check Now' to start a session."
+                    : $"Log directory not found: {LogsBaseDir}";
+                StatusText.Text = _currentLogPath == null ? "No logs found" : "Log file not found";
+                UpdateDisplay();
+                return;
+            }
+
+            // Read with sharing so we don't block the writer
+            using var stream = new FileStream(_currentLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+            var content = reader.ReadToEnd();
+            _lastFileSize = stream.Length;
+
+            // Trim to max lines
+            var lines = content.Split('\n');
+            if (lines.Length > MaxLines)
+            {
+                _fullLogText = string.Join('\n', lines[^MaxLines..]);
+            }
+            else
+            {
+                _fullLogText = content;
+            }
+
+            var lineCount = _fullLogText.Split('\n').Length;
+            LineCountText.Text = $"{lineCount} lines";
+
+            // Show session info in status bar
+            var sessionDir = Path.GetDirectoryName(_currentLogPath);
+            var sessionName = sessionDir != null
+                ? $"{Path.GetFileName(Path.GetDirectoryName(sessionDir))}/{Path.GetFileName(sessionDir)}"
+                : "";
+            StatusText.Text = $"Session: {sessionName}  •  {Path.GetFileName(_currentLogPath)}";
+            UpdateDisplay();
+        }
+        catch (Exception ex)
+        {
+            _fullLogText = $"Error reading log: {ex.Message}";
+            StatusText.Text = "Error reading log file";
+            UpdateDisplay();
+        }
+    }
+
+    private void AppendNewContent()
+    {
+        try
+        {
+            if (_currentLogPath == null || !File.Exists(_currentLogPath)) return;
+
+            using var stream = new FileStream(_currentLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            // If file was truncated/rotated, reload entirely
+            if (stream.Length < _lastFileSize)
+            {
+                LoadLogFile();
+                return;
+            }
+
+            if (stream.Length == _lastFileSize) return;
+
+            // Read only new content
+            stream.Seek(_lastFileSize, SeekOrigin.Begin);
+            using var reader = new StreamReader(stream);
+            var newContent = reader.ReadToEnd();
+            _lastFileSize = stream.Length;
+
+            if (string.IsNullOrEmpty(newContent)) return;
+
+            _fullLogText += newContent;
+
+            // Trim if too long
+            var lines = _fullLogText.Split('\n');
+            if (lines.Length > MaxLines)
+            {
+                _fullLogText = string.Join('\n', lines[^MaxLines..]);
+            }
+
+            var lineCount = _fullLogText.Split('\n').Length;
+            LineCountText.Text = $"{lineCount} lines";
+            UpdateDisplay();
+        }
+        catch
+        {
+            // File might be temporarily locked during write
+        }
+    }
+
+    private void UpdateDisplay()
+    {
+        if (string.IsNullOrEmpty(_filterText))
+        {
+            LogTextBlock.Text = _fullLogText;
+        }
+        else
+        {
+            var lines = _fullLogText.Split('\n');
+            var filtered = lines.Where(l => l.Contains(_filterText, StringComparison.OrdinalIgnoreCase));
+            LogTextBlock.Text = string.Join('\n', filtered);
+        }
+
+        if (_autoScroll)
+        {
+            LogScrollViewer.UpdateLayout();
+            LogScrollViewer.ChangeView(null, LogScrollViewer.ScrollableHeight, null);
+        }
+    }
+
+    private void StartWatching()
+    {
+        // Watch the current log file for changes (tailing)
+        WatchCurrentLogFile();
+
+        // Watch the logs base directory for new sessions
+        try
+        {
+            if (!Directory.Exists(LogsBaseDir)) return;
+
+            _dirWatcher?.Dispose();
+            _dirWatcher = new FileSystemWatcher(LogsBaseDir)
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.FileName,
+                Filter = "*.log",
+                EnableRaisingEvents = true
+            };
+
+            _dirWatcher.Created += (s, e) =>
+            {
+                var name = Path.GetFileName(e.FullPath);
+                if (!name.Equals("install.log", StringComparison.OrdinalIgnoreCase) &&
+                    !name.Equals("run.log", StringComparison.OrdinalIgnoreCase))
+                    return;
+
+                // New session started — switch to it
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    _currentLogPath = e.FullPath;
+                    _lastFileSize = 0;
+                    LoadLogFile();
+                    WatchCurrentLogFile();
+                });
+            };
+        }
+        catch
+        {
+            // Could not watch for new sessions
+        }
+    }
+
+    private void WatchCurrentLogFile()
+    {
+        _fileWatcher?.Dispose();
+        _fileWatcher = null;
+
+        if (_currentLogPath == null) return;
+
+        try
+        {
+            var dir = Path.GetDirectoryName(_currentLogPath);
+            var file = Path.GetFileName(_currentLogPath);
+
+            if (dir == null || !Directory.Exists(dir)) return;
+
+            _fileWatcher = new FileSystemWatcher(dir, file)
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size,
+                EnableRaisingEvents = true
+            };
+
+            _fileWatcher.Changed += (s, e) =>
+            {
+                DispatcherQueue.TryEnqueue(AppendNewContent);
+            };
+        }
+        catch
+        {
+            // Could not watch log file
+        }
+    }
+
+    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        _filterText = SearchBox.Text;
+        UpdateDisplay();
+    }
+
+    private void AutoScrollToggle_Click(object sender, RoutedEventArgs e)
+    {
+        _autoScroll = AutoScrollToggle.IsChecked == true;
+        if (_autoScroll)
+        {
+            LogScrollViewer.ChangeView(null, LogScrollViewer.ScrollableHeight, null);
+        }
+    }
+
+    private void Refresh_Click(object sender, RoutedEventArgs e)
+    {
+        FindAndLoadLatestLog();
+    }
+
+    private void Clear_Click(object sender, RoutedEventArgs e)
+    {
+        _fullLogText = string.Empty;
+        LogTextBlock.Text = string.Empty;
+        LineCountText.Text = "0 lines";
+    }
+
+    private void PopOut_Click(object sender, RoutedEventArgs e)
+    {
+        PopOutRequested?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/gui/ManagedSoftwareCenter/Controls/LogViewerControl.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Controls/LogViewerControl.xaml.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace Cimian.GUI.ManagedSoftwareCenter.Controls;
 
@@ -19,6 +20,7 @@ public partial class LogViewerControl : UserControl
     private string _fullLogText = string.Empty;
     private string _filterText = string.Empty;
     private bool _autoScroll = true;
+    private bool _showDebug;
     private long _lastFileSize;
 
     /// <summary>Raised when the user clicks the pop-out button (flyout mode only).</summary>
@@ -190,15 +192,22 @@ public partial class LogViewerControl : UserControl
 
     private void UpdateDisplay()
     {
-        if (string.IsNullOrEmpty(_filterText))
+        // DEBUG lines are hidden by default to keep the view readable; the search
+        // filter applies on top. When nothing is being filtered out, show the raw
+        // text untouched (cheapest path).
+        if (_showDebug && string.IsNullOrEmpty(_filterText))
         {
             LogTextBlock.Text = _fullLogText;
         }
         else
         {
-            var lines = _fullLogText.Split('\n');
-            var filtered = lines.Where(l => l.Contains(_filterText, StringComparison.OrdinalIgnoreCase));
-            LogTextBlock.Text = string.Join('\n', filtered);
+            var lines = _fullLogText.Split('\n')
+                .Where(l => _showDebug || !IsDebugLine(l));
+            if (!string.IsNullOrEmpty(_filterText))
+            {
+                lines = lines.Where(l => l.Contains(_filterText, StringComparison.OrdinalIgnoreCase));
+            }
+            LogTextBlock.Text = string.Join('\n', lines);
         }
 
         if (_autoScroll)
@@ -296,9 +305,64 @@ public partial class LogViewerControl : UserControl
         }
     }
 
+    private void ShowDebugToggle_Click(object sender, RoutedEventArgs e)
+    {
+        _showDebug = ShowDebugToggle.IsChecked == true;
+        UpdateDisplay();
+    }
+
+    /// <summary>
+    /// True for a DEBUG-level session log line. Lines are formatted
+    /// "[timestamp] LEVEL message"; the level sits right after "] ". Continuation
+    /// lines (no timestamp) are not treated as debug so multi-line messages from
+    /// higher levels stay visible.
+    /// </summary>
+    private static bool IsDebugLine(string line)
+    {
+        var idx = line.IndexOf("] ", StringComparison.Ordinal);
+        return idx >= 0
+            && line.AsSpan(idx + 2).TrimStart().StartsWith("DEBUG", StringComparison.Ordinal);
+    }
+
     private void Refresh_Click(object sender, RoutedEventArgs e)
     {
         FindAndLoadLatestLog();
+    }
+
+    /// <summary>
+    /// Copies the currently shown log (respecting the active filter) to the
+    /// clipboard so users can paste it into a ticket/report. Restores the status
+    /// text after a moment of "Copied" feedback.
+    /// </summary>
+    private void Copy_Click(object sender, RoutedEventArgs e)
+    {
+        var text = LogTextBlock.Text;
+        if (string.IsNullOrEmpty(text)) return;
+
+        try
+        {
+            var package = new DataPackage { RequestedOperation = DataPackageOperation.Copy };
+            package.SetText(text);
+            Clipboard.SetContent(package);
+
+            var lineCount = text.Split('\n').Length;
+            var previous = StatusText.Text;
+            StatusText.Text = $"Copied {lineCount} lines to clipboard";
+
+            var timer = DispatcherQueue.CreateTimer();
+            timer.Interval = TimeSpan.FromSeconds(2);
+            timer.IsRepeating = false;
+            timer.Tick += (s, _) =>
+            {
+                StatusText.Text = previous;
+                timer.Stop();
+            };
+            timer.Start();
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = $"Copy failed: {ex.Message}";
+        }
     }
 
     private void Clear_Click(object sender, RoutedEventArgs e)

--- a/gui/ManagedSoftwareCenter/Converters/Converters.cs
+++ b/gui/ManagedSoftwareCenter/Converters/Converters.cs
@@ -152,6 +152,7 @@ public class StringFormatConverter : IValueConverter
 ///   spinner — Visibility of the in-progress ring (downloading/installing/removing)
 ///   icon    — Visibility of the static glyph (everything else)
 ///   panel   — Visibility of the whole stage panel (collapsed when no stage)
+///   bar     — Visibility of the slim in-row progress bar (active stages only)
 /// </summary>
 public class ItemStageConverter : IValueConverter
 {
@@ -165,6 +166,10 @@ public class ItemStageConverter : IValueConverter
         {
             "panel" => string.IsNullOrEmpty(stage) ? Visibility.Collapsed : Visibility.Visible,
             "spinner" => active ? Visibility.Visible : Visibility.Collapsed,
+            // Slim per-row progress bar: shown while the item is actively worked
+            // (download/install/remove) so a targeted --item run renders progress
+            // in the row itself instead of the global banner.
+            "bar" => active ? Visibility.Visible : Visibility.Collapsed,
             "icon" => !active && !string.IsNullOrEmpty(stage) ? Visibility.Visible : Visibility.Collapsed,
             "text" => stage switch
             {

--- a/gui/ManagedSoftwareCenter/Converters/Converters.cs
+++ b/gui/ManagedSoftwareCenter/Converters/Converters.cs
@@ -156,6 +156,13 @@ public class StringFormatConverter : IValueConverter
 /// </summary>
 public class ItemStageConverter : IValueConverter
 {
+    // Cached once: the "brush" facet is hit on every layout/scroll pass, so
+    // allocating a fresh SolidColorBrush per Convert call was needless GC churn.
+    private static readonly SolidColorBrush GreenBrush = new(Windows.UI.Color.FromArgb(255, 16, 124, 16));
+    private static readonly SolidColorBrush RedBrush = new(Windows.UI.Color.FromArgb(255, 209, 52, 56));
+    private static readonly SolidColorBrush AccentBrush = new(Windows.UI.Color.FromArgb(255, 0, 120, 212));
+    private static readonly SolidColorBrush GrayBrush = new(Windows.UI.Color.FromArgb(255, 110, 110, 110));
+
     public object Convert(object value, Type targetType, object parameter, string language)
     {
         var stage = (value as string)?.ToLowerInvariant();
@@ -191,14 +198,14 @@ public class ItemStageConverter : IValueConverter
                 "failed" => "",                 // Cancel (X)
                 _ => string.Empty
             },
-            "brush" => new SolidColorBrush(stage switch
+            "brush" => stage switch
             {
-                "installed" or "removed" => Windows.UI.Color.FromArgb(255, 16, 124, 16),   // green
-                "failed" => Windows.UI.Color.FromArgb(255, 209, 52, 56),                   // red
-                "downloading" or "installing" or "removing" => Windows.UI.Color.FromArgb(255, 0, 120, 212), // accent blue
-                "downloaded" => Windows.UI.Color.FromArgb(255, 16, 124, 16),               // green
-                _ => Windows.UI.Color.FromArgb(255, 110, 110, 110)                         // gray (pending)
-            }),
+                "installed" or "removed" => GreenBrush,
+                "failed" => RedBrush,
+                "downloading" or "installing" or "removing" => AccentBrush,
+                "downloaded" => GreenBrush,
+                _ => GrayBrush                                                             // pending
+            },
             _ => string.Empty
         };
     }

--- a/gui/ManagedSoftwareCenter/Converters/Converters.cs
+++ b/gui/ManagedSoftwareCenter/Converters/Converters.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
 
 namespace Cimian.GUI.ManagedSoftwareCenter.Converters;
 
@@ -139,6 +140,81 @@ public class StringFormatConverter : IValueConverter
     {
         throw new NotImplementedException();
     }
+}
+
+/// <summary>
+/// Renders a live item lifecycle stage (pending / downloading / downloaded /
+/// installing / installed / removing / removed / failed) as one facet chosen
+/// by ConverterParameter:
+///   text    — display label
+///   brush   — SolidColorBrush for label and glyph
+///   glyph   — Segoe Fluent icon for terminal/idle stages
+///   spinner — Visibility of the in-progress ring (downloading/installing/removing)
+///   icon    — Visibility of the static glyph (everything else)
+///   panel   — Visibility of the whole stage panel (collapsed when no stage)
+/// </summary>
+public class ItemStageConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var stage = (value as string)?.ToLowerInvariant();
+        var facet = parameter as string ?? "text";
+        var active = stage is "downloading" or "installing" or "removing";
+
+        return facet switch
+        {
+            "panel" => string.IsNullOrEmpty(stage) ? Visibility.Collapsed : Visibility.Visible,
+            "spinner" => active ? Visibility.Visible : Visibility.Collapsed,
+            "icon" => !active && !string.IsNullOrEmpty(stage) ? Visibility.Visible : Visibility.Collapsed,
+            "text" => stage switch
+            {
+                "pending" => "Pending",
+                "downloading" => "Downloading...",
+                "downloaded" => "Downloaded",
+                "installing" => "Installing...",
+                "installed" => "Installed",
+                "removing" => "Removing...",
+                "removed" => "Removed",
+                "failed" => "Failed",
+                _ => string.Empty
+            },
+            "glyph" => stage switch
+            {
+                "pending" => "",                // Recent (clock)
+                "downloaded" => "",             // Download
+                "installed" or "removed" => "", // CheckMark
+                "failed" => "",                 // Cancel (X)
+                _ => string.Empty
+            },
+            "brush" => new SolidColorBrush(stage switch
+            {
+                "installed" or "removed" => Windows.UI.Color.FromArgb(255, 16, 124, 16),   // green
+                "failed" => Windows.UI.Color.FromArgb(255, 209, 52, 56),                   // red
+                "downloading" or "installing" or "removing" => Windows.UI.Color.FromArgb(255, 0, 120, 212), // accent blue
+                "downloaded" => Windows.UI.Color.FromArgb(255, 16, 124, 16),               // green
+                _ => Windows.UI.Color.FromArgb(255, 110, 110, 110)                         // gray (pending)
+            }),
+            _ => string.Empty
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+/// <summary>
+/// Inverse of ItemStageConverter's "panel" facet: visible only when the item
+/// has NO live stage (idle), used for the static "Will be installed" labels.
+/// </summary>
+public class NoStageToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+        => string.IsNullOrEmpty(value as string) ? Visibility.Visible : Visibility.Collapsed;
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotImplementedException();
 }
 
 /// <summary>

--- a/gui/ManagedSoftwareCenter/MainWindow.xaml.cs
+++ b/gui/ManagedSoftwareCenter/MainWindow.xaml.cs
@@ -31,8 +31,14 @@ public partial class MainWindow : Window
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
 
-        // Set window size and center on screen
-        AppWindow.Resize(new Windows.Graphics.SizeInt32(2100, 1170));
+        // Set window size (capped to the work area) and center on screen
+        var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+        var windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
+        var workArea = Microsoft.UI.Windowing.DisplayArea.GetFromWindowId(
+            windowId, Microsoft.UI.Windowing.DisplayAreaFallback.Primary).WorkArea;
+        AppWindow.Resize(new Windows.Graphics.SizeInt32(
+            Math.Min(2100, workArea.Width),
+            Math.Min(1170, workArea.Height)));
         CenterOnScreen();
 
         // Get ViewModel from DI
@@ -43,14 +49,17 @@ public partial class MainWindow : Window
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
     }
 
+    // Centers on the work area using the actual window size, clamped so the
+    // window never opens outside the visible area on smaller displays.
     private void CenterOnScreen()
     {
         var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         var windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
-        var displayArea = Microsoft.UI.Windowing.DisplayArea.GetFromWindowId(
-            windowId, Microsoft.UI.Windowing.DisplayAreaFallback.Primary);
-        var x = (displayArea.WorkArea.Width - 2100) / 2;
-        var y = (displayArea.WorkArea.Height - 1170) / 2;
+        var work = Microsoft.UI.Windowing.DisplayArea.GetFromWindowId(
+            windowId, Microsoft.UI.Windowing.DisplayAreaFallback.Primary).WorkArea;
+        var size = AppWindow.Size;
+        var x = work.X + Math.Max(0, (work.Width - size.Width) / 2);
+        var y = work.Y + Math.Max(0, (work.Height - size.Height) / 2);
         AppWindow.Move(new Windows.Graphics.PointInt32(x, y));
     }
 

--- a/gui/ManagedSoftwareCenter/Models/InstallInfo.cs
+++ b/gui/ManagedSoftwareCenter/Models/InstallInfo.cs
@@ -70,7 +70,7 @@ public class InstallInfo
 /// <summary>
 /// Represents a software item that can be installed/updated/removed
 /// </summary>
-public class InstallableItem
+public class InstallableItem : System.ComponentModel.INotifyPropertyChanged
 {
     /// <summary>
     /// Internal name/identifier
@@ -289,6 +289,28 @@ public class InstallableItem
     /// </summary>
     [YamlIgnore]
     public BitmapImage? IconImage { get; set; }
+
+    /// <summary>
+    /// Live lifecycle stage streamed from managedsoftwareupdate during a run:
+    /// pending, downloading, downloaded, installing, installed, removing,
+    /// removed, failed. Null when no run is reporting on this item. The only
+    /// property with change notification — rows must update in place as the
+    /// engine progresses through stages.
+    /// </summary>
+    [YamlIgnore]
+    public string? LiveStage
+    {
+        get => _liveStage;
+        set
+        {
+            if (_liveStage == value) return;
+            _liveStage = value;
+            PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(LiveStage)));
+        }
+    }
+    private string? _liveStage;
+
+    public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
 
     /// <summary>
     /// Days pending text for UI binding (not serialized)

--- a/gui/ManagedSoftwareCenter/Models/InstallInfo.cs
+++ b/gui/ManagedSoftwareCenter/Models/InstallInfo.cs
@@ -310,6 +310,25 @@ public class InstallableItem : System.ComponentModel.INotifyPropertyChanged
     }
     private string? _liveStage;
 
+    /// <summary>
+    /// Detail accompanying the live stage — for the "failed" stage this is the
+    /// failure reason (e.g. "Exit code 1603") streamed from managedsoftwareupdate,
+    /// so the row can show users the exact code while a run is in flight. Null/empty
+    /// when there's nothing extra to show. Notifies so the row updates in place.
+    /// </summary>
+    [YamlIgnore]
+    public string? LiveStageDetail
+    {
+        get => _liveStageDetail;
+        set
+        {
+            if (_liveStageDetail == value) return;
+            _liveStageDetail = value;
+            PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(LiveStageDetail)));
+        }
+    }
+    private string? _liveStageDetail;
+
     public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
 
     /// <summary>

--- a/gui/ManagedSoftwareCenter/Models/ProgressMessage.cs
+++ b/gui/ManagedSoftwareCenter/Models/ProgressMessage.cs
@@ -111,6 +111,13 @@ public enum ProgressMessageType
     ShowLog,
 
     /// <summary>
+    /// Per-item lifecycle stage update (ItemName + stage string in Detail):
+    /// pending, downloading, downloaded, installing, installed, removing,
+    /// removed, failed
+    /// </summary>
+    ItemStatus,
+
+    /// <summary>
     /// Download progress
     /// </summary>
     Downloading,

--- a/gui/ManagedSoftwareCenter/Program.cs
+++ b/gui/ManagedSoftwareCenter/Program.cs
@@ -14,6 +14,13 @@ public static class Program
     [STAThread]
     static void Main(string[] args)
     {
+        // App.UnhandledException only sees XAML-thread exceptions. Exceptions
+        // escaping async void handlers on threadpool threads (e.g. service
+        // event callbacks) kill the process with no trace in msc_crash.log —
+        // log them here so post-mortems don't depend on Windows Error Reporting.
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            Log($"FATAL (background): {e.ExceptionObject}");
+
         try
         {
             Log("Starting COM wrappers initialization...");

--- a/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
@@ -52,6 +52,16 @@ public interface ITriggerService
     bool IsOperationRunning { get; }
 
     /// <summary>
+    /// True when the in-flight (or most recently launched) operation is targeted
+    /// at a specific set of items via <c>--item</c> (a self-serve click or the
+    /// Updates "Install Now" over the known pending set). False for broad runs —
+    /// a check, an <c>--installonly</c> pass, or an externally launched session.
+    /// The shell uses this to render progress inside each item's row for targeted
+    /// runs and the global banner for broad ones.
+    /// </summary>
+    bool IsItemScopedOperation { get; }
+
+    /// <summary>
     /// Human-readable description of the in-flight operation, e.g.
     /// "Installing Gimp, Cyberduck...". Set when a trigger writes the flag
     /// file and cleared once CimianWatcher consumes it (or the call fails).

--- a/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
@@ -24,9 +24,22 @@ public interface ITriggerService
     /// the full preflight pipeline and only touches the affected package. When called
     /// concurrently before CimianWatcher has consumed the flag file, the names are
     /// coalesced into a single `--item N1 --item N2 ...` run so rapid clicks do not
-    /// lose entries to a clobbering race.
+    /// lose entries to a clobbering race. Pass <paramref name="asRemoval"/> when the
+    /// item was flipped to a removal request so the progress banner reads
+    /// "Removing X..." instead of "Installing X...".
     /// </summary>
-    Task TriggerInstallItemAsync(string itemName);
+    Task TriggerInstallItemAsync(string itemName, bool asRemoval = false);
+
+    /// <summary>
+    /// Trigger a fast targeted run for a set of items at once — used by the Updates
+    /// page "Install Now" so it processes exactly the pending installs/removals via a
+    /// single `--item N1 --item N2 ... --no-preflight` run instead of a full
+    /// `--installonly` pass (which re-runs preflight and re-evaluates the entire
+    /// catalog from scratch). Names are coalesced with any already-pending self-serve
+    /// clicks into one run. Names listed in <paramref name="removalNames"/> are
+    /// flagged as removals so the progress banner verb reflects them.
+    /// </summary>
+    Task TriggerInstallItemsAsync(IEnumerable<string> itemNames, IEnumerable<string>? removalNames = null);
 
     /// <summary>
     /// Trigger stop of current operation (during download phase)

--- a/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/ITriggerService.cs
@@ -23,7 +23,7 @@ public interface ITriggerService
     /// the self-service manifest. Uses `--item <name> --no-preflight` so the run skips
     /// the full preflight pipeline and only touches the affected package. When called
     /// concurrently before CimianWatcher has consumed the flag file, the names are
-    /// coalesced into a single `--item N1 --item N2 ...` run so rapid clicks do not
+    /// coalesced into a single `--item N1 N2 ...` run so rapid clicks do not
     /// lose entries to a clobbering race. Pass <paramref name="asRemoval"/> when the
     /// item was flipped to a removal request so the progress banner reads
     /// "Removing X..." instead of "Installing X...".
@@ -33,7 +33,7 @@ public interface ITriggerService
     /// <summary>
     /// Trigger a fast targeted run for a set of items at once — used by the Updates
     /// page "Install Now" so it processes exactly the pending installs/removals via a
-    /// single `--item N1 --item N2 ... --no-preflight` run instead of a full
+    /// single `--item N1 N2 ... --no-preflight` run instead of a full
     /// `--installonly` pass (which re-runs preflight and re-evaluates the entire
     /// catalog from scratch). Names are coalesced with any already-pending self-serve
     /// clicks into one run. Names listed in <paramref name="removalNames"/> are

--- a/gui/ManagedSoftwareCenter/Services/InstallInfoService.cs
+++ b/gui/ManagedSoftwareCenter/Services/InstallInfoService.cs
@@ -286,7 +286,9 @@ public class InstallInfoService : IInstallInfoService, IDisposable
             var info = await LoadAsync();
 
             _logger?.LogDebug("InstallInfo.yaml changed, notifying subscribers");
-            InstallInfoChanged?.Invoke(this, info);
+            // FileSystemWatcher delivers on a threadpool thread; subscribers set
+            // XAML-bound observable properties, so raise on the UI thread.
+            UiDispatcher.Post(() => InstallInfoChanged?.Invoke(this, info));
         }
         catch (TaskCanceledException)
         {

--- a/gui/ManagedSoftwareCenter/Services/ProgressPipeClient.cs
+++ b/gui/ManagedSoftwareCenter/Services/ProgressPipeClient.cs
@@ -79,7 +79,9 @@ public class ProgressPipeClient : IProgressPipeClient, IDisposable
                 _writer = new StreamWriter(_pipe) { AutoFlush = true };
 
                 _logger?.LogInformation("Connected to progress pipe");
-                ConnectionChanged?.Invoke(this, true);
+                // Connection loop runs on the threadpool; subscribers touch
+                // XAML-bound state, so raise on the UI thread.
+                UiDispatcher.Post(() => ConnectionChanged?.Invoke(this, true));
 
                 // Read messages until disconnected
                 await ReadMessagesAsync(cancellationToken);
@@ -95,7 +97,7 @@ public class ProgressPipeClient : IProgressPipeClient, IDisposable
             finally
             {
                 await CleanupPipeAsync();
-                ConnectionChanged?.Invoke(this, false);
+                UiDispatcher.Post(() => ConnectionChanged?.Invoke(this, false));
             }
 
             if (!cancellationToken.IsCancellationRequested)
@@ -125,7 +127,7 @@ public class ProgressPipeClient : IProgressPipeClient, IDisposable
                     _logger?.LogDebug("Received progress: {Message} - {Detail} ({Percent}%)", 
                         message.Message, message.Detail, message.Percent);
                     
-                    ProgressReceived?.Invoke(this, message);
+                    UiDispatcher.Post(() => ProgressReceived?.Invoke(this, message));
                 }
             }
             catch (OperationCanceledException)

--- a/gui/ManagedSoftwareCenter/Services/ProgressServer.cs
+++ b/gui/ManagedSoftwareCenter/Services/ProgressServer.cs
@@ -1,5 +1,5 @@
 // ProgressServer.cs - TCP server for receiving progress from managedsoftwareupdate
-// Listens on TCP port 19847 (matching Go's PipeReporter)
+// Listens on TCP port 19848 (the login-window CimianStatus uses 19847)
 
 using System.IO;
 using System.Net;
@@ -18,7 +18,12 @@ namespace Cimian.GUI.ManagedSoftwareCenter.Services;
 /// </summary>
 public class ProgressServer : IProgressPipeClient, IDisposable
 {
-    private const int Port = 19847;
+    // MSC listens on its OWN port, distinct from the login-window CimianStatus
+    // listener (19847). Both can be alive at once — e.g. a locked machine shows
+    // the login window (19847) while the user session's MSC is also running — so
+    // sharing a port made them collide (whoever bound first won; the other
+    // retried forever). MSC tells the engine to report here via --status-port.
+    public const int Port = 19848;
 
     private readonly ILogger<ProgressServer>? _logger;
     private TcpListener? _listener;

--- a/gui/ManagedSoftwareCenter/Services/ProgressServer.cs
+++ b/gui/ManagedSoftwareCenter/Services/ProgressServer.cs
@@ -94,7 +94,9 @@ public class ProgressServer : IProgressPipeClient, IDisposable
                         _isConnected = true;
                         Log("CLIENT CONNECTED!");
                         _logger?.LogInformation("managedsoftwareupdate connected");
-                        ConnectionChanged?.Invoke(this, true);
+                        // Listen loop runs on the threadpool; subscribers touch
+                        // XAML-bound state, so raise on the UI thread.
+                        UiDispatcher.Post(() => ConnectionChanged?.Invoke(this, true));
 
                         // Read messages from this client
                         await ReadMessagesAsync(cancellationToken);
@@ -120,7 +122,7 @@ public class ProgressServer : IProgressPipeClient, IDisposable
                         if (wasConnected)
                         {
                             Log("Client disconnected");
-                            ConnectionChanged?.Invoke(this, false);
+                            UiDispatcher.Post(() => ConnectionChanged?.Invoke(this, false));
                         }
                     }
                 }
@@ -178,7 +180,7 @@ public class ProgressServer : IProgressPipeClient, IDisposable
                             progressMessage.Type, progressMessage.Message, progressMessage.Detail, progressMessage.Percent);
                         System.Diagnostics.Debug.WriteLine($"[ProgressServer] Parsed: Type={progressMessage.Type}, Message={progressMessage.Message}");
                         
-                        ProgressReceived?.Invoke(this, progressMessage);
+                        UiDispatcher.Post(() => ProgressReceived?.Invoke(this, progressMessage));
                     }
 
                     // Check for quit message

--- a/gui/ManagedSoftwareCenter/Services/ProgressServer.cs
+++ b/gui/ManagedSoftwareCenter/Services/ProgressServer.cs
@@ -240,6 +240,14 @@ public class ProgressServer : IProgressPipeClient, IDisposable
                 progress.Detail = goMessage.Data;
                 break;
 
+            case "itemStatus":
+                // Per-item lifecycle stage: pending, downloading, downloaded,
+                // installing, installed, removing, removed, failed.
+                progress.Type = ProgressMessageType.ItemStatus;
+                progress.ItemName = goMessage.Item;
+                progress.Detail = goMessage.Data;
+                break;
+
             case "quit":
                 progress.Type = ProgressMessageType.Complete;
                 progress.Message = "Complete";
@@ -278,11 +286,31 @@ public class ProgressServer : IProgressPipeClient, IDisposable
     }
 
     /// <inheritdoc />
-    public Task SendCommandAsync(CommandMessage command)
+    public async Task SendCommandAsync(CommandMessage command)
     {
-        // Commands not supported in TCP mode - Go reporter doesn't listen for responses
-        _logger?.LogDebug("SendCommand not supported in TCP server mode");
-        return Task.CompletedTask;
+        // The status connection is duplex: managedsoftwareupdate's reporter
+        // runs a command read loop. Stop is the only supported command.
+        var stream = _stream;
+        if (stream == null || _client?.Connected != true)
+        {
+            _logger?.LogWarning("Cannot send {Type} command - no client connected", command.Type);
+            return;
+        }
+
+        try
+        {
+            var json = command.Type == CommandType.Stop
+                ? "{\"type\":\"stop\"}"
+                : "{\"type\":\"requestStatus\"}";
+            var bytes = Encoding.UTF8.GetBytes(json + "\n");
+            await stream.WriteAsync(bytes);
+            await stream.FlushAsync();
+            _logger?.LogInformation("Sent {Type} command to managedsoftwareupdate", command.Type);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to send {Type} command", command.Type);
+        }
     }
 
     private async Task CleanupClientAsync()
@@ -332,6 +360,9 @@ internal class GoStatusMessage
 
     [JsonPropertyName("data")]
     public string? Data { get; set; }
+
+    [JsonPropertyName("item")]
+    public string? Item { get; set; }
 
     [JsonPropertyName("percent")]
     public int Percent { get; set; }

--- a/gui/ManagedSoftwareCenter/Services/ProgressServer.cs
+++ b/gui/ManagedSoftwareCenter/Services/ProgressServer.cs
@@ -242,10 +242,12 @@ public class ProgressServer : IProgressPipeClient, IDisposable
 
             case "itemStatus":
                 // Per-item lifecycle stage: pending, downloading, downloaded,
-                // installing, installed, removing, removed, failed.
+                // installing, installed, removing, removed, failed. For "failed",
+                // Message carries the reason (e.g. "Exit code 1603").
                 progress.Type = ProgressMessageType.ItemStatus;
                 progress.ItemName = goMessage.Item;
                 progress.Detail = goMessage.Data;
+                progress.Message = goMessage.Message ?? string.Empty;
                 break;
 
             case "quit":
@@ -360,6 +362,9 @@ internal class GoStatusMessage
 
     [JsonPropertyName("data")]
     public string? Data { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
 
     [JsonPropertyName("item")]
     public string? Item { get; set; }

--- a/gui/ManagedSoftwareCenter/Services/TriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/TriggerService.cs
@@ -16,6 +16,10 @@ namespace Cimian.GUI.ManagedSoftwareCenter.Services;
 public class TriggerService : ITriggerService, IDisposable
 {
     private const string BootstrapFlagFile = @"C:\ProgramData\ManagedInstalls\.cimian.bootstrap";
+    // Tell the engine to report progress to MSC's own listener (ProgressServer.Port)
+    // instead of the default 19847 used by the login-window CimianStatus, so the
+    // two never collide. Appended to every --show-status run MSC triggers.
+    private static readonly string StatusPortArg = $"--status-port {ProgressServer.Port}";
     private static readonly TimeSpan ServiceTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
 
@@ -38,9 +42,12 @@ public class TriggerService : ITriggerService, IDisposable
     // races the first.
     private Task? _currentBatch;
     private bool _isOperationRunning;
+    private bool _isItemScopedOperation;
     private string? _currentOperationLabel;
 
     public bool IsOperationRunning => _isOperationRunning;
+
+    public bool IsItemScopedOperation => _isItemScopedOperation;
 
     public string? CurrentOperationLabel => _currentOperationLabel;
 
@@ -56,10 +63,11 @@ public class TriggerService : ITriggerService, IDisposable
     public async Task TriggerCheckAsync()
     {
         _logger?.LogInformation("Triggering check via CimianWatcher");
+        _isItemScopedOperation = false;
         _currentOperationLabel = "Checking for updates...";
         try
         {
-            await WriteFlagFileAndWaitAsync("--checkonly --show-status -vv").ConfigureAwait(false);
+            await WriteFlagFileAndWaitAsync($"--checkonly --show-status -vv {StatusPortArg}").ConfigureAwait(false);
         }
         finally
         {
@@ -71,10 +79,11 @@ public class TriggerService : ITriggerService, IDisposable
     public async Task TriggerInstallAsync()
     {
         _logger?.LogInformation("Triggering install via CimianWatcher");
+        _isItemScopedOperation = false;
         _currentOperationLabel = "Installing pending updates...";
         try
         {
-            await WriteFlagFileAndWaitAsync("--installonly --show-status -vv").ConfigureAwait(false);
+            await WriteFlagFileAndWaitAsync($"--installonly --show-status -vv {StatusPortArg}").ConfigureAwait(false);
         }
         finally
         {
@@ -125,7 +134,8 @@ public class TriggerService : ITriggerService, IDisposable
                 foreach (var r in removalNames.Where(n => !string.IsNullOrWhiteSpace(n)))
                     _pendingRemovals.Add(r);
             }
-            var mergedArgs = BootstrapArgsBuilder.BuildSelfServeInstallArgs(_pendingItemOrder);
+            var mergedArgs = $"{BootstrapArgsBuilder.BuildSelfServeInstallArgs(_pendingItemOrder)} {StatusPortArg}";
+            _isItemScopedOperation = true;
             _currentOperationLabel = BuildOperationLabel(_pendingItemOrder, _pendingRemovals);
 
             if (_currentBatch != null && !_currentBatch.IsCompleted)
@@ -239,11 +249,55 @@ public class TriggerService : ITriggerService, IDisposable
         }
 
         // Consumed cleanly — pending state cleared so the next click starts a
-        // fresh batch. _isOperationRunning stays true; completion of the install
-        // is signaled by the InstallInfo.yaml FileSystemWatcher or the
-        // StatusReporter pipe, which is also responsible for flipping the
-        // overlay back to idle.
+        // fresh batch. Completion of the install is normally signaled by the
+        // InstallInfo.yaml FileSystemWatcher or the StatusReporter quit, which
+        // flips the overlay back to idle.
         await ClearBatchStateAsync().ConfigureAwait(false);
+
+        // Safety net: a run that ends WITHOUT rewriting InstallInfo or sending
+        // quit (e.g. an immediate parse/lock failure) would otherwise leave the
+        // GUI stuck showing "Stop" forever. Wait for the launched process to
+        // actually exit, then clear the running state ourselves.
+        await SignalOperationDoneOnProcessExitAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Waits for the managedsoftwareupdate process the watcher just launched to
+    /// exit, then clears <see cref="_isOperationRunning"/> and notifies — UNLESS a
+    /// follow-up batch has been queued in the meantime (a fresh flag or a new
+    /// in-flight batch), in which case that batch owns the running state. This is
+    /// the backstop for runs that never signal completion any other way; normal
+    /// runs pass through harmlessly after InstallInfoChanged already reset the UI.
+    /// </summary>
+    private async Task SignalOperationDoneOnProcessExitAsync()
+    {
+        // Give the freshly-consumed flag a moment to spawn the process.
+        var startWait = TimeSpan.Zero;
+        while (!IsUpdateProcessRunning() && startWait < TimeSpan.FromSeconds(5))
+        {
+            await Task.Delay(PollInterval).ConfigureAwait(false);
+            startWait += PollInterval;
+        }
+        // Then wait for it to finish. No fixed cap — a real install can take
+        // minutes; the process either exits or the user closes the app.
+        while (IsUpdateProcessRunning())
+        {
+            await Task.Delay(PollInterval).ConfigureAwait(false);
+        }
+
+        await _flagFileLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            // A queued follow-up (new batch or pending flag) now owns the state.
+            if (_currentBatch != null || File.Exists(BootstrapFlagFile)) return;
+            if (!_isOperationRunning) return;
+            _isOperationRunning = false;
+        }
+        finally
+        {
+            _flagFileLock.Release();
+        }
+        RaiseOperationStatusChanged(false);
     }
 
     /// <summary>

--- a/gui/ManagedSoftwareCenter/Services/TriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/TriggerService.cs
@@ -23,6 +23,11 @@ public class TriggerService : ITriggerService, IDisposable
     private readonly SemaphoreSlim _flagFileLock = new(1, 1);
     private readonly HashSet<string> _pendingItems = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<string> _pendingItemOrder = new();
+    // Subset of _pendingItems the caller flagged as removals, so the progress
+    // label reads "Removing X..." instead of "Installing X...". The engine still
+    // decides install vs uninstall from the self-serve manifest — this only
+    // affects the human-facing banner verb.
+    private readonly HashSet<string> _pendingRemovals = new(StringComparer.OrdinalIgnoreCase);
 
     // A single in-flight Task per targeted-install batch. Concurrent
     // TriggerInstallItemAsync calls that arrive while the flag file from a
@@ -78,28 +83,50 @@ public class TriggerService : ITriggerService, IDisposable
     }
 
     /// <inheritdoc />
-    public async Task TriggerInstallItemAsync(string itemName)
+    public Task TriggerInstallItemAsync(string itemName, bool asRemoval = false)
     {
         if (string.IsNullOrWhiteSpace(itemName))
         {
             throw new ArgumentException("itemName must be provided", nameof(itemName));
         }
 
-        // Validate the name up front — BuildSelfServeInstallArgs would throw on
+        return TriggerInstallItemsAsync(new[] { itemName }, asRemoval ? new[] { itemName } : null);
+    }
+
+    /// <inheritdoc />
+    public async Task TriggerInstallItemsAsync(IEnumerable<string> itemNames, IEnumerable<string>? removalNames = null)
+    {
+        if (itemNames == null) throw new ArgumentNullException(nameof(itemNames));
+
+        var names = itemNames.Where(n => !string.IsNullOrWhiteSpace(n)).ToList();
+        if (names.Count == 0)
+        {
+            throw new ArgumentException("At least one item name is required", nameof(itemNames));
+        }
+
+        // Validate names up front — BuildSelfServeInstallArgs would throw on
         // control characters too, but catching it here gives a clearer caller
         // stack trace than something coming from inside the merge loop.
-        _ = BootstrapArgsBuilder.QuoteArgument(itemName);
+        foreach (var n in names) _ = BootstrapArgsBuilder.QuoteArgument(n);
 
         Task batchTask;
         await _flagFileLock.WaitAsync().ConfigureAwait(false);
         try
         {
-            if (_pendingItems.Add(itemName))
+            foreach (var n in names)
             {
-                _pendingItemOrder.Add(itemName);
+                if (_pendingItems.Add(n))
+                {
+                    _pendingItemOrder.Add(n);
+                }
+            }
+            if (removalNames != null)
+            {
+                foreach (var r in removalNames.Where(n => !string.IsNullOrWhiteSpace(n)))
+                    _pendingRemovals.Add(r);
             }
             var mergedArgs = BootstrapArgsBuilder.BuildSelfServeInstallArgs(_pendingItemOrder);
-            _currentOperationLabel = BuildOperationLabel(_pendingItemOrder);
+            _currentOperationLabel = BuildOperationLabel(_pendingItemOrder, _pendingRemovals);
 
             if (_currentBatch != null && !_currentBatch.IsCompleted)
             {
@@ -109,8 +136,8 @@ public class TriggerService : ITriggerService, IDisposable
                 // The existing batch's poll loop is what we await.
                 await WriteFlagFileAsync(mergedArgs).ConfigureAwait(false);
                 _logger?.LogInformation(
-                    "Merged {Item} into in-flight self-serve batch ({Label})",
-                    itemName, _currentOperationLabel);
+                    "Merged [{Items}] into in-flight self-serve batch ({Label})",
+                    string.Join(", ", names), _currentOperationLabel);
                 batchTask = _currentBatch;
             }
             else
@@ -132,15 +159,23 @@ public class TriggerService : ITriggerService, IDisposable
 
     /// <summary>
     /// Composes the human-readable progress label rendered in the shell overlay
-    /// while a self-serve run is in flight. Long batches (4+ items) are
-    /// summarized as a count so the message stays single-line.
+    /// while a self-serve run is in flight. The verb follows the batch: all
+    /// removals read "Removing...", all installs "Installing...", and a mix is
+    /// summarized as "Processing N items...". Long single-verb batches (4+ items)
+    /// collapse to a count so the message stays single-line.
     /// </summary>
-    internal static string BuildOperationLabel(IReadOnlyList<string> items)
+    internal static string BuildOperationLabel(IReadOnlyList<string> items, IReadOnlySet<string> removals)
     {
-        if (items.Count == 0) return "Installing requested items...";
-        if (items.Count == 1) return $"Installing {items[0]}...";
-        if (items.Count <= 3) return $"Installing {string.Join(", ", items)}...";
-        return $"Installing {items.Count} items ({items[0]}, {items[1]}, +{items.Count - 2} more)...";
+        if (items.Count == 0) return "Working...";
+
+        var removalCount = items.Count(removals.Contains);
+        if (removalCount > 0 && removalCount < items.Count)
+            return $"Processing {items.Count} items...";
+
+        var verb = removalCount == items.Count ? "Removing" : "Installing";
+        if (items.Count == 1) return $"{verb} {items[0]}...";
+        if (items.Count <= 3) return $"{verb} {string.Join(", ", items)}...";
+        return $"{verb} {items.Count} items ({items[0]}, {items[1]}, +{items.Count - 2} more)...";
     }
 
     /// <summary>
@@ -310,6 +345,7 @@ public class TriggerService : ITriggerService, IDisposable
         {
             _pendingItems.Clear();
             _pendingItemOrder.Clear();
+            _pendingRemovals.Clear();
             _currentOperationLabel = null;
             _currentBatch = null;
         }

--- a/gui/ManagedSoftwareCenter/Services/TriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/TriggerService.cs
@@ -262,6 +262,17 @@ public class TriggerService : ITriggerService, IDisposable
         while (File.Exists(BootstrapFlagFile) && elapsed < ServiceTimeout)
         {
             await Task.Delay(PollInterval).ConfigureAwait(false);
+
+            if (IsUpdateProcessRunning())
+            {
+                // CimianWatcher defers flag consumption while a run is in
+                // flight (a second launch would just lose the instance lock).
+                // The flag file is our queued request, not a dead service —
+                // don't count this wait against the timeout.
+                elapsed = TimeSpan.Zero;
+                continue;
+            }
+
             elapsed += PollInterval;
         }
 
@@ -275,6 +286,21 @@ public class TriggerService : ITriggerService, IDisposable
         }
 
         _logger?.LogInformation("CimianWatcher consumed flag file — managedsoftwareupdate is running");
+    }
+
+    private static bool IsUpdateProcessRunning()
+    {
+        try
+        {
+            var procs = System.Diagnostics.Process.GetProcessesByName("managedsoftwareupdate");
+            var running = procs.Length > 0;
+            foreach (var p in procs) p.Dispose();
+            return running;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private async Task ClearBatchStateAsync()

--- a/gui/ManagedSoftwareCenter/Services/TriggerService.cs
+++ b/gui/ManagedSoftwareCenter/Services/TriggerService.cs
@@ -181,7 +181,7 @@ public class TriggerService : ITriggerService, IDisposable
     private async Task RunSelfServeBatchAsync(string initialArgs)
     {
         _isOperationRunning = true;
-        OperationStatusChanged?.Invoke(this, true);
+        RaiseOperationStatusChanged(true);
         try
         {
             await WriteFlagFileAsync(initialArgs).ConfigureAwait(false);
@@ -190,7 +190,7 @@ public class TriggerService : ITriggerService, IDisposable
         catch (InvalidOperationException)
         {
             _isOperationRunning = false;
-            OperationStatusChanged?.Invoke(this, false);
+            RaiseOperationStatusChanged(false);
             await ClearBatchStateAsync().ConfigureAwait(false);
             throw;
         }
@@ -198,7 +198,7 @@ public class TriggerService : ITriggerService, IDisposable
         {
             _logger?.LogError(ex, "Self-serve batch failed");
             _isOperationRunning = false;
-            OperationStatusChanged?.Invoke(this, false);
+            RaiseOperationStatusChanged(false);
             await ClearBatchStateAsync().ConfigureAwait(false);
             return;
         }
@@ -217,7 +217,7 @@ public class TriggerService : ITriggerService, IDisposable
     private async Task WriteFlagFileAndWaitAsync(string arguments)
     {
         _isOperationRunning = true;
-        OperationStatusChanged?.Invoke(this, true);
+        RaiseOperationStatusChanged(true);
         try
         {
             await WriteFlagFileAsync(arguments).ConfigureAwait(false);
@@ -226,16 +226,24 @@ public class TriggerService : ITriggerService, IDisposable
         catch (InvalidOperationException)
         {
             _isOperationRunning = false;
-            OperationStatusChanged?.Invoke(this, false);
+            RaiseOperationStatusChanged(false);
             throw;
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Flag-file trigger failed");
             _isOperationRunning = false;
-            OperationStatusChanged?.Invoke(this, false);
+            RaiseOperationStatusChanged(false);
         }
     }
+
+    /// <summary>
+    /// Raises OperationStatusChanged on the UI thread. The poll loops run on
+    /// threadpool continuations (ConfigureAwait(false)) and subscribers set
+    /// XAML-bound observable properties.
+    /// </summary>
+    private void RaiseOperationStatusChanged(bool isRunning)
+        => UiDispatcher.Post(() => OperationStatusChanged?.Invoke(this, isRunning));
 
     private async Task WriteFlagFileAsync(string arguments)
     {

--- a/gui/ManagedSoftwareCenter/Services/UiDispatcher.cs
+++ b/gui/ManagedSoftwareCenter/Services/UiDispatcher.cs
@@ -1,0 +1,40 @@
+// UiDispatcher.cs - Marshals service events onto the WinUI dispatcher thread.
+// Background sources (FileSystemWatcher, named-pipe/TCP read loops, flag-file
+// poll loops) raise events that viewmodels consume by setting ObservableProperty
+// members. PropertyChanged into an active XAML binding from a non-UI thread is
+// a fatal COMException (0x8001010E RPC_E_WRONG_THREAD), and inside an async void
+// handler it kills the process — so every cross-thread event source must raise
+// through Post().
+
+using Microsoft.UI.Dispatching;
+
+namespace Cimian.GUI.ManagedSoftwareCenter.Services;
+
+/// <summary>
+/// Static dispatcher used by services to raise events on the UI thread.
+/// Initialized once from the App constructor. When no queue has been set
+/// (unit tests), Post() invokes the action inline.
+/// </summary>
+public static class UiDispatcher
+{
+    private static DispatcherQueue? s_queue;
+
+    /// <summary>Captures the UI thread's DispatcherQueue. Call once at startup.</summary>
+    public static void Initialize(DispatcherQueue queue) => s_queue = queue;
+
+    /// <summary>
+    /// Runs <paramref name="action"/> on the UI thread. Executes inline when
+    /// already on the UI thread or when no queue is set (tests). Returns false
+    /// only if the dispatcher rejected the enqueue (app shutting down).
+    /// </summary>
+    public static bool Post(Action action)
+    {
+        var queue = s_queue;
+        if (queue == null || queue.HasThreadAccess)
+        {
+            action();
+            return true;
+        }
+        return queue.TryEnqueue(() => action());
+    }
+}

--- a/gui/ManagedSoftwareCenter/ViewModels/ItemDetailViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/ItemDetailViewModel.cs
@@ -150,9 +150,14 @@ public partial class ItemDetailViewModel : ObservableObject
     {
         if (Item == null) return;
 
-        // Check self-service manifest for pending requests
-        var isInstallRequested = await _selfServiceService.IsInstallRequestedAsync(Item.Name);
-        var isRemovalRequested = await _selfServiceService.IsRemovalRequestedAsync(Item.Name);
+        // Check self-service manifest for pending requests. Install requests
+        // persist after the install completes (standing subscription), so they
+        // only count as pending while the item still needs action; removal
+        // requests only while the item is still installed.
+        var isInstallRequested = await _selfServiceService.IsInstallRequestedAsync(Item.Name)
+            && !(Item.Installed && !Item.NeedsUpdate);
+        var isRemovalRequested = await _selfServiceService.IsRemovalRequestedAsync(Item.Name)
+            && Item.Installed;
 
         // Determine status and available actions
         if (isInstallRequested)

--- a/gui/ManagedSoftwareCenter/ViewModels/ItemDetailViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/ItemDetailViewModel.cs
@@ -264,7 +264,7 @@ public partial class ItemDetailViewModel : ObservableObject
         }
 
         await _selfServiceService.AddRemovalRequestAsync(Item.Name);
-        await _triggerService.TriggerInstallItemAsync(Item.Name);
+        await _triggerService.TriggerInstallItemAsync(Item.Name, asRemoval: true);
         await UpdateStatusAsync();
     }
 

--- a/gui/ManagedSoftwareCenter/ViewModels/MyItemsViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/MyItemsViewModel.cs
@@ -25,6 +25,33 @@ public class MyItem
     public bool CanCancel { get; set; }
     public InstallableItem? CatalogItem { get; set; }
     public BitmapImage? IconImage { get; set; }
+
+    /// <summary>True once a standing install request is actually installed.</summary>
+    public bool IsInstalled => Status == ItemStatus.Installed;
+
+    /// <summary>
+    /// Show "Remove" (immediate uninstall) instead of "Cancel" once an installed,
+    /// uninstallable item is on the list — there's no pending request to cancel,
+    /// the meaningful action is to uninstall it. Pending requests still cancel.
+    /// </summary>
+    public bool ShowRemove => IsInstallRequest && IsInstalled
+        && CatalogItem?.Uninstallable == true;
+
+    /// <summary>Cancel is the action whenever Remove isn't (pending requests).</summary>
+    public bool ShowCancel => !ShowRemove;
+
+    /// <summary>Friendly status label for the badge (raw enum is not user-facing).</summary>
+    public string StatusText => Status switch
+    {
+        ItemStatus.Installed => "Installed",
+        ItemStatus.NotInstalled => "Not installed",
+        ItemStatus.InstallRequested => "Install pending",
+        ItemStatus.WillBeInstalled => "Will be installed",
+        ItemStatus.RemovalRequested => "Removal pending",
+        ItemStatus.WillBeRemoved => "Will be removed",
+        ItemStatus.Installing => "Installing...",
+        _ => Status
+    };
 }
 
 /// <summary>
@@ -157,6 +184,26 @@ public partial class MyItemsViewModel : ObservableObject
         await _selfServiceService.RemoveRequestAsync(item.Name);
 
         // Refresh list
+        await LoadAsync();
+    }
+
+    /// <summary>
+    /// Uninstall an installed item directly from My Items: flip it to a removal
+    /// request (drops it from managed_installs, adds to managed_uninstalls) and
+    /// kick off a targeted run — same proven path as the Software page Remove.
+    /// </summary>
+    [RelayCommand]
+    private async Task RemoveItemAsync(MyItem item)
+    {
+        if (item == null || string.IsNullOrWhiteSpace(item.Name)) return;
+
+        if (item.CatalogItem != null)
+        {
+            item.CatalogItem.LiveStage = "pending";
+        }
+
+        await _selfServiceService.AddRemovalRequestAsync(item.Name);
+        await _triggerService.TriggerInstallItemAsync(item.Name, asRemoval: true);
         await LoadAsync();
     }
 

--- a/gui/ManagedSoftwareCenter/ViewModels/MyItemsViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/MyItemsViewModel.cs
@@ -91,9 +91,14 @@ public partial class MyItemsViewModel : ObservableObject
                     Version = catalogItem?.Version,
                     Category = catalogItem?.Category,
                     Icon = catalogItem?.Icon,
-                    Status = catalogItem?.WillBeInstalled == true 
-                        ? ItemStatus.WillBeInstalled 
-                        : ItemStatus.InstallRequested,
+                    // The install request persists after the install completes
+                    // (standing subscription) — show the real state, not a
+                    // perpetual pending badge.
+                    Status = catalogItem?.Installed == true && catalogItem.NeedsUpdate != true
+                        ? ItemStatus.Installed
+                        : (catalogItem?.WillBeInstalled == true
+                            ? ItemStatus.WillBeInstalled
+                            : ItemStatus.InstallRequested),
                     IsInstallRequest = true,
                     CanCancel = catalogItem?.Status != ItemStatus.Installing,
                     CatalogItem = catalogItem
@@ -112,25 +117,31 @@ public partial class MyItemsViewModel : ObservableObject
                     Version = catalogItem?.InstalledVersion ?? catalogItem?.Version,
                     Category = catalogItem?.Category,
                     Icon = catalogItem?.Icon,
-                    Status = catalogItem?.WillBeRemoved == true 
-                        ? ItemStatus.WillBeRemoved 
-                        : ItemStatus.RemovalRequested,
+                    // Removal is only pending while the item is still installed.
+                    Status = catalogItem?.Installed != true
+                        ? ItemStatus.NotInstalled
+                        : (catalogItem.WillBeRemoved
+                            ? ItemStatus.WillBeRemoved
+                            : ItemStatus.RemovalRequested),
                     IsRemovalRequest = true,
                     CanCancel = catalogItem?.Status != ItemStatus.Installing,
                     CatalogItem = catalogItem
                 });
             }
 
-            Items = new ObservableCollection<MyItem>(myItems.OrderBy(x => x.DisplayName));
-            IsEmpty = Items.Count == 0;
+            var ordered = myItems.OrderBy(x => x.DisplayName).ToList();
 
-            // Load icons
-            foreach (var item in Items)
+            // Load icons BEFORE assigning the bound collection — IconImage has no
+            // change notification, so a later assignment would not update rows.
+            foreach (var item in ordered)
             {
                 item.IconImage = await _iconService.GetIconAsync(item.Name, item.Icon);
             }
-            HasPendingActions = Items.Any(x => 
-                x.Status == ItemStatus.InstallRequested || 
+
+            Items = new ObservableCollection<MyItem>(ordered);
+            IsEmpty = Items.Count == 0;
+            HasPendingActions = Items.Any(x =>
+                x.Status == ItemStatus.InstallRequested ||
                 x.Status == ItemStatus.RemovalRequested);
         }
         finally

--- a/gui/ManagedSoftwareCenter/ViewModels/ShellViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/ShellViewModel.cs
@@ -205,9 +205,14 @@ public partial class ShellViewModel : ObservableObject
     [RelayCommand]
     private async Task StopInstallAsync()
     {
-        if (!CanStopInstall) return;
-
+        // Cancel covers both phases: delete a queued (not yet consumed) flag
+        // file, and tell a running managedsoftwareupdate to stop gracefully
+        // before its next item.
+        await _triggerService.TriggerStopAsync();
         await _progressClient.SendCommandAsync(new CommandMessage { Type = CommandType.Stop });
+
+        ProgressMessage = "Cancelling...";
+        ProgressDetail = "Finishing the current item, then stopping.";
     }
 
     private async Task RefreshDataAsync()

--- a/gui/ManagedSoftwareCenter/ViewModels/ShellViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/ShellViewModel.cs
@@ -172,9 +172,9 @@ public partial class ShellViewModel : ObservableObject
         
         // Now set installing - this will trigger UI updates
         IsInstalling = true;
-        
+
         // Navigate to Updates page to show progress
-        NavigateToPage = "updates";
+        RequestNavigate("updates");
         
         try
         {
@@ -487,6 +487,18 @@ public partial class ShellViewModel : ObservableObject
         // fire OnInstallInfoChanged which resets state.
     }
 
+    /// <summary>
+    /// Requests navigation even when NavigateToPage already holds the target.
+    /// MainWindow reacts to PropertyChanged, and the generated setter suppresses
+    /// it for equal values — so a second navigation to the same page would be
+    /// silently dropped without the null reset.
+    /// </summary>
+    private void RequestNavigate(string page)
+    {
+        NavigateToPage = null;
+        NavigateToPage = page;
+    }
+
     private void OnOperationStatusChanged(object? sender, bool isRunning)
     {
         if (isRunning)
@@ -502,6 +514,10 @@ public partial class ShellViewModel : ObservableObject
             ProgressPercent = 0;
             IsProgressIndeterminate = true;
             CanStopInstall = false;
+
+            // Bring the Updates page forward so the user sees the pending item
+            // and its progress regardless of which page they clicked Install on.
+            RequestNavigate("updates");
         }
         else
         {

--- a/gui/ManagedSoftwareCenter/ViewModels/ShellViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/ShellViewModel.cs
@@ -43,6 +43,13 @@ public partial class ShellViewModel : ObservableObject
     [ObservableProperty]
     public partial bool IsInstalling { get; set; }
 
+    // True when the current run should use the global progress banner (a broad
+    // run: check, install-all, or an externally launched session). False for a
+    // targeted --item run, where progress is rendered inside each item's row
+    // instead. Set at the start of a run; reset when it ends.
+    [ObservableProperty]
+    public partial bool ShowGlobalBanner { get; set; }
+
     [ObservableProperty]
     public partial string ProgressMessage { get; set; } = string.Empty;
 
@@ -126,6 +133,9 @@ public partial class ShellViewModel : ObservableObject
         if (IsManagedSoftwareUpdateRunning())
         {
             IsInstalling = true;
+            // An already-running session was launched outside the GUI (scheduled /
+            // bootstrap), so it is broad — use the global banner.
+            ShowGlobalBanner = true;
             CanRefresh = false;
             ProgressMessage = "Update in progress...";
             ProgressDetail = "Waiting for status...";
@@ -169,7 +179,10 @@ public partial class ShellViewModel : ObservableObject
         ProgressPercent = 0;
         IsProgressIndeterminate = true;
         CanStopInstall = false;
-        
+
+        // A check is a broad run — show the global banner.
+        ShowGlobalBanner = true;
+
         // Now set installing - this will trigger UI updates
         IsInstalling = true;
 
@@ -324,6 +337,7 @@ public partial class ShellViewModel : ObservableObject
         // Re-enable refresh and end installing state
         CanRefresh = true;
         IsInstalling = false;
+        ShowGlobalBanner = false;
 
         // Always fire SessionCompleted when InstallInfo.yaml changes — this ensures
         // the Updates page reloads with fresh data even when IsInstalling was already
@@ -352,10 +366,12 @@ public partial class ShellViewModel : ObservableObject
         {
             case ProgressMessageType.Status:
                 ProgressMessage = message.Message;
+                // Per-item failures are surfaced inline — a red reason on the
+                // item's own row and in the Updates "Problem Items" section — so a
+                // session error needs no interrupting modal.
                 if (message.Error)
                 {
                     IsInstalling = false;
-                    _ = ShowErrorRecoveryDialogAsync(message);
                 }
                 break;
                 
@@ -371,6 +387,7 @@ public partial class ShellViewModel : ObservableObject
                 
             case ProgressMessageType.Complete:
                 IsInstalling = false;
+                ShowGlobalBanner = false;
                 CanRefresh = true;
                 ProgressMessage = "Complete";
                 ProgressDetail = string.Empty;
@@ -382,8 +399,10 @@ public partial class ShellViewModel : ObservableObject
                 
             case ProgressMessageType.Error:
                 IsInstalling = false;
+                ShowGlobalBanner = false;
                 CanRefresh = true;
-                _ = ShowErrorRecoveryDialogAsync(message);
+                // No modal — the failed item shows its reason inline on its row
+                // and under "Problem Items"; an interrupting dialog is redundant.
                 break;
                 
             case ProgressMessageType.RestartRequired:
@@ -409,28 +428,6 @@ public partial class ShellViewModel : ObservableObject
         }
         
         CanStopInstall = message.StopButtonEnabled;
-    }
-
-    private async Task ShowErrorRecoveryDialogAsync(ProgressMessage message)
-    {
-        var itemName = message.ItemName ?? "Unknown";
-        var isRemoval = message.Message?.Contains("remov", StringComparison.OrdinalIgnoreCase) == true;
-
-        var title = isRemoval ? "Removal Error" : "Installation Error";
-        var detail = !string.IsNullOrEmpty(message.Detail) ? message.Detail : message.Message;
-        var guidance = isRemoval
-            ? $"The removal of \"{itemName}\" failed.\n\n{detail}\n\nRemoval will be attempted again. If this situation continues, contact your systems administrator."
-            : $"The installation of \"{itemName}\" failed.\n\n{detail}\n\nInstallation will be attempted again. If this situation continues, contact your systems administrator.";
-
-        try
-        {
-            await _alertService.ShowInfoAsync(title, guidance);
-        }
-        catch
-        {
-            // Dialog might fail if window is not ready
-            _notificationService.ShowInstallFailed(itemName, detail);
-        }
     }
 
     /// <summary>
@@ -476,8 +473,11 @@ public partial class ShellViewModel : ObservableObject
     {
         if (connected && !IsInstalling)
         {
-            // MSU just connected — enter progress mode
+            // MSU connected without the GUI having triggered a targeted run — it
+            // was launched externally (scheduled / bootstrap), so it is broad:
+            // use the global banner.
             IsInstalling = true;
+            ShowGlobalBanner = true;
             CanRefresh = false;
             ProgressMessage = "Update in progress...";
             ProgressDetail = string.Empty;
@@ -513,6 +513,9 @@ public partial class ShellViewModel : ObservableObject
             // "Installing Gimp...") so users immediately see what they kicked
             // off; fall back to the generic message for unattributed triggers.
             IsInstalling = true;
+            // A targeted --item run renders progress per-row; only broad runs
+            // (check / install-all) use the global banner.
+            ShowGlobalBanner = !_triggerService.IsItemScopedOperation;
             CanRefresh = false;
             ProgressMessage = _triggerService.CurrentOperationLabel ?? "Checking for updates...";
             ProgressDetail = string.Empty;

--- a/gui/ManagedSoftwareCenter/ViewModels/SoftwareViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/SoftwareViewModel.cs
@@ -251,7 +251,7 @@ public partial class SoftwareViewModel : ObservableObject
         item.Status = ItemStatus.RemovalRequested;
 
         // Targeted, preflight-skipping trigger — fast feedback for the just-clicked item.
-        await _triggerService.TriggerInstallItemAsync(item.Name);
+        await _triggerService.TriggerInstallItemAsync(item.Name, asRemoval: true);
 
         ApplyFilters();
     }

--- a/gui/ManagedSoftwareCenter/ViewModels/SoftwareViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/SoftwareViewModel.cs
@@ -172,16 +172,24 @@ public partial class SoftwareViewModel : ObservableObject
 
         foreach (var item in _allItems)
         {
-            // Check if user has requested install
+            // Check if user has requested install. The request persists in the
+            // self-serve manifest after the install completes (that's the user's
+            // standing subscription), so only show a pending state while the
+            // item still needs action — otherwise it reads "Install pending"
+            // forever on an installed item.
             if (selfService.ManagedInstalls.Any(x => x.Equals(item.Name, StringComparison.OrdinalIgnoreCase)))
             {
-                item.Status = item.WillBeInstalled ? ItemStatus.WillBeInstalled : ItemStatus.InstallRequested;
                 item.UserRequested = true;
+                item.Status = item.Installed && !item.NeedsUpdate
+                    ? ItemStatus.Installed
+                    : (item.WillBeInstalled ? ItemStatus.WillBeInstalled : ItemStatus.InstallRequested);
             }
-            // Check if user has requested removal
+            // Check if user has requested removal — pending only while still installed.
             else if (selfService.ManagedUninstalls.Any(x => x.Equals(item.Name, StringComparison.OrdinalIgnoreCase)))
             {
-                item.Status = item.WillBeRemoved ? ItemStatus.WillBeRemoved : ItemStatus.RemovalRequested;
+                item.Status = !item.Installed
+                    ? ItemStatus.NotInstalled
+                    : (item.WillBeRemoved ? ItemStatus.WillBeRemoved : ItemStatus.RemovalRequested);
             }
             // Set appropriate status based on installed state
             else if (item.Installed)

--- a/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
@@ -23,6 +23,22 @@ public partial class UpdatesViewModel : ObservableObject
     private readonly IProgressPipeClient _progressClient;
     private readonly ISelfServiceManifestService _selfServiceService;
 
+    // Set by an explicit re-check so the next load drops the lingering
+    // "Installed"/"Removed" rows instead of re-injecting them.
+    private bool _dropCompletedOnNextLoad;
+
+    /// <summary>A row that finished this session (terminal success stage).</summary>
+    private static bool IsDone(InstallableItem x) =>
+        x.LiveStage is "installed" or "removed";
+
+    /// <summary>
+    /// The user navigated away from the Updates page (or did an explicit
+    /// re-check): they have seen the finished rows, so drop the lingering green
+    /// "Installed"/"Removed" rows on the next load instead of keeping them
+    /// forever. Live reloads while the page is visible still retain them.
+    /// </summary>
+    public void DismissCompletedRows() => _dropCompletedOnNextLoad = true;
+
     [ObservableProperty]
     public partial ObservableCollection<InstallableItem> Updates { get; set; } = [];
 
@@ -162,6 +178,19 @@ public partial class UpdatesViewModel : ObservableObject
         IsLoading = true;
         try
         {
+            // Rows that finished this session keep their green "Installed"/"Removed"
+            // check on screen instead of vanishing the instant InstallInfo is
+            // rewritten. Capture them from the current collections before the
+            // rebuild; they are re-injected below and linger until the next
+            // explicit check (which sets _dropCompletedOnNextLoad).
+            var completedRows = _dropCompletedOnNextLoad
+                ? new Dictionary<string, InstallableItem>(StringComparer.OrdinalIgnoreCase)
+                : PendingInstalls.Concat(Updates).Concat(PendingRemovals)
+                    .Where(IsDone)
+                    .GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+            _dropCompletedOnNextLoad = false;
+
             // Updates tab is derived from managed_installs (records for items needing
             // install or update this session). Split by the needs_update flag set by
             // managedsoftwareupdate during the catalog comparison:
@@ -204,6 +233,18 @@ public partial class UpdatesViewModel : ObservableObject
                 requested.WillBeInstalled = true;
                 installsList.Add(requested);
                 known.Add(name);
+            }
+
+            // Re-inject items that finished earlier this session so the result
+            // stays visible (green check) even though they are no longer pending.
+            // They keep their terminal LiveStage, so the row renders the check
+            // and not the "Will be installed/removed" idle label.
+            foreach (var done in completedRows.Values)
+            {
+                if (known.Contains(done.Name)) continue; // still pending/listed
+                if (done.LiveStage == "removed") pendingRemovals.Add(done);
+                else installsList.Add(done);
+                known.Add(done.Name);
             }
 
             // Load icons BEFORE assigning the bound collections — IconImage is a
@@ -252,13 +293,16 @@ public partial class UpdatesViewModel : ObservableObject
             }
             ProblemItems = new ObservableCollection<ProblemItem>(orphanProblems);
 
-            // Update flags
+            // Section visibility includes finished rows (so the green check shows);
+            // the pending COUNT excludes them so the status text and Install Now
+            // reflect only outstanding work. (The nav badge is computed separately
+            // from InstallInfo by the shell, so it clears on its own.)
             HasUpdates = Updates.Count > 0;
             HasPendingInstalls = PendingInstalls.Count > 0;
             HasPendingRemovals = PendingRemovals.Count > 0;
             HasProblems = ProblemItems.Count > 0;
-            TotalUpdateCount = Updates.Count + PendingInstalls.Count + PendingRemovals.Count;
-            IsEmpty = TotalUpdateCount == 0 && !HasProblems;
+            TotalUpdateCount = Updates.Concat(PendingInstalls).Concat(PendingRemovals).Count(x => !IsDone(x));
+            IsEmpty = Updates.Count + PendingInstalls.Count + PendingRemovals.Count == 0 && !HasProblems;
             HasForcedDeadlines = Updates.Concat(PendingInstalls).Any(x => x.HasDeadline);
 
             // Notify HasPendingWork changed
@@ -296,6 +340,9 @@ public partial class UpdatesViewModel : ObservableObject
     /// </summary>
     public async Task CheckForUpdatesAsync()
     {
+        // An explicit re-check is the user acknowledging the last run's results —
+        // drop the lingering "Installed"/"Removed" rows on the reload that follows.
+        _dropCompletedOnNextLoad = true;
         IsLoading = true;
         try
         {
@@ -314,7 +361,8 @@ public partial class UpdatesViewModel : ObservableObject
     [RelayCommand]
     private async Task InstallAllUpdatesAsync()
     {
-        if (!HasPendingWork) return;
+        // Only outstanding work counts — lingering finished rows don't.
+        if (TotalUpdateCount == 0) return;
 
         // Check battery status before installing
         if (!await CheckBatteryAsync()) return;
@@ -326,13 +374,17 @@ public partial class UpdatesViewModel : ObservableObject
         // and it streams per-item lifecycle stages onto each row. Removals are
         // already classified as uninstalls in the self-serve manifest, so naming
         // them with --item triggers the removal.
+        // Exclude rows that already finished this session (lingering green check)
+        // so a second Install Now doesn't re-trigger them.
         var targets = Updates.Concat(PendingInstalls).Concat(PendingRemovals)
+            .Where(x => !IsDone(x))
             .Select(x => x.Name)
             .Where(n => !string.IsNullOrWhiteSpace(n))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         var removalTargets = PendingRemovals
+            .Where(x => !IsDone(x))
             .Select(x => x.Name)
             .Where(n => !string.IsNullOrWhiteSpace(n))
             .ToList();
@@ -343,12 +395,7 @@ public partial class UpdatesViewModel : ObservableObject
             {
                 await _triggerService.TriggerInstallItemsAsync(targets, removalTargets);
             }
-            else
-            {
-                // No named targets (shouldn't happen when HasPendingWork) — fall
-                // back to the full install pass.
-                await _triggerService.TriggerInstallAsync();
-            }
+            // No outstanding targets (only lingering finished rows) — nothing to do.
         }
         catch (InvalidOperationException ex)
         {

--- a/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
@@ -129,6 +129,22 @@ public partial class UpdatesViewModel : ObservableObject
     /// </summary>
     private async void OnProgressReceived(object? sender, ProgressMessage message)
     {
+        // async void fed by external input over the progress channel: an unhandled
+        // exception after an await would crash the process. Catch, log, and ignore
+        // so a malformed/unexpected message can never take the app down.
+        try
+        {
+            await HandleProgressReceivedAsync(message);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[UpdatesViewModel] OnProgressReceived failed for '{message?.ItemName}': {ex}");
+        }
+    }
+
+    private async Task HandleProgressReceivedAsync(ProgressMessage message)
+    {
         if (message.Type != ProgressMessageType.ItemStatus) return;
         if (string.IsNullOrEmpty(message.ItemName)) return;
 

--- a/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
@@ -109,20 +109,30 @@ public partial class UpdatesViewModel : ObservableObject
                             x.Status == ItemStatus.UpdateAvailable ||
                             x.Status == ItemStatus.UpdateWillBeInstalled)
                 .ToList();
+            var installsList = managedInstalls.Except(updatesList).ToList();
+
+            // Load pending removals
+            var removals = await _installInfoService.GetRemovalsAsync();
+            var pendingRemovals = removals.Where(x => x.WillBeRemoved || x.Installed).ToList();
+
+            // Load icons BEFORE assigning the bound collections — IconImage is a
+            // plain property without change notification, so a later assignment
+            // would not update an already-rendered row.
+            foreach (var item in updatesList.Concat(installsList).Concat(pendingRemovals))
+            {
+                item.IconImage = await _iconService.GetIconAsync(item.Name, item.Icon);
+            }
+
             Updates = new ObservableCollection<InstallableItem>(
                 updatesList.OrderBy(x => x.ForceInstallAfterDate.HasValue ? 0 : 1)
                        .ThenBy(x => x.ForceInstallAfterDate ?? DateTime.MaxValue)
                        .ThenBy(x => x.GetDisplayName()));
 
-            var installsList = managedInstalls.Except(updatesList).ToList();
             PendingInstalls = new ObservableCollection<InstallableItem>(
                 installsList.OrderBy(x => x.ForceInstallAfterDate.HasValue ? 0 : 1)
                        .ThenBy(x => x.ForceInstallAfterDate ?? DateTime.MaxValue)
                        .ThenBy(x => x.GetDisplayName()));
 
-            // Load pending removals
-            var removals = await _installInfoService.GetRemovalsAsync();
-            var pendingRemovals = removals.Where(x => x.WillBeRemoved || x.Installed).ToList();
             PendingRemovals = new ObservableCollection<InstallableItem>(pendingRemovals.OrderBy(x => x.GetDisplayName()));
 
             // Load problem items
@@ -148,12 +158,6 @@ public partial class UpdatesViewModel : ObservableObject
                 PendingInstalls.Any(x => 
                     x.RestartAction?.Equals("restart", StringComparison.OrdinalIgnoreCase) == true ||
                     x.RestartAction?.Equals("RequireRestart", StringComparison.OrdinalIgnoreCase) == true);
-
-            // Load icons for all items
-            foreach (var item in Updates.Concat(PendingInstalls).Concat(PendingRemovals))
-            {
-                item.IconImage = await _iconService.GetIconAsync(item.Name, item.Icon);
-            }
 
             // Track days pending for updates and pending installs
             var allPending = Updates.Concat(PendingInstalls).ToList();

--- a/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
@@ -147,12 +147,29 @@ public partial class UpdatesViewModel : ObservableObject
         {
             existing.LiveStageDetail = detail;
             existing.LiveStage = stage;
+            // The engine emits a generic "pending" for every item — including
+            // removals — before the real verb. A removal first seen that way can
+            // land under Pending Installs; once a removal stage arrives, move it
+            // to the removals section so it doesn't show "Removed" under installs.
+            if (stage is "removing" or "removed" && PendingInstalls.Contains(existing))
+            {
+                PendingInstalls.Remove(existing);
+                if (!PendingRemovals.Contains(existing)) PendingRemovals.Add(existing);
+                HasPendingInstalls = PendingInstalls.Count > 0;
+                HasPendingRemovals = true;
+            }
             return;
         }
 
-        // Unknown item: synthesize a row. Removal stages go to the removals
-        // section, everything else to pending installs.
-        var item = new InstallableItem { Name = message.ItemName, LiveStage = stage, LiveStageDetail = detail };
+        // Unknown item: synthesize a row. Resolve the real catalog record first so
+        // it reads properly (display name, version, icon) instead of a bare
+        // placeholder with no name; fall back to just the engine's item name for
+        // anything not in InstallInfo. Removal stages go to the removals section,
+        // everything else to pending installs.
+        var item = await _installInfoService.GetItemByNameAsync(message.ItemName)
+                   ?? new InstallableItem { Name = message.ItemName };
+        item.LiveStage = stage;
+        item.LiveStageDetail = detail;
         item.IconImage = await _iconService.GetIconAsync(item.Name, item.Icon);
 
         if (stage is "removing" or "removed")
@@ -191,6 +208,21 @@ public partial class UpdatesViewModel : ObservableObject
                     .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
             _dropCompletedOnNextLoad = false;
 
+            // A targeted --item run rewrites InstallInfo with only the scheduled
+            // subset, which would drop the OTHER pending rows from the Updates list
+            // mid-run. So the list stays a stable reflection of the whole run,
+            // capture the currently-pending (non-finished) rows while an operation
+            // is in flight; they are re-injected below unless the fresh InstallInfo
+            // shows them already satisfied. Gated on IsOperationRunning so a cold
+            // load (or a broad re-check) still reconciles fully.
+            var carryOverPending = _triggerService.IsOperationRunning
+                ? PendingInstalls.Concat(Updates).Where(x => !IsDone(x))
+                        .Select(x => (item: x, removal: false))
+                    .Concat(PendingRemovals.Where(x => !IsDone(x)).Select(x => (item: x, removal: true)))
+                    .GroupBy(t => t.item.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, (InstallableItem item, bool removal)>(StringComparer.OrdinalIgnoreCase);
+
             // Updates tab is derived from managed_installs (records for items needing
             // install or update this session). Split by the needs_update flag set by
             // managedsoftwareupdate during the catalog comparison:
@@ -201,7 +233,32 @@ public partial class UpdatesViewModel : ObservableObject
             // re-evaluate needs_update). The previous version-string comparison
             // was case- and format-sensitive — use NeedsUpdate as the source of
             // truth.
-            var managedInstalls = await _installInfoService.GetManagedInstallsAsync();
+            // Load the self-serve manifest and optional catalog up front. An
+            // optional item only appears in managed_installs/removals because the
+            // user self-serve requested it (the engine promotes it from optional).
+            // If they have since cancelled that request via My Items "Cancel", drop
+            // it from the Updates list on this live reload instead of waiting for
+            // the next engine run to rewrite InstallInfo. Admin-required items are
+            // never in optional_installs, so they are never filtered this way.
+            var selfServe = await _selfServiceService.GetAllRequestsAsync();
+            var selfServeInstalls = new HashSet<string>(
+                selfServe.ManagedInstalls.Where(n => !string.IsNullOrWhiteSpace(n)),
+                StringComparer.OrdinalIgnoreCase);
+            var selfServeUninstalls = new HashSet<string>(
+                selfServe.ManagedUninstalls.Where(n => !string.IsNullOrWhiteSpace(n)),
+                StringComparer.OrdinalIgnoreCase);
+            var optionalNames = new HashSet<string>(
+                (await _installInfoService.GetOptionalInstallsAsync()).Select(x => x.Name),
+                StringComparer.OrdinalIgnoreCase);
+
+            bool IsCancelledSelfServeInstall(InstallableItem x) =>
+                optionalNames.Contains(x.Name) && !selfServeInstalls.Contains(x.Name);
+            bool IsCancelledSelfServeRemoval(InstallableItem x) =>
+                optionalNames.Contains(x.Name) && !selfServeUninstalls.Contains(x.Name);
+
+            var managedInstalls = (await _installInfoService.GetManagedInstallsAsync())
+                .Where(x => !IsCancelledSelfServeInstall(x))
+                .ToList();
 
             var updatesList = managedInstalls
                 .Where(x => x.NeedsUpdate ||
@@ -210,16 +267,17 @@ public partial class UpdatesViewModel : ObservableObject
                 .ToList();
             var installsList = managedInstalls.Except(updatesList).ToList();
 
-            // Load pending removals
+            // Load pending removals (also dropping just-cancelled self-serve ones).
             var removals = await _installInfoService.GetRemovalsAsync();
-            var pendingRemovals = removals.Where(x => x.WillBeRemoved || x.Installed).ToList();
+            var pendingRemovals = removals
+                .Where(x => (x.WillBeRemoved || x.Installed) && !IsCancelledSelfServeRemoval(x))
+                .ToList();
 
             // Surface self-serve install requests the engine hasn't written into
             // managed_installs yet — a fresh click, or a run that hasn't finished
             // (InstallInfo is only rewritten at the end). Without this an item the
             // user just asked to install ("install-requested") is invisible on the
             // Updates tab until the next full InstallInfo rewrite.
-            var selfServe = await _selfServiceService.GetAllRequestsAsync();
             var known = new HashSet<string>(
                 updatesList.Concat(installsList).Concat(pendingRemovals).Select(x => x.Name),
                 StringComparer.OrdinalIgnoreCase);
@@ -235,6 +293,25 @@ public partial class UpdatesViewModel : ObservableObject
                 known.Add(name);
             }
 
+            // Symmetric to the install surfacing above: a removal the user just
+            // requested (My Items / Software "Remove") lives in the self-serve
+            // manifest's uninstalls, but the engine doesn't write it into
+            // InstallInfo `removals` until the run finishes (minutes later).
+            // Surface it now so it appears under Pending Removals immediately
+            // ("Will be removed") with its real name, version, and icon — installs
+            // and removals stay equally fluid. Skip anything already gone.
+            foreach (var name in selfServe.ManagedUninstalls)
+            {
+                if (string.IsNullOrWhiteSpace(name) || known.Contains(name)) continue;
+                var requested = await _installInfoService.GetItemByNameAsync(name);
+                if (requested == null) continue;
+                if (!requested.Installed) continue; // nothing to remove
+                requested.Status = ItemStatus.RemovalRequested;
+                requested.WillBeRemoved = true;
+                pendingRemovals.Add(requested);
+                known.Add(name);
+            }
+
             // Re-inject items that finished earlier this session so the result
             // stays visible (green check) even though they are no longer pending.
             // They keep their terminal LiveStage, so the row renders the check
@@ -245,6 +322,26 @@ public partial class UpdatesViewModel : ObservableObject
                 if (done.LiveStage == "removed") pendingRemovals.Add(done);
                 else installsList.Add(done);
                 known.Add(done.Name);
+            }
+
+            // Re-inject pending rows a targeted-run subset write dropped, so the
+            // whole run's pending set stays visible. Skip any the fresh InstallInfo
+            // now reports as satisfied (installed, not needing update or removal) so
+            // a completed item can't be resurrected; an item with no fresh record
+            // (e.g. an admin-required install outside the targeted subset) is kept
+            // and reconciles on the next broad check.
+            foreach (var (item, removal) in carryOverPending.Values)
+            {
+                if (known.Contains(item.Name)) continue;
+                // Never resurrect a self-serve request the user just cancelled.
+                if (removal ? IsCancelledSelfServeRemoval(item) : IsCancelledSelfServeInstall(item))
+                    continue;
+                var fresh = await _installInfoService.GetItemByNameAsync(item.Name);
+                if (fresh != null && fresh.Installed && !fresh.NeedsUpdate && !fresh.WillBeRemoved)
+                    continue; // already satisfied — let it drop
+                if (removal) pendingRemovals.Add(item);
+                else installsList.Add(item);
+                known.Add(item.Name);
             }
 
             // Load icons BEFORE assigning the bound collections — IconImage is a

--- a/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
@@ -21,6 +21,7 @@ public partial class UpdatesViewModel : ObservableObject
     private readonly IUpdateTrackingService _updateTrackingService;
     private readonly IAlertService _alertService;
     private readonly IProgressPipeClient _progressClient;
+    private readonly ISelfServiceManifestService _selfServiceService;
 
     [ObservableProperty]
     public partial ObservableCollection<InstallableItem> Updates { get; set; } = [];
@@ -75,7 +76,8 @@ public partial class UpdatesViewModel : ObservableObject
         IIconService iconService,
         IUpdateTrackingService updateTrackingService,
         IAlertService alertService,
-        IProgressPipeClient progressClient)
+        IProgressPipeClient progressClient,
+        ISelfServiceManifestService selfServiceService)
     {
         _installInfoService = installInfoService;
         _triggerService = triggerService;
@@ -83,9 +85,23 @@ public partial class UpdatesViewModel : ObservableObject
         _updateTrackingService = updateTrackingService;
         _alertService = alertService;
         _progressClient = progressClient;
+        _selfServiceService = selfServiceService;
 
         _installInfoService.InstallInfoChanged += OnInstallInfoChanged;
         _progressClient.ProgressReceived += OnProgressReceived;
+        _selfServiceService.RequestsChanged += OnSelfServiceRequestsChanged;
+    }
+
+    /// <summary>
+    /// A self-serve request was added or cancelled elsewhere (e.g. My Items
+    /// "Cancel"). Reload so a cancelled install-requested item drops off the
+    /// Updates tab immediately instead of lingering until the next InstallInfo
+    /// rewrite. Marshalled to the UI thread — the manifest service may raise
+    /// this from a background continuation.
+    /// </summary>
+    private void OnSelfServiceRequestsChanged(object? sender, EventArgs e)
+    {
+        UiDispatcher.Post(() => _ = LoadAsync());
     }
 
     /// <summary>
@@ -104,15 +120,23 @@ public partial class UpdatesViewModel : ObservableObject
         var existing = PendingInstalls.Concat(Updates).Concat(PendingRemovals)
             .FirstOrDefault(x => string.Equals(x.Name, message.ItemName, StringComparison.OrdinalIgnoreCase));
 
+        // For "failed", Message carries the reason (e.g. "Exit code 1603") so the
+        // user sees the exact code on the row instead of an unchanged "Will be
+        // installed". Other stages clear any prior detail.
+        var detail = string.Equals(stage, "failed", StringComparison.OrdinalIgnoreCase)
+            ? message.Message
+            : null;
+
         if (existing != null)
         {
+            existing.LiveStageDetail = detail;
             existing.LiveStage = stage;
             return;
         }
 
         // Unknown item: synthesize a row. Removal stages go to the removals
         // section, everything else to pending installs.
-        var item = new InstallableItem { Name = message.ItemName, LiveStage = stage };
+        var item = new InstallableItem { Name = message.ItemName, LiveStage = stage, LiveStageDetail = detail };
         item.IconImage = await _iconService.GetIconAsync(item.Name, item.Icon);
 
         if (stage is "removing" or "removed")
@@ -161,6 +185,27 @@ public partial class UpdatesViewModel : ObservableObject
             var removals = await _installInfoService.GetRemovalsAsync();
             var pendingRemovals = removals.Where(x => x.WillBeRemoved || x.Installed).ToList();
 
+            // Surface self-serve install requests the engine hasn't written into
+            // managed_installs yet — a fresh click, or a run that hasn't finished
+            // (InstallInfo is only rewritten at the end). Without this an item the
+            // user just asked to install ("install-requested") is invisible on the
+            // Updates tab until the next full InstallInfo rewrite.
+            var selfServe = await _selfServiceService.GetAllRequestsAsync();
+            var known = new HashSet<string>(
+                updatesList.Concat(installsList).Concat(pendingRemovals).Select(x => x.Name),
+                StringComparer.OrdinalIgnoreCase);
+            foreach (var name in selfServe.ManagedInstalls)
+            {
+                if (string.IsNullOrWhiteSpace(name) || known.Contains(name)) continue;
+                var requested = await _installInfoService.GetItemByNameAsync(name);
+                if (requested == null) continue;
+                if (requested.Installed && !requested.NeedsUpdate) continue; // already satisfied
+                requested.Status = ItemStatus.InstallRequested;
+                requested.WillBeInstalled = true;
+                installsList.Add(requested);
+                known.Add(name);
+            }
+
             // Load icons BEFORE assigning the bound collections — IconImage is a
             // plain property without change notification, so a later assignment
             // would not update an already-rendered row.
@@ -181,9 +226,31 @@ public partial class UpdatesViewModel : ObservableObject
 
             PendingRemovals = new ObservableCollection<InstallableItem>(pendingRemovals.OrderBy(x => x.GetDisplayName()));
 
-            // Load problem items
+            // Load problem items and surface each error on its own row rather
+            // than in a separate section: match a problem to the pending install,
+            // update, or removal it belongs to and stamp the row's LiveStageDetail
+            // (the red inline reason). Only problems with no matching row — an
+            // item that isn't otherwise listed — remain in the standalone section
+            // so nothing is silently dropped.
             var problems = await _installInfoService.GetProblemItemsAsync();
-            ProblemItems = new ObservableCollection<ProblemItem>(problems);
+            var rowsByName = Updates.Concat(PendingInstalls).Concat(PendingRemovals)
+                .GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+            var orphanProblems = new List<ProblemItem>();
+            foreach (var problem in problems)
+            {
+                if (!string.IsNullOrWhiteSpace(problem.Name) &&
+                    rowsByName.TryGetValue(problem.Name, out var row))
+                {
+                    row.LiveStageDetail = problem.ErrorMessage;
+                }
+                else
+                {
+                    orphanProblems.Add(problem);
+                }
+            }
+            ProblemItems = new ObservableCollection<ProblemItem>(orphanProblems);
 
             // Update flags
             HasUpdates = Updates.Count > 0;
@@ -252,10 +319,36 @@ public partial class UpdatesViewModel : ObservableObject
         // Check battery status before installing
         if (!await CheckBatteryAsync()) return;
 
-        // Trigger installation of all pending updates
+        // Install exactly the items shown as pending (installs, updates, and
+        // removals) via one targeted `--item ... --no-preflight` run. This is
+        // the same fast path as a single self-serve click — it skips preflight
+        // and the full ~85-item catalog re-evaluation that --installonly forced,
+        // and it streams per-item lifecycle stages onto each row. Removals are
+        // already classified as uninstalls in the self-serve manifest, so naming
+        // them with --item triggers the removal.
+        var targets = Updates.Concat(PendingInstalls).Concat(PendingRemovals)
+            .Select(x => x.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var removalTargets = PendingRemovals
+            .Select(x => x.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToList();
+
         try
         {
-            await _triggerService.TriggerInstallAsync();
+            if (targets.Count > 0)
+            {
+                await _triggerService.TriggerInstallItemsAsync(targets, removalTargets);
+            }
+            else
+            {
+                // No named targets (shouldn't happen when HasPendingWork) — fall
+                // back to the full install pass.
+                await _triggerService.TriggerInstallAsync();
+            }
         }
         catch (InvalidOperationException ex)
         {
@@ -266,13 +359,16 @@ public partial class UpdatesViewModel : ObservableObject
     [RelayCommand]
     private async Task InstallUpdateAsync(InstallableItem item)
     {
+        if (item == null || string.IsNullOrWhiteSpace(item.Name)) return;
+
         // Check battery status before installing
         if (!await CheckBatteryAsync()) return;
 
-        // For individual update installation
+        // Install just this row via the fast targeted path (was previously a
+        // full --installonly run that ignored the item entirely).
         try
         {
-            await _triggerService.TriggerInstallAsync();
+            await _triggerService.TriggerInstallItemAsync(item.Name);
         }
         catch (InvalidOperationException ex)
         {

--- a/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
+++ b/gui/ManagedSoftwareCenter/ViewModels/UpdatesViewModel.cs
@@ -20,6 +20,7 @@ public partial class UpdatesViewModel : ObservableObject
     private readonly IIconService _iconService;
     private readonly IUpdateTrackingService _updateTrackingService;
     private readonly IAlertService _alertService;
+    private readonly IProgressPipeClient _progressClient;
 
     [ObservableProperty]
     public partial ObservableCollection<InstallableItem> Updates { get; set; } = [];
@@ -73,15 +74,60 @@ public partial class UpdatesViewModel : ObservableObject
         ITriggerService triggerService,
         IIconService iconService,
         IUpdateTrackingService updateTrackingService,
-        IAlertService alertService)
+        IAlertService alertService,
+        IProgressPipeClient progressClient)
     {
         _installInfoService = installInfoService;
         _triggerService = triggerService;
         _iconService = iconService;
         _updateTrackingService = updateTrackingService;
         _alertService = alertService;
+        _progressClient = progressClient;
 
         _installInfoService.InstallInfoChanged += OnInstallInfoChanged;
+        _progressClient.ProgressReceived += OnProgressReceived;
+    }
+
+    /// <summary>
+    /// Routes per-item lifecycle stages from the running managedsoftwareupdate
+    /// onto the matching row. Items the engine reports that aren't in the
+    /// current list yet (e.g. a fresh self-serve click whose InstallInfo
+    /// hasn't been rewritten) get a synthetic row so the user sees progress
+    /// immediately. Raised on the UI thread by the progress server.
+    /// </summary>
+    private async void OnProgressReceived(object? sender, ProgressMessage message)
+    {
+        if (message.Type != ProgressMessageType.ItemStatus) return;
+        if (string.IsNullOrEmpty(message.ItemName)) return;
+
+        var stage = message.Detail;
+        var existing = PendingInstalls.Concat(Updates).Concat(PendingRemovals)
+            .FirstOrDefault(x => string.Equals(x.Name, message.ItemName, StringComparison.OrdinalIgnoreCase));
+
+        if (existing != null)
+        {
+            existing.LiveStage = stage;
+            return;
+        }
+
+        // Unknown item: synthesize a row. Removal stages go to the removals
+        // section, everything else to pending installs.
+        var item = new InstallableItem { Name = message.ItemName, LiveStage = stage };
+        item.IconImage = await _iconService.GetIconAsync(item.Name, item.Icon);
+
+        if (stage is "removing" or "removed")
+        {
+            PendingRemovals.Add(item);
+            HasPendingRemovals = true;
+        }
+        else
+        {
+            PendingInstalls.Add(item);
+            HasPendingInstalls = true;
+        }
+        IsEmpty = false;
+        TotalUpdateCount = Updates.Count + PendingInstalls.Count + PendingRemovals.Count;
+        OnPropertyChanged(nameof(HasPendingWork));
     }
 
     /// <summary>

--- a/gui/ManagedSoftwareCenter/Views/CategoriesPage.xaml
+++ b/gui/ManagedSoftwareCenter/Views/CategoriesPage.xaml
@@ -35,14 +35,21 @@
                        Margin="0,16,0,0" />
         </StackPanel>
 
-        <!-- Categories list -->
-        <ListView x:Name="CategoriesList"
+        <!-- Categories grid: fixed-width cards that wrap to fill the window -->
+        <GridView x:Name="CategoriesList"
                   Grid.Row="1"
                   SelectionMode="Single"
-                  SelectionChanged="OnCategorySelectionChanged">
-            <ListView.ItemTemplate>
+                  SelectionChanged="OnCategorySelectionChanged"
+                  IsItemClickEnabled="False">
+            <GridView.ItemContainerStyle>
+                <Style TargetType="GridViewItem">
+                    <Setter Property="Margin" Value="0,0,12,12"/>
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                </Style>
+            </GridView.ItemContainerStyle>
+            <GridView.ItemTemplate>
                 <DataTemplate>
-                    <Border Margin="0,8" Padding="16" 
+                    <Border Width="320" Height="148" Padding="16"
                           Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                           CornerRadius="8"
                           BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
@@ -50,7 +57,7 @@
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
 
                             <!-- Category header -->
@@ -59,20 +66,23 @@
                                           Margin="0,0,10,0" VerticalAlignment="Center"
                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                 <TextBlock Text="{Binding Name}"
-                                           Style="{StaticResource SubtitleTextBlockStyle}" />
-                                <TextBlock Text="{Binding ItemCount}" 
+                                           Style="{StaticResource SubtitleTextBlockStyle}"
+                                           TextTrimming="CharacterEllipsis"
+                                           MaxWidth="180"/>
+                                <TextBlock Text="{Binding ItemCount}"
                                            Margin="8,0,0,0"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            VerticalAlignment="Center" />
-                                <TextBlock Text="items" 
+                                <TextBlock Text="items"
                                            Margin="4,0,0,0"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            VerticalAlignment="Center" />
                             </StackPanel>
 
                             <!-- Preview icons -->
-                            <ItemsControl Grid.Row="1" 
+                            <ItemsControl Grid.Row="1"
                                           ItemsSource="{Binding PreviewItems}"
+                                          VerticalAlignment="Bottom"
                                           Margin="0,12,0,0">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
@@ -94,7 +104,7 @@
                         </Grid>
                     </Border>
                 </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+            </GridView.ItemTemplate>
+        </GridView>
     </Grid>
 </Page>

--- a/gui/ManagedSoftwareCenter/Views/LogWindow.xaml
+++ b/gui/ManagedSoftwareCenter/Views/LogWindow.xaml
@@ -3,83 +3,24 @@
     x:Class="Cimian.GUI.ManagedSoftwareCenter.Views.LogWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Cimian.GUI.ManagedSoftwareCenter.Controls"
     Title="Managed Software Update Log">
 
     <Grid Padding="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <!-- Integrated Title Bar + Toolbar -->
-        <Grid x:Name="AppTitleBar" Grid.Row="0" Padding="12,8,180,8" Height="48"
+        <!-- Integrated Title Bar (drag region) -->
+        <Grid x:Name="AppTitleBar" Grid.Row="0" Padding="16,0,180,0" Height="40"
               Background="Transparent">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-
-            <!-- Search Box -->
-            <TextBox x:Name="SearchBox"
-                     PlaceholderText="Filter log..."
-                     TextChanged="SearchBox_TextChanged"
-                     MaxWidth="300"
-                     HorizontalAlignment="Left"/>
-
-            <!-- Action Buttons -->
-            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4">
-                <ToggleButton x:Name="AutoScrollToggle"
-                              IsChecked="True"
-                              ToolTipService.ToolTip="Auto-scroll to bottom"
-                              Click="AutoScrollToggle_Click">
-                    <FontIcon Glyph="&#xE74B;" FontSize="14"/>
-                </ToggleButton>
-                <Button Click="Refresh_Click"
-                        ToolTipService.ToolTip="Reload log">
-                    <FontIcon Glyph="&#xE72C;" FontSize="14"/>
-                </Button>
-                <Button Click="Clear_Click"
-                        ToolTipService.ToolTip="Clear display">
-                    <FontIcon Glyph="&#xE894;" FontSize="14"/>
-                </Button>
-            </StackPanel>
-        </Grid>
-
-        <!-- Log Content -->
-        <ScrollViewer x:Name="LogScrollViewer" Grid.Row="1"
-                      VerticalScrollBarVisibility="Auto"
-                      HorizontalScrollBarVisibility="Auto">
-            <TextBlock x:Name="LogTextBlock"
-                       FontFamily="Cascadia Mono, Consolas, Courier New"
+            <TextBlock Text="Managed Software Update Log"
                        FontSize="12"
-                       IsTextSelectionEnabled="True"
-                       TextWrapping="Wrap"
-                       Padding="12"
-                       Text="Loading log..."/>
-        </ScrollViewer>
-
-        <!-- Status Bar -->
-        <Grid Grid.Row="2" Padding="12,6"
-              Background="{ThemeResource LayerFillColorDefaultBrush}"
-              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-              BorderThickness="0,1,0,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-
-            <TextBlock x:Name="StatusText"
-                       FontSize="11"
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                       VerticalAlignment="Center"
-                       Text="Watching log file..."/>
-
-            <TextBlock x:Name="LineCountText"
-                       Grid.Column="1"
-                       FontSize="11"
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        VerticalAlignment="Center"/>
         </Grid>
+
+        <!-- Log Viewer -->
+        <controls:LogViewerControl x:Name="LogViewer" Grid.Row="1"/>
     </Grid>
 </Window>

--- a/gui/ManagedSoftwareCenter/Views/LogWindow.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Views/LogWindow.xaml.cs
@@ -1,27 +1,15 @@
-// LogWindow.xaml.cs - Log viewer window for Cimian session logs
-// Finds the most recent session log, displays entries, and tails if running
+// LogWindow.xaml.cs - Standalone log viewer window
+// Thin host around LogViewerControl; opened from the View Log flyout's
+// pop-out button or the Ctrl+L accelerator.
 
-using System.IO;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 namespace Cimian.GUI.ManagedSoftwareCenter.Views;
 
 public partial class LogWindow : Window
 {
-    private const string LogsBaseDir = @"C:\ProgramData\ManagedInstalls\logs";
-    private const int MaxLines = 5000;
-
     private static LogWindow? _instance;
     private static readonly object _instanceLock = new();
-
-    private FileSystemWatcher? _fileWatcher;
-    private FileSystemWatcher? _dirWatcher;
-    private string? _currentLogPath;
-    private string _fullLogText = string.Empty;
-    private string _filterText = string.Empty;
-    private bool _autoScroll = true;
-    private long _lastFileSize;
 
     /// <summary>
     /// Gets or activates the singleton log window.
@@ -36,7 +24,7 @@ public partial class LogWindow : Window
             }
             _instance.Activate();
             // Refresh to latest log whenever brought to front
-            _instance.FindAndLoadLatestLog();
+            _instance.LogViewer.RefreshLog();
             return _instance;
         }
     }
@@ -52,279 +40,33 @@ public partial class LogWindow : Window
         CenterOnScreen();
 
         Closed += OnClosed;
-        FindAndLoadLatestLog();
-        StartWatching();
+        LogViewer.Start();
     }
 
+    /// <summary>
+    /// Centers the window on the work area of its display and clamps the
+    /// position so it can never open outside the visible area. Uses the
+    /// actual window size — centering math must never hardcode dimensions,
+    /// which previously pushed the window off the top of smaller screens.
+    /// </summary>
     private void CenterOnScreen()
     {
         var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         var windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
         var displayArea = Microsoft.UI.Windowing.DisplayArea.GetFromWindowId(
             windowId, Microsoft.UI.Windowing.DisplayAreaFallback.Primary);
-        var x = (displayArea.WorkArea.Width - 2250) / 2;
-        var y = (displayArea.WorkArea.Height - 1500) / 2;
+
+        var work = displayArea.WorkArea;
+        var size = AppWindow.Size;
+
+        var x = work.X + Math.Max(0, (work.Width - size.Width) / 2);
+        var y = work.Y + Math.Max(0, (work.Height - size.Height) / 2);
         AppWindow.Move(new Windows.Graphics.PointInt32(x, y));
-    }
-
-    /// <summary>
-    /// Finds the most recent install.log across all session directories
-    /// Session structure: logs/YYYY-MM-DD/HHMM/install.log
-    /// </summary>
-    private string? FindLatestLogFile()
-    {
-        if (!Directory.Exists(LogsBaseDir)) return null;
-
-        // Get day directories sorted descending
-        var dayDirs = Directory.GetDirectories(LogsBaseDir)
-            .OrderByDescending(d => Path.GetFileName(d))
-            .Take(3); // only check last 3 days
-
-        foreach (var dayDir in dayDirs)
-        {
-            var sessionDirs = Directory.GetDirectories(dayDir)
-                .OrderByDescending(d => Path.GetFileName(d));
-
-            foreach (var sessionDir in sessionDirs)
-            {
-                var installLog = Path.Combine(sessionDir, "install.log");
-                if (File.Exists(installLog))
-                    return installLog;
-
-                var runLog = Path.Combine(sessionDir, "run.log");
-                if (File.Exists(runLog))
-                    return runLog;
-            }
-        }
-
-        return null;
-    }
-
-    private void FindAndLoadLatestLog()
-    {
-        _currentLogPath = FindLatestLogFile();
-        LoadLogFile();
-    }
-
-    private void LoadLogFile()
-    {
-        try
-        {
-            if (_currentLogPath == null || !File.Exists(_currentLogPath))
-            {
-                _fullLogText = Directory.Exists(LogsBaseDir)
-                    ? "No log sessions found. Run 'Check Now' to start a session."
-                    : $"Log directory not found: {LogsBaseDir}";
-                StatusText.Text = _currentLogPath == null ? "No logs found" : "Log file not found";
-                UpdateDisplay();
-                return;
-            }
-
-            // Read with sharing so we don't block the writer
-            using var stream = new FileStream(_currentLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var reader = new StreamReader(stream);
-            var content = reader.ReadToEnd();
-            _lastFileSize = stream.Length;
-
-            // Trim to max lines
-            var lines = content.Split('\n');
-            if (lines.Length > MaxLines)
-            {
-                _fullLogText = string.Join('\n', lines[^MaxLines..]);
-            }
-            else
-            {
-                _fullLogText = content;
-            }
-
-            var lineCount = _fullLogText.Split('\n').Length;
-            LineCountText.Text = $"{lineCount} lines";
-
-            // Show session info in status bar
-            var sessionDir = Path.GetDirectoryName(_currentLogPath);
-            var sessionName = sessionDir != null
-                ? $"{Path.GetFileName(Path.GetDirectoryName(sessionDir))}/{Path.GetFileName(sessionDir)}"
-                : "";
-            StatusText.Text = $"Session: {sessionName}  •  {Path.GetFileName(_currentLogPath)}";
-            UpdateDisplay();
-        }
-        catch (Exception ex)
-        {
-            _fullLogText = $"Error reading log: {ex.Message}";
-            StatusText.Text = "Error reading log file";
-            UpdateDisplay();
-        }
-    }
-
-    private void AppendNewContent()
-    {
-        try
-        {
-            if (_currentLogPath == null || !File.Exists(_currentLogPath)) return;
-
-            using var stream = new FileStream(_currentLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-
-            // If file was truncated/rotated, reload entirely
-            if (stream.Length < _lastFileSize)
-            {
-                LoadLogFile();
-                return;
-            }
-
-            if (stream.Length == _lastFileSize) return;
-
-            // Read only new content
-            stream.Seek(_lastFileSize, SeekOrigin.Begin);
-            using var reader = new StreamReader(stream);
-            var newContent = reader.ReadToEnd();
-            _lastFileSize = stream.Length;
-
-            if (string.IsNullOrEmpty(newContent)) return;
-
-            _fullLogText += newContent;
-
-            // Trim if too long
-            var lines = _fullLogText.Split('\n');
-            if (lines.Length > MaxLines)
-            {
-                _fullLogText = string.Join('\n', lines[^MaxLines..]);
-            }
-
-            var lineCount = _fullLogText.Split('\n').Length;
-            LineCountText.Text = $"{lineCount} lines";
-            UpdateDisplay();
-        }
-        catch
-        {
-            // File might be temporarily locked during write
-        }
-    }
-
-    private void UpdateDisplay()
-    {
-        if (string.IsNullOrEmpty(_filterText))
-        {
-            LogTextBlock.Text = _fullLogText;
-        }
-        else
-        {
-            var lines = _fullLogText.Split('\n');
-            var filtered = lines.Where(l => l.Contains(_filterText, StringComparison.OrdinalIgnoreCase));
-            LogTextBlock.Text = string.Join('\n', filtered);
-        }
-
-        if (_autoScroll)
-        {
-            LogScrollViewer.UpdateLayout();
-            LogScrollViewer.ChangeView(null, LogScrollViewer.ScrollableHeight, null);
-        }
-    }
-
-    private void StartWatching()
-    {
-        // Watch the current log file for changes (tailing)
-        WatchCurrentLogFile();
-
-        // Watch the logs base directory for new sessions
-        try
-        {
-            if (!Directory.Exists(LogsBaseDir)) return;
-
-            _dirWatcher = new FileSystemWatcher(LogsBaseDir)
-            {
-                IncludeSubdirectories = true,
-                NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.FileName,
-                Filter = "*.log",
-                EnableRaisingEvents = true
-            };
-
-            _dirWatcher.Created += (s, e) =>
-            {
-                var name = Path.GetFileName(e.FullPath);
-                if (!name.Equals("install.log", StringComparison.OrdinalIgnoreCase) &&
-                    !name.Equals("run.log", StringComparison.OrdinalIgnoreCase))
-                    return;
-
-                // New session started — switch to it
-                DispatcherQueue.TryEnqueue(() =>
-                {
-                    _currentLogPath = e.FullPath;
-                    _lastFileSize = 0;
-                    LoadLogFile();
-                    WatchCurrentLogFile();
-                });
-            };
-        }
-        catch
-        {
-            // Could not watch for new sessions
-        }
-    }
-
-    private void WatchCurrentLogFile()
-    {
-        _fileWatcher?.Dispose();
-        _fileWatcher = null;
-
-        if (_currentLogPath == null) return;
-
-        try
-        {
-            var dir = Path.GetDirectoryName(_currentLogPath);
-            var file = Path.GetFileName(_currentLogPath);
-
-            if (dir == null || !Directory.Exists(dir)) return;
-
-            _fileWatcher = new FileSystemWatcher(dir, file)
-            {
-                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size,
-                EnableRaisingEvents = true
-            };
-
-            _fileWatcher.Changed += (s, e) =>
-            {
-                DispatcherQueue.TryEnqueue(AppendNewContent);
-            };
-        }
-        catch
-        {
-            // Could not watch log file
-        }
-    }
-
-    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
-    {
-        _filterText = SearchBox.Text;
-        UpdateDisplay();
-    }
-
-    private void AutoScrollToggle_Click(object sender, RoutedEventArgs e)
-    {
-        _autoScroll = AutoScrollToggle.IsChecked == true;
-        if (_autoScroll)
-        {
-            LogScrollViewer.ChangeView(null, LogScrollViewer.ScrollableHeight, null);
-        }
-    }
-
-    private void Refresh_Click(object sender, RoutedEventArgs e)
-    {
-        FindAndLoadLatestLog();
-    }
-
-    private void Clear_Click(object sender, RoutedEventArgs e)
-    {
-        _fullLogText = string.Empty;
-        LogTextBlock.Text = string.Empty;
-        LineCountText.Text = "0 lines";
     }
 
     private void OnClosed(object sender, WindowEventArgs e)
     {
-        _fileWatcher?.Dispose();
-        _fileWatcher = null;
-        _dirWatcher?.Dispose();
-        _dirWatcher = null;
+        LogViewer.Stop();
 
         lock (_instanceLock)
         {

--- a/gui/ManagedSoftwareCenter/Views/MyItemsPage.xaml
+++ b/gui/ManagedSoftwareCenter/Views/MyItemsPage.xaml
@@ -2,7 +2,12 @@
 <Page
     x:Class="Cimian.GUI.ManagedSoftwareCenter.Views.MyItemsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Cimian.GUI.ManagedSoftwareCenter.Converters">
+
+    <Page.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+    </Page.Resources>
 
     <Grid Margin="24">
         <Grid.RowDefinitions>
@@ -90,16 +95,22 @@
                                     Margin="8,0"
                                     VerticalAlignment="Center"
                                     Background="{ThemeResource SubtleFillColorSecondaryBrush}">
-                                <TextBlock Text="{Binding Status}" 
+                                <TextBlock Text="{Binding StatusText}"
                                            FontSize="12"
                                            Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
                             </Border>
 
-                            <!-- Cancel button -->
-                            <Button Grid.Column="3"
-                                    Content="Cancel"
-                                    Click="OnCancelClick"
-                                    Tag="{Binding}" />
+                            <!-- Action: Remove (uninstall) for installed items, else Cancel the request -->
+                            <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="8">
+                                <Button Content="Remove"
+                                        Click="OnRemoveClick"
+                                        Tag="{Binding}"
+                                        Visibility="{Binding ShowRemove, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                <Button Content="Cancel"
+                                        Click="OnCancelClick"
+                                        Tag="{Binding}"
+                                        Visibility="{Binding ShowCancel, Converter={StaticResource BoolToVisibilityConverter}}" />
+                            </StackPanel>
                         </Grid>
                     </Border>
                 </DataTemplate>

--- a/gui/ManagedSoftwareCenter/Views/MyItemsPage.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Views/MyItemsPage.xaml.cs
@@ -72,6 +72,14 @@ public partial class MyItemsPage : Page
         }
     }
 
+    private async void OnRemoveClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.Tag is MyItem item)
+        {
+            await ViewModel.RemoveItemCommand.ExecuteAsync(item);
+        }
+    }
+
     private void ProcessAll_Click(object sender, RoutedEventArgs e)
     {
         _ = ViewModel.ProcessAllCommand.ExecuteAsync(null);

--- a/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
+++ b/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
@@ -12,6 +12,7 @@
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <converters:ItemStageConverter x:Key="ItemStageConverter" />
         <converters:NoStageToVisibilityConverter x:Key="NoStageToVisibilityConverter" />
+        <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
 
     <Grid>
@@ -219,6 +220,16 @@
                                                            Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
                                                            VerticalAlignment="Center"/>
                                             </StackPanel>
+                                            <!-- Failure reason (e.g. "Exit code 1603") while a run reports it -->
+                                            <TextBlock Text="{Binding LiveStageDetail}"
+                                                       FontSize="11"
+                                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                       TextWrapping="Wrap"
+                                                       MaxWidth="300"
+                                                       HorizontalAlignment="Right"
+                                                       TextAlignment="Right"
+                                                       Margin="0,2,0,0"
+                                                       Visibility="{Binding LiveStageDetail, Converter={StaticResource NullToVisibilityConverter}}"/>
                                         </StackPanel>
                                     </Grid>
                                 </Border>
@@ -286,20 +297,33 @@
                                                        Margin="0,2,0,0"/>
                                         </StackPanel>
 
-                                        <!-- Live stage while a run reports -->
-                                        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="6"
-                                                    VerticalAlignment="Center"
-                                                    Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=panel}">
-                                            <ProgressRing Width="16" Height="16" IsActive="True"
-                                                          Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=spinner}"/>
-                                            <FontIcon Glyph="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=glyph}"
-                                                      FontSize="14"
-                                                      Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
-                                                      Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=icon}"/>
-                                            <TextBlock Text="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=text}"
-                                                       FontSize="12"
-                                                       Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
-                                                       VerticalAlignment="Center"/>
+                                        <!-- Live stage while a run reports; the failure
+                                             reason stays visible independently so a
+                                             persisted problem shows even when idle. -->
+                                        <StackPanel Grid.Column="2" VerticalAlignment="Center">
+                                            <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Right"
+                                                        Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=panel}">
+                                                <ProgressRing Width="16" Height="16" IsActive="True"
+                                                              Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=spinner}"/>
+                                                <FontIcon Glyph="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=glyph}"
+                                                          FontSize="14"
+                                                          Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
+                                                          Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=icon}"/>
+                                                <TextBlock Text="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=text}"
+                                                           FontSize="12"
+                                                           Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
+                                                           VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                            <!-- Failure reason (e.g. "Exit code 1603") from a run or a persisted problem -->
+                                            <TextBlock Text="{Binding LiveStageDetail}"
+                                                       FontSize="11"
+                                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                       TextWrapping="Wrap"
+                                                       MaxWidth="300"
+                                                       HorizontalAlignment="Right"
+                                                       TextAlignment="Right"
+                                                       Margin="0,2,0,0"
+                                                       Visibility="{Binding LiveStageDetail, Converter={StaticResource NullToVisibilityConverter}}"/>
                                         </StackPanel>
                                     </Grid>
                                 </Border>
@@ -368,6 +392,16 @@
                                                            Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
                                                            VerticalAlignment="Center"/>
                                             </StackPanel>
+                                            <!-- Failure reason while a run reports it -->
+                                            <TextBlock Text="{Binding LiveStageDetail}"
+                                                       FontSize="11"
+                                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                       TextWrapping="Wrap"
+                                                       MaxWidth="300"
+                                                       HorizontalAlignment="Right"
+                                                       TextAlignment="Right"
+                                                       Margin="0,2,0,0"
+                                                       Visibility="{Binding LiveStageDetail, Converter={StaticResource NullToVisibilityConverter}}"/>
                                         </StackPanel>
                                     </Grid>
                                 </Border>

--- a/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
+++ b/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
@@ -10,6 +10,8 @@
     <Page.Resources>
         <converters:StringFormatConverter x:Key="StringFormatConverter" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <converters:ItemStageConverter x:Key="ItemStageConverter" />
+        <converters:NoStageToVisibilityConverter x:Key="NoStageToVisibilityConverter" />
     </Page.Resources>
 
     <Grid>
@@ -76,6 +78,57 @@
                         </Button>
                     </StackPanel>
                 </Grid>
+
+                <!-- In-flight Progress Banner: shown while managedsoftwareupdate
+                     runs. Items stay visible below with per-row live stages. -->
+                <Border x:Name="ProgressOverlay"
+                        Visibility="Collapsed"
+                        Background="{ThemeResource LayerFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="16"
+                        Margin="0,0,0,16">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <ProgressRing x:Name="ProgressSpinner"
+                                      IsActive="False"
+                                      Width="28" Height="28"
+                                      VerticalAlignment="Center"/>
+
+                        <StackPanel Grid.Column="1" Margin="16,0" VerticalAlignment="Center">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBlock x:Name="ProgressMessageText"
+                                           Text="Working..."
+                                           FontWeight="SemiBold"/>
+                                <TextBlock x:Name="ProgressPercentText"
+                                           Text=""
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            </StackPanel>
+                            <TextBlock x:Name="ProgressDetailText"
+                                       Text=""
+                                       FontSize="12"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextTrimming="CharacterEllipsis"/>
+                            <ProgressBar x:Name="ProgressBar"
+                                         Minimum="0" Maximum="100" Value="0"
+                                         IsIndeterminate="True"
+                                         Margin="0,8,0,0"/>
+                        </StackPanel>
+
+                        <Button x:Name="StopButton"
+                                Grid.Column="2"
+                                Content="Cancel"
+                                Click="StopButton_Click"
+                                VerticalAlignment="Center"
+                                MinWidth="100"/>
+                    </Grid>
+                </Border>
 
                 <!-- Restart Required Warning -->
                 <Border x:Name="RestartWarning"
@@ -144,13 +197,28 @@
                                                        Margin="0,2,0,0"/>
                                         </StackPanel>
 
-                                        <!-- Size -->
-                                        <StackPanel Grid.Column="2" VerticalAlignment="Center" 
+                                        <!-- Status: idle label, or live stage while a run reports -->
+                                        <StackPanel Grid.Column="2" VerticalAlignment="Center"
                                                     HorizontalAlignment="Right">
                                             <TextBlock Text="Will be installed"
                                                        FontSize="12"
                                                        Foreground="{ThemeResource SystemFillColorSuccessBrush}"
-                                                       HorizontalAlignment="Right"/>
+                                                       HorizontalAlignment="Right"
+                                                       Visibility="{Binding LiveStage, Converter={StaticResource NoStageToVisibilityConverter}}"/>
+                                            <StackPanel Orientation="Horizontal" Spacing="6"
+                                                        HorizontalAlignment="Right"
+                                                        Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=panel}">
+                                                <ProgressRing Width="16" Height="16" IsActive="True"
+                                                              Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=spinner}"/>
+                                                <FontIcon Glyph="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=glyph}"
+                                                          FontSize="14"
+                                                          Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
+                                                          Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=icon}"/>
+                                                <TextBlock Text="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=text}"
+                                                           FontSize="12"
+                                                           Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
+                                                           VerticalAlignment="Center"/>
+                                            </StackPanel>
                                         </StackPanel>
                                     </Grid>
                                 </Border>
@@ -218,8 +286,21 @@
                                                        Margin="0,2,0,0"/>
                                         </StackPanel>
 
-                                        <!-- Spacer -->
-                                        <Border Grid.Column="2"/>
+                                        <!-- Live stage while a run reports -->
+                                        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="6"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=panel}">
+                                            <ProgressRing Width="16" Height="16" IsActive="True"
+                                                          Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=spinner}"/>
+                                            <FontIcon Glyph="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=glyph}"
+                                                      FontSize="14"
+                                                      Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
+                                                      Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=icon}"/>
+                                            <TextBlock Text="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=text}"
+                                                       FontSize="12"
+                                                       Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
+                                                       VerticalAlignment="Center"/>
+                                        </StackPanel>
                                     </Grid>
                                 </Border>
                             </DataTemplate>
@@ -268,12 +349,26 @@
                                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                                         </StackPanel>
 
-                                        <!-- Removal Badge -->
-                                        <TextBlock Grid.Column="2" 
-                                                   Text="Will be removed"
-                                                   FontSize="12"
-                                                   Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                                   VerticalAlignment="Center"/>
+                                        <!-- Removal status: idle label, or live stage while a run reports -->
+                                        <StackPanel Grid.Column="2" VerticalAlignment="Center">
+                                            <TextBlock Text="Will be removed"
+                                                       FontSize="12"
+                                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                       Visibility="{Binding LiveStage, Converter={StaticResource NoStageToVisibilityConverter}}"/>
+                                            <StackPanel Orientation="Horizontal" Spacing="6"
+                                                        Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=panel}">
+                                                <ProgressRing Width="16" Height="16" IsActive="True"
+                                                              Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=spinner}"/>
+                                                <FontIcon Glyph="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=glyph}"
+                                                          FontSize="14"
+                                                          Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
+                                                          Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=icon}"/>
+                                                <TextBlock Text="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=text}"
+                                                           FontSize="12"
+                                                           Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
+                                                           VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </StackPanel>
                                     </Grid>
                                 </Border>
                             </DataTemplate>
@@ -347,68 +442,5 @@
                          HorizontalAlignment="Center"
                          VerticalAlignment="Center"/>
 
-        <!-- Full-Page Progress View (during install/check) - takes over entire page -->
-        <Grid x:Name="ProgressOverlay" 
-              Visibility="Collapsed"
-              Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-            
-            <!-- Center the progress content -->
-            <StackPanel HorizontalAlignment="Center" 
-                        VerticalAlignment="Center"
-                        Margin="48">
-                
-                <!-- Progress Ring -->
-                <ProgressRing x:Name="ProgressSpinner"
-                                 IsActive="True"
-                                 Width="80" Height="80"
-                                 HorizontalAlignment="Center"/>
-                
-                <!-- Progress Message -->
-                <TextBlock x:Name="ProgressMessageText"
-                           Text="Checking for updates..."
-                           FontSize="24"
-                           FontWeight="SemiBold"
-                           HorizontalAlignment="Center"
-                           TextAlignment="Center"
-                           Margin="0,32,0,0"/>
-                
-                <!-- Progress Detail -->
-                <TextBlock x:Name="ProgressDetailText"
-                           Text=""
-                           FontSize="14"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                           HorizontalAlignment="Center"
-                           TextAlignment="Center"
-                           TextWrapping="Wrap"
-                           MaxWidth="500"
-                           Margin="0,12,0,0"/>
-                
-                <!-- Progress Bar -->
-                <ProgressBar x:Name="ProgressBar"
-                             Minimum="0"
-                             Maximum="100"
-                             Value="0"
-                             IsIndeterminate="True"
-                             Width="400"
-                             Margin="0,32,0,0"/>
-                
-                <!-- Percent Text -->
-                <TextBlock x:Name="ProgressPercentText"
-                           Text=""
-                           FontSize="13"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                           HorizontalAlignment="Center"
-                           Margin="0,12,0,0"/>
-                
-                <!-- Stop Button -->
-                <Button x:Name="StopButton"
-                        Content="Stop"
-                        Click="StopButton_Click"
-                        HorizontalAlignment="Center"
-                        MinWidth="120"
-                        Margin="0,32,0,0"
-                        Visibility="Collapsed"/>
-            </StackPanel>
-        </Grid>
     </Grid>
 </Page>

--- a/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
+++ b/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
@@ -67,6 +67,20 @@
                                 </Flyout>
                             </Button.Flyout>
                         </Button>
+                        <!-- Always available when idle so the user can re-scan at
+                             any time ("sitting"); sits left of Install Now as the
+                             secondary action. Matches the reference MSC. -->
+                        <Button x:Name="HeaderCheckAgainButton"
+                                Visibility="Collapsed"
+                                Click="CheckNow_Click"
+                                MinWidth="140"
+                                Height="44">
+                            <StackPanel Orientation="Horizontal">
+                                <FontIcon Glyph="&#xE72C;" FontSize="16"/>
+                                <TextBlock Text="Check Again" Margin="8,0,0,0"/>
+                            </StackPanel>
+                        </Button>
+                        <!-- Primary action; shown only when there is pending work. -->
                         <Button x:Name="InstallNowButton"
                                 Style="{StaticResource AccentButtonStyle}"
                                 Click="InstallNow_Click"
@@ -75,6 +89,19 @@
                             <StackPanel Orientation="Horizontal">
                                 <FontIcon Glyph="&#xE896;" FontSize="16"/>
                                 <TextBlock Text="Install Now" Margin="8,0,0,0" FontWeight="SemiBold"/>
+                            </StackPanel>
+                        </Button>
+                        <!-- Replaces Install Now during a targeted per-item run,
+                             where progress lives in the rows and the banner (with
+                             its Cancel) is hidden. -->
+                        <Button x:Name="HeaderStopButton"
+                                Visibility="Collapsed"
+                                Click="StopButton_Click"
+                                MinWidth="140"
+                                Height="44">
+                            <StackPanel Orientation="Horizontal">
+                                <FontIcon Glyph="&#xE71A;" FontSize="16"/>
+                                <TextBlock Text="Stop" Margin="8,0,0,0" FontWeight="SemiBold"/>
                             </StackPanel>
                         </Button>
                     </StackPanel>
@@ -220,6 +247,12 @@
                                                            Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
                                                            VerticalAlignment="Center"/>
                                             </StackPanel>
+                                            <!-- Slim in-row progress for a targeted per-item run -->
+                                            <ProgressBar IsIndeterminate="True"
+                                                         Height="2" Width="160"
+                                                         Margin="0,4,0,0"
+                                                         HorizontalAlignment="Right"
+                                                         Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=bar}"/>
                                             <!-- Failure reason (e.g. "Exit code 1603") while a run reports it -->
                                             <TextBlock Text="{Binding LiveStageDetail}"
                                                        FontSize="11"
@@ -314,6 +347,12 @@
                                                            Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
                                                            VerticalAlignment="Center"/>
                                             </StackPanel>
+                                            <!-- Slim in-row progress for a targeted per-item run -->
+                                            <ProgressBar IsIndeterminate="True"
+                                                         Height="2" Width="160"
+                                                         Margin="0,4,0,0"
+                                                         HorizontalAlignment="Right"
+                                                         Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=bar}"/>
                                             <!-- Failure reason (e.g. "Exit code 1603") from a run or a persisted problem -->
                                             <TextBlock Text="{Binding LiveStageDetail}"
                                                        FontSize="11"
@@ -392,6 +431,12 @@
                                                            Foreground="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=brush}"
                                                            VerticalAlignment="Center"/>
                                             </StackPanel>
+                                            <!-- Slim in-row progress for a targeted per-item run -->
+                                            <ProgressBar IsIndeterminate="True"
+                                                         Height="2" Width="160"
+                                                         Margin="0,4,0,0"
+                                                         HorizontalAlignment="Right"
+                                                         Visibility="{Binding LiveStage, Converter={StaticResource ItemStageConverter}, ConverterParameter=bar}"/>
                                             <!-- Failure reason while a run reports it -->
                                             <TextBlock Text="{Binding LiveStageDetail}"
                                                        FontSize="11"

--- a/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
+++ b/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
@@ -4,7 +4,8 @@
     x:Class="Cimian.GUI.ManagedSoftwareCenter.Views.UpdatesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:converters="using:Cimian.GUI.ManagedSoftwareCenter.Converters">
+    xmlns:converters="using:Cimian.GUI.ManagedSoftwareCenter.Converters"
+    xmlns:controls="using:Cimian.GUI.ManagedSoftwareCenter.Controls">
 
     <Page.Resources>
         <converters:StringFormatConverter x:Key="StringFormatConverter" />
@@ -44,6 +45,24 @@
                                 <FontIcon Glyph="&#xE7C3;" FontSize="16"/>
                                 <TextBlock Text="View Log" Margin="8,0,0,0"/>
                             </StackPanel>
+                            <Button.Flyout>
+                                <Flyout x:Name="LogFlyout"
+                                        Placement="BottomEdgeAlignedRight"
+                                        Opening="LogFlyout_Opening"
+                                        Closed="LogFlyout_Closed">
+                                    <Flyout.FlyoutPresenterStyle>
+                                        <Style TargetType="FlyoutPresenter">
+                                            <Setter Property="MaxWidth" Value="820"/>
+                                            <Setter Property="MaxHeight" Value="560"/>
+                                            <Setter Property="Padding" Value="0"/>
+                                            <Setter Property="CornerRadius" Value="8"/>
+                                        </Style>
+                                    </Flyout.FlyoutPresenterStyle>
+                                    <controls:LogViewerControl x:Name="FlyoutLogViewer"
+                                                               Width="780"
+                                                               Height="520"/>
+                                </Flyout>
+                            </Button.Flyout>
                         </Button>
                         <Button x:Name="InstallNowButton"
                                 Style="{StaticResource AccentButtonStyle}"

--- a/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml.cs
@@ -37,16 +37,14 @@ public partial class UpdatesPage : Page
         
         Loaded += async (s, e) =>
         {
-            // Check progress state on load - must be done after UI is ready
+            // Check progress state on load - must be done after UI is ready.
+            // The banner and the item list coexist, so always load the list.
             if (_shellViewModel?.IsInstalling == true)
             {
                 ShowProgressOverlay();
                 UpdateProgressUI();
             }
-            else
-            {
-                await LoadDataAsync();
-            }
+            await LoadDataAsync();
         };
         
         Unloaded += (s, e) =>
@@ -60,22 +58,25 @@ public partial class UpdatesPage : Page
         };
     }
 
+    // The progress banner sits at the top of the content; the item list stays
+    // visible underneath with per-row live stages, and View Log remains usable.
     private void ShowProgressOverlay()
     {
         ProgressOverlay.Visibility = Visibility.Visible;
         ProgressSpinner.IsActive = true;
-        MainContent.Visibility = Visibility.Collapsed;
+        MainContent.Visibility = Visibility.Visible;
         EmptyState.Visibility = Visibility.Collapsed;
         LoadingIndicator.Visibility = Visibility.Collapsed;
         LoadingIndicator.IsActive = false;
-        InstallNowButton.Visibility = Visibility.Collapsed;
+        InstallNowButton.IsEnabled = false;
+        StopButton.IsEnabled = true;
     }
 
     private void HideProgressOverlay()
     {
         ProgressOverlay.Visibility = Visibility.Collapsed;
         ProgressSpinner.IsActive = false;
-        InstallNowButton.Visibility = Visibility.Visible;
+        InstallNowButton.IsEnabled = ViewModel.HasPendingWork;
     }
 
     private void UpdateProgressUI()
@@ -96,8 +97,6 @@ public partial class UpdatesPage : Page
             ProgressBar.Value = _shellViewModel.ProgressPercent;
             ProgressPercentText.Text = $"{_shellViewModel.ProgressPercent}%";
         }
-        
-        StopButton.Visibility = _shellViewModel.CanStopInstall ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void ShellViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -135,7 +134,11 @@ public partial class UpdatesPage : Page
         {
             LoadingIndicator.IsActive = true;
             LoadingIndicator.Visibility = Visibility.Visible;
-            MainContent.Visibility = Visibility.Collapsed;
+            // Keep content (and the progress banner) on screen during a run.
+            if (_shellViewModel?.IsInstalling != true)
+            {
+                MainContent.Visibility = Visibility.Collapsed;
+            }
             EmptyState.Visibility = Visibility.Collapsed;
             StatusText.Text = "Checking for updates...";
 
@@ -171,8 +174,11 @@ public partial class UpdatesPage : Page
         // Update restart warning
         RestartWarning.Visibility = ViewModel.RequiresRestart ? Visibility.Visible : Visibility.Collapsed;
 
-        // Show empty state or main content
-        bool hasAnyContent = ViewModel.HasPendingWork || ViewModel.HasProblems;
+        // Show empty state or main content. While a run is in flight the
+        // content (with the progress banner) always stays up, even if the
+        // pending list hasn't been populated yet.
+        bool hasAnyContent = ViewModel.HasPendingWork || ViewModel.HasProblems
+            || _shellViewModel?.IsInstalling == true;
         MainContent.Visibility = hasAnyContent ? Visibility.Visible : Visibility.Collapsed;
         EmptyState.Visibility = hasAnyContent ? Visibility.Collapsed : Visibility.Visible;
 

--- a/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml.cs
@@ -39,11 +39,7 @@ public partial class UpdatesPage : Page
         {
             // Check progress state on load - must be done after UI is ready.
             // The banner and the item list coexist, so always load the list.
-            if (_shellViewModel?.IsInstalling == true)
-            {
-                ShowProgressOverlay();
-                UpdateProgressUI();
-            }
+            ApplyRunState();
             await LoadDataAsync();
         };
         
@@ -62,6 +58,52 @@ public partial class UpdatesPage : Page
         };
     }
 
+    // Decides how an in-flight run is presented:
+    //  - broad run (check / install-all / external)  -> global banner, with the
+    //    item list below showing per-row live stages;
+    //  - targeted per-item run                        -> NO banner; progress lives
+    //    inside each item's row, and the header shows "Stop" so Cancel is still
+    //    reachable without the banner;
+    //  - idle                                          -> "Check Again" always
+    //    available (re-scan any time), with "Install Now" added beside it only
+    //    when there is pending work. Matches the reference MSC behavior.
+    private void ApplyRunState()
+    {
+        bool running = _shellViewModel?.IsInstalling == true;
+        bool broad = _shellViewModel?.ShowGlobalBanner == true;
+
+        if (running && broad)
+        {
+            // Broad run: the banner conveys progress and carries its own Cancel.
+            ShowProgressOverlay();
+            UpdateProgressUI();
+            InstallNowButton.Visibility = Visibility.Collapsed;
+            HeaderCheckAgainButton.Visibility = Visibility.Collapsed;
+            HeaderStopButton.Visibility = Visibility.Collapsed;
+        }
+        else if (running && !broad)
+        {
+            // Item-scoped: hide the banner, keep the list (rows carry the
+            // progress), and present Stop in place of Install Now.
+            HideBanner();
+            MainContent.Visibility = Visibility.Visible;
+            InstallNowButton.Visibility = Visibility.Collapsed;
+            HeaderCheckAgainButton.Visibility = Visibility.Collapsed;
+            HeaderStopButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            // Idle: Check Again is always offered; Install Now appears beside it
+            // only when there is outstanding work.
+            HideBanner();
+            HeaderStopButton.Visibility = Visibility.Collapsed;
+            HeaderCheckAgainButton.Visibility = Visibility.Visible;
+            bool hasWork = ViewModel.TotalUpdateCount > 0;
+            InstallNowButton.Visibility = hasWork ? Visibility.Visible : Visibility.Collapsed;
+            InstallNowButton.IsEnabled = hasWork;
+        }
+    }
+
     // The progress banner sits at the top of the content; the item list stays
     // visible underneath with per-row live stages, and View Log remains usable.
     private void ShowProgressOverlay()
@@ -76,11 +118,18 @@ public partial class UpdatesPage : Page
         StopButton.IsEnabled = true;
     }
 
-    private void HideProgressOverlay()
+    // Collapses the global banner without touching the header buttons — the
+    // caller (ApplyRunState) owns Install Now / Stop visibility.
+    private void HideBanner()
     {
         ProgressOverlay.Visibility = Visibility.Collapsed;
         ProgressSpinner.IsActive = false;
-        InstallNowButton.IsEnabled = ViewModel.TotalUpdateCount > 0;
+    }
+
+    private void HideProgressOverlay()
+    {
+        HideBanner();
+        ApplyRunState();
     }
 
     private void UpdateProgressUI()
@@ -110,16 +159,17 @@ public partial class UpdatesPage : Page
             switch (e.PropertyName)
             {
                 case nameof(ShellViewModel.IsInstalling):
-                    if (_shellViewModel?.IsInstalling == true)
+                    ApplyRunState();
+                    if (_shellViewModel?.IsInstalling != true)
                     {
-                        ShowProgressOverlay();
-                    }
-                    else
-                    {
-                        HideProgressOverlay();
                         // Reload data after operation completes
                         _ = LoadDataAsync();
                     }
+                    break;
+                case nameof(ShellViewModel.ShowGlobalBanner):
+                    // Scope can flip after IsInstalling is already set (e.g. an
+                    // external session connects mid-flight) — re-apply.
+                    ApplyRunState();
                     break;
                 case nameof(ShellViewModel.ProgressMessage):
                 case nameof(ShellViewModel.ProgressDetail):
@@ -202,9 +252,10 @@ public partial class UpdatesPage : Page
 
 
 
-        // Update Install button state — only outstanding work, not lingering
-        // finished rows.
-        InstallNowButton.IsEnabled = ViewModel.TotalUpdateCount > 0;
+        // Header buttons (Install Now vs Stop, enablement) follow the run state —
+        // ApplyRunState keeps Install Now disabled/hidden during a run and enabled
+        // only for outstanding work when idle.
+        ApplyRunState();
     }
 
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -236,9 +287,9 @@ public partial class UpdatesPage : Page
         }
         finally
         {
-            // Re-enable after command completes
-            if (sender is Button btn2)
-                btn2.IsEnabled = ViewModel.TotalUpdateCount > 0;
+            // Re-apply run state — if the run launched, Install Now is now hidden
+            // behind Stop; if it didn't, it re-enables only for outstanding work.
+            ApplyRunState();
         }
     }
 

--- a/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml.cs
@@ -49,6 +49,10 @@ public partial class UpdatesPage : Page
         
         Unloaded += (s, e) =>
         {
+            // The user has seen any finished rows (green check) — let the next
+            // load drop them so returning to the page is clean.
+            ViewModel.DismissCompletedRows();
+
             // Unsubscribe from shell events
             if (_shellViewModel != null)
             {
@@ -76,7 +80,7 @@ public partial class UpdatesPage : Page
     {
         ProgressOverlay.Visibility = Visibility.Collapsed;
         ProgressSpinner.IsActive = false;
-        InstallNowButton.IsEnabled = ViewModel.HasPendingWork;
+        InstallNowButton.IsEnabled = ViewModel.TotalUpdateCount > 0;
     }
 
     private void UpdateProgressUI()
@@ -198,8 +202,9 @@ public partial class UpdatesPage : Page
 
 
 
-        // Update Install button state
-        InstallNowButton.IsEnabled = ViewModel.HasPendingWork;
+        // Update Install button state — only outstanding work, not lingering
+        // finished rows.
+        InstallNowButton.IsEnabled = ViewModel.TotalUpdateCount > 0;
     }
 
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -233,7 +238,7 @@ public partial class UpdatesPage : Page
         {
             // Re-enable after command completes
             if (sender is Button btn2)
-                btn2.IsEnabled = ViewModel.HasPendingWork;
+                btn2.IsEnabled = ViewModel.TotalUpdateCount > 0;
         }
     }
 

--- a/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml.cs
+++ b/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml.cs
@@ -260,9 +260,35 @@ public partial class UpdatesPage : Page
         _shellViewModel?.StopInstallCommand.Execute(null);
     }
 
+    // The log opens as a flyout anchored to the button (set via Button.Flyout,
+    // shown automatically on click). The flyout's pop-out button promotes it to
+    // the standalone LogWindow for users who want a persistent view.
+    private bool _logPopOutWired;
+
     private void ViewLog_Click(object sender, RoutedEventArgs e)
     {
-        LogWindow.GetOrActivate();
+        // Flyout opens itself; nothing to do here.
+    }
+
+    private void LogFlyout_Opening(object? sender, object e)
+    {
+        if (!_logPopOutWired)
+        {
+            _logPopOutWired = true;
+            FlyoutLogViewer.ShowPopOutButton = true;
+            FlyoutLogViewer.PopOutRequested += (_, _) =>
+            {
+                LogFlyout.Hide();
+                LogWindow.GetOrActivate();
+            };
+        }
+
+        FlyoutLogViewer.Start();
+    }
+
+    private void LogFlyout_Closed(object? sender, object e)
+    {
+        FlyoutLogViewer.Stop();
     }
 
     private void OnSessionCompleted(object? sender, EventArgs e)

--- a/shared/core/Services/BootstrapArgsBuilder.cs
+++ b/shared/core/Services/BootstrapArgsBuilder.cs
@@ -68,33 +68,37 @@ public static class BootstrapArgsBuilder
 
     /// <summary>
     /// Builds the full Args line for a self-serve targeted install:
-    /// "--item N1 --item N2 ... --no-preflight --show-status -vv".
+    /// "--item N1 N2 ... --no-preflight --show-status -vv".
     /// Order of items is preserved from the input; duplicates (case-insensitive)
     /// are dropped so callers can pass raw click history without preprocessing.
     /// </summary>
+    /// <remarks>
+    /// All names follow a SINGLE --item flag. The engine's --item is a
+    /// CommandLineParser sequence option, populated by "--item A B C" (one flag,
+    /// many values). Repeating the flag ("--item A --item B") throws
+    /// "Option 'item' is defined multiple times" and the run exits 1 — which is
+    /// exactly what stranded multi-item self-serve batches.
+    /// </remarks>
     public static string BuildSelfServeInstallArgs(IEnumerable<string> itemNames)
     {
         if (itemNames == null) throw new ArgumentNullException(nameof(itemNames));
 
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var sb = new StringBuilder();
+        var names = new StringBuilder();
         foreach (var name in itemNames)
         {
             if (string.IsNullOrWhiteSpace(name)) continue;
             if (!seen.Add(name)) continue;
-            if (sb.Length > 0) sb.Append(' ');
-            sb.Append("--item ");
-            sb.Append(QuoteArgument(name));
+            if (names.Length > 0) names.Append(' ');
+            names.Append(QuoteArgument(name));
         }
 
-        if (sb.Length == 0)
+        if (names.Length == 0)
         {
             throw new ArgumentException("At least one item name is required", nameof(itemNames));
         }
 
-        sb.Append(' ');
-        sb.Append(SelfServeTrailingArgs);
-        return sb.ToString();
+        return $"--item {names} {SelfServeTrailingArgs}";
     }
 
     /// <summary>
@@ -117,10 +121,14 @@ public static class BootstrapArgsBuilder
         for (int i = 0; i < tokens.Count; i++)
         {
             if (!string.Equals(tokens[i], "--item", StringComparison.Ordinal)) continue;
-            if (i + 1 >= tokens.Count) break;
-            var next = tokens[i + 1];
-            if (next.StartsWith("--", StringComparison.Ordinal)) continue;
-            result.Add(next);
+            // Collect every value token following the flag until the next switch
+            // ("--item A B C"). Also tolerates the legacy repeated-flag form
+            // ("--item A --item B"), where each inner loop stops at the next --item.
+            for (int j = i + 1; j < tokens.Count; j++)
+            {
+                if (tokens[j].StartsWith("--", StringComparison.Ordinal)) break;
+                result.Add(tokens[j]);
+            }
         }
         return result;
     }

--- a/shared/core/Services/SelfServiceManifestService.cs
+++ b/shared/core/Services/SelfServiceManifestService.cs
@@ -33,6 +33,16 @@ public class SelfServiceManifest
 public interface ISelfServiceManifestService
 {
     /// <summary>
+    /// Raised whenever the manifest changes on disk via this service (an install
+    /// or removal request added, or a request cancelled). Lets viewmodels that
+    /// derive their list from the self-serve manifest (e.g. the Updates tab's
+    /// install-requested cross-reference) refresh immediately instead of waiting
+    /// for the next InstallInfo rewrite. May be raised on a background thread —
+    /// subscribers that touch UI must marshal.
+    /// </summary>
+    event EventHandler? RequestsChanged;
+
+    /// <summary>
     /// Load the self-service manifest from disk
     /// </summary>
     Task<SelfServiceManifest> LoadAsync();
@@ -85,6 +95,9 @@ public class SelfServiceManifestService : ISelfServiceManifestService
     private readonly IDeserializer _deserializer;
     private readonly ISerializer _serializer;
     private readonly SemaphoreSlim _lock = new(1, 1);
+
+    /// <inheritdoc />
+    public event EventHandler? RequestsChanged;
 
     public SelfServiceManifestService(ILogger<SelfServiceManifestService>? logger = null)
     {
@@ -190,6 +203,7 @@ public class SelfServiceManifestService : ISelfServiceManifestService
         manifest.ManagedInstalls.Add(itemName);
 
         await SaveAsync(manifest);
+        RequestsChanged?.Invoke(this, EventArgs.Empty);
         _logger?.LogInformation("Successfully added install request for {ItemName}", itemName);
     }
 
@@ -221,6 +235,7 @@ public class SelfServiceManifestService : ISelfServiceManifestService
         manifest.ManagedUninstalls.Add(itemName);
 
         await SaveAsync(manifest);
+        RequestsChanged?.Invoke(this, EventArgs.Empty);
         _logger?.LogInformation("Successfully added removal request for {ItemName}", itemName);
     }
 
@@ -255,6 +270,7 @@ public class SelfServiceManifestService : ISelfServiceManifestService
         if (wasRemoved)
         {
             await SaveAsync(manifest);
+            RequestsChanged?.Invoke(this, EventArgs.Empty);
             _logger?.LogInformation("Successfully removed request for {ItemName}", itemName);
         }
         else

--- a/tests/Managedsoftwareupdate/InstallerServiceTests.cs
+++ b/tests/Managedsoftwareupdate/InstallerServiceTests.cs
@@ -306,4 +306,23 @@ public class InstallerServiceTests
     }
 
     #endregion
+
+    #region Registry Uninstall Silent-Switch Inference
+
+    [Theory]
+    // NSIS uninstallers -> /S. "uninstall.exe" also starts with "unins" but is NOT
+    // Inno; the regression this guards is it being handed /VERYSILENT and no-op'ing.
+    [InlineData(@"C:\Program Files\VideoLAN\VLC\uninstall.exe", "/S")]
+    [InlineData(@"C:\Program Files\App\uninst.exe", "/S")]
+    [InlineData(@"C:\Program Files\App\Uninstall.exe", "/S")]
+    [InlineData(@"C:\Program Files\App\unins.exe", "/S")]
+    // Inno Setup uninstallers are unins###.exe (unins + digits) -> /VERYSILENT.
+    [InlineData(@"C:\Program Files\App\unins000.exe", "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART")]
+    [InlineData(@"C:\Program Files\App\unins001.exe", "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART")]
+    public void InferRegistrySilentSwitch_PicksEngineCorrectFlags(string exePath, string expected)
+    {
+        Assert.Equal(expected, InstallerService.InferRegistrySilentSwitch(exePath));
+    }
+
+    #endregion
 }

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -214,6 +214,39 @@ public class UpdateModelsTests
         Assert.True(item.IsUninstallable());
     }
 
+    [Fact]
+    public void CatalogItem_IsUninstallable_ExeInstaller_ReturnsTrue()
+    {
+        // An exe/NSIS app with no explicit uninstaller block is still removable:
+        // UninstallAsync drives the uninstaller the app registered in the Windows
+        // uninstall registry. This is the removal mechanism and is independent of
+        // unattended_uninstall (which only governs silent background removal).
+        var item = new CatalogItem
+        {
+            Uninstallable = true,
+            Uninstaller = [],
+            Installer = new InstallerInfo { Type = "exe" },
+            UnattendedUninstall = false
+        };
+
+        Assert.True(item.IsUninstallable());
+    }
+
+    [Fact]
+    public void CatalogItem_IsUninstallable_ExeButOptedOut_ReturnsFalse()
+    {
+        // uninstallable:false is the explicit admin opt-out and wins even for an exe
+        // app — the package is declared non-removable.
+        var item = new CatalogItem
+        {
+            Uninstallable = false,
+            Uninstaller = [],
+            Installer = new InstallerInfo { Type = "exe" }
+        };
+
+        Assert.False(item.IsUninstallable());
+    }
+
     #endregion
 
     #region InstallerInfo Tests

--- a/tests/Shared/BootstrapArgsBuilderTests.cs
+++ b/tests/Shared/BootstrapArgsBuilderTests.cs
@@ -33,17 +33,19 @@ public class BootstrapArgsBuilderTests
     }
 
     [Fact]
-    public void BuildSelfServeInstallArgs_MultipleItems_EmitsItemFlagPerEntry()
+    public void BuildSelfServeInstallArgs_MultipleItems_EmitsSingleItemFlag()
     {
+        // One --item flag with all values — repeated flags crash the engine's
+        // CommandLineParser sequence option ("defined multiple times" -> exit 1).
         var args = BootstrapArgsBuilder.BuildSelfServeInstallArgs(new[] { "Gimp", "Cyberduck" });
-        Assert.Equal("--item Gimp --item Cyberduck --no-preflight --show-status -vv", args);
+        Assert.Equal("--item Gimp Cyberduck --no-preflight --show-status -vv", args);
     }
 
     [Fact]
     public void BuildSelfServeInstallArgs_QuotesNamesWithSpaces()
     {
         var args = BootstrapArgsBuilder.BuildSelfServeInstallArgs(new[] { "VS Code", "Gimp" });
-        Assert.Equal("--item \"VS Code\" --item Gimp --no-preflight --show-status -vv", args);
+        Assert.Equal("--item \"VS Code\" Gimp --no-preflight --show-status -vv", args);
     }
 
     [Fact]

--- a/tests/gui-harness/MscHarness.ps1
+++ b/tests/gui-harness/MscHarness.ps1
@@ -1,0 +1,457 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Headless driver for Managed Software Center (MSC) self-service flows.
+
+.DESCRIPTION
+  The MSC window is a thin shell. Every button does exactly two things:
+    1. mutate  C:\ProgramData\ManagedInstalls\SelfServeManifest.yaml
+    2. run the engine (managedsoftwareupdate) with a --item filter
+  ...and then reads the result back from InstallInfo.yaml.
+
+  This module reproduces that contract so any GUI interaction can be exercised
+  and asserted from the terminal -- no WinUI window, no clicking, no waiting on
+  the 10s CimianWatcher poll. Plan mode (--checkonly) verifies the *decision*
+  (will-be-installed / will-be-removed) in seconds without touching the system;
+  -Apply performs the real install/removal only when you ask for it.
+
+  Canonical contract (do not duplicate logic -- mirror it):
+    GUI mutation:  shared/core/Services/SelfServiceManifestService.cs
+    GUI trigger:   gui/ManagedSoftwareCenter/Services/TriggerService.cs
+    Flag args:     shared/core/Services/BootstrapArgsBuilder.cs
+    Engine write:  cli/managedsoftwareupdate/Services/UpdateEngine.cs (WriteInstallInfo)
+    Paths:         shared/core/Services/CimianPaths.cs
+
+.EXAMPLE
+  . .\MscHarness.ps1            # dot-source to load the functions
+  Show-MscState                # what the Updates tab would show right now
+  Invoke-MscInstall Blender    # plan: mimic clicking Install on Blender (safe, no install)
+  Invoke-MscInstall Blender -Apply   # actually install it
+  Invoke-MscRemove VLC         # plan: mimic clicking Remove on VLC
+  Clear-MscStuck Gimp          # unstick a wedged pending item
+  Invoke-MscScenario Blender   # full install->assert->remove->assert round trip (plan mode)
+
+.EXAMPLE
+  # One-shot CLI form (no dot-sourcing):
+  pwsh .\MscHarness.ps1 state
+  pwsh .\MscHarness.ps1 install Blender
+  pwsh .\MscHarness.ps1 remove VLC -Apply
+  pwsh .\MscHarness.ps1 clear Gimp
+#>
+
+# ----------------------------------------------------------------------------
+# Paths -- keep in sync with shared/core/Services/CimianPaths.cs
+# ----------------------------------------------------------------------------
+$script:DataDir     = 'C:\ProgramData\ManagedInstalls'
+$script:SelfServe   = Join-Path $script:DataDir 'SelfServeManifest.yaml'
+$script:InstallInfo = Join-Path $script:DataDir 'InstallInfo.yaml'
+$script:FlagFile    = Join-Path $script:DataDir '.cimian.bootstrap'
+$script:StateJson   = Join-Path $script:DataDir 'reports\state.json'
+$script:Msu         = 'C:\Program Files\Cimian\managedsoftwareupdate.exe'
+
+Import-Module powershell-yaml -ErrorAction Stop
+
+function Test-Elevated {
+    ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+    ).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+}
+
+# ----------------------------------------------------------------------------
+# Engine runner -- the only thing that needs elevation
+# ----------------------------------------------------------------------------
+function Invoke-Msu {
+    <#  Runs managedsoftwareupdate with the given args, captures output + exit code.
+        Mirrors how CimianWatcher launches the engine, minus the service hop. #>
+    [CmdletBinding()]
+    param([Parameter(ValueFromRemainingArguments)] [string[]] $MsuArgs)
+
+    if (-not (Test-Path $script:Msu)) { throw "managedsoftwareupdate not found at $script:Msu" }
+
+    Write-Host "  > managedsoftwareupdate $($MsuArgs -join ' ')" -ForegroundColor DarkGray
+    $sw = [Diagnostics.Stopwatch]::StartNew()
+    if (Test-Elevated) {
+        $out = & $script:Msu @MsuArgs 2>&1 | Out-String
+    } else {
+        $out = & sudo $script:Msu @MsuArgs 2>&1 | Out-String
+    }
+    $sw.Stop()
+    $code = $LASTEXITCODE
+    if ($code -ne 0) {
+        Write-Host "  engine exit=$code -- last 20 lines:" -ForegroundColor Red
+        ($out -split "`r?`n" | Where-Object { $_.Trim() } | Select-Object -Last 20) |
+            ForEach-Object { Write-Host "    $_" -ForegroundColor DarkYellow }
+    }
+    [pscustomobject]@{
+        ExitCode = $code
+        Seconds  = [math]::Round($sw.Elapsed.TotalSeconds, 1)
+        Output   = $out
+    }
+}
+
+# ----------------------------------------------------------------------------
+# SelfServeManifest.yaml -- read / mutate / write
+# Mirrors SelfServiceManifestService.{AddInstallRequest,AddRemovalRequest,RemoveRequest}Async
+# ----------------------------------------------------------------------------
+function Get-MscSelfServe {
+    if (-not (Test-Path $script:SelfServe)) {
+        return [pscustomobject]@{ ManagedInstalls=@(); ManagedUninstalls=@(); OptionalInstalls=@() }
+    }
+    $y = Get-Content $script:SelfServe -Raw | ConvertFrom-Yaml
+    [pscustomobject]@{
+        ManagedInstalls   = @($y.managed_installs)   | Where-Object { $_ }
+        ManagedUninstalls = @($y.managed_uninstalls) | Where-Object { $_ }
+        OptionalInstalls  = @($y.optional_installs)  | Where-Object { $_ }
+    }
+}
+
+function Set-MscSelfServe {
+    param([Parameter(Mandatory)] $Manifest)
+    # Format manually to match the on-disk style the C# service writes
+    # (list items flush-left, empty lists as []).
+    $sb = [Text.StringBuilder]::new()
+    [void]$sb.AppendLine('name: SelfServeManifest')
+    foreach ($pair in @(
+        @('managed_installs',   $Manifest.ManagedInstalls),
+        @('managed_uninstalls', $Manifest.ManagedUninstalls),
+        @('optional_installs',  $Manifest.OptionalInstalls))) {
+        $key = $pair[0]; $list = @($pair[1]) | Where-Object { $_ }
+        if ($list.Count -eq 0) { [void]$sb.AppendLine("${key}: []"); continue }
+        [void]$sb.AppendLine("${key}:")
+        foreach ($n in $list) { [void]$sb.AppendLine("- $n") }
+    }
+    Set-Content -Path $script:SelfServe -Value $sb.ToString().TrimEnd() -Encoding utf8
+}
+
+function Add-MscInstallRequest {
+    param([Parameter(Mandatory)] [string] $Name)
+    $m = Get-MscSelfServe
+    $m.ManagedUninstalls = @($m.ManagedUninstalls | Where-Object { $_ -ne $Name })          # cancel any pending removal
+    if ($m.ManagedInstalls -notcontains $Name) { $m.ManagedInstalls = @($m.ManagedInstalls) + $Name }
+    Set-MscSelfServe $m
+}
+
+function Add-MscRemovalRequest {
+    param([Parameter(Mandatory)] [string] $Name)
+    $m = Get-MscSelfServe
+    $m.ManagedInstalls  = @($m.ManagedInstalls  | Where-Object { $_ -ne $Name })            # cancel any pending install
+    $m.OptionalInstalls = @($m.OptionalInstalls | Where-Object { $_ -ne $Name })
+    if ($m.ManagedUninstalls -notcontains $Name) { $m.ManagedUninstalls = @($m.ManagedUninstalls) + $Name }
+    Set-MscSelfServe $m
+}
+
+function Remove-MscRequest {
+    param([Parameter(Mandatory)] [string] $Name)
+    $m = Get-MscSelfServe
+    $m.ManagedInstalls   = @($m.ManagedInstalls   | Where-Object { $_ -ne $Name })
+    $m.ManagedUninstalls = @($m.ManagedUninstalls | Where-Object { $_ -ne $Name })
+    $m.OptionalInstalls  = @($m.OptionalInstalls  | Where-Object { $_ -ne $Name })
+    Set-MscSelfServe $m
+}
+
+# ----------------------------------------------------------------------------
+# InstallInfo.yaml -- the observable result the GUI renders
+# ----------------------------------------------------------------------------
+function Get-MscState {
+    <#  Flattens InstallInfo.yaml into one row per item, the same data the
+        Software/Updates tabs bind to. #>
+    if (-not (Test-Path $script:InstallInfo)) { return @() }
+    $y = Get-Content $script:InstallInfo -Raw | ConvertFrom-Yaml
+    $rows = foreach ($section in 'managed_installs','removals','optional_installs','problem_items') {
+        foreach ($it in @($y.$section)) {
+            if (-not $it.name) { continue }
+            [pscustomobject]@{
+                Section      = $section
+                Name         = $it.name
+                Version      = $it.version_to_install
+                Installed    = [bool]$it.installed
+                Status       = $it.status
+                WillInstall  = [bool]$it.will_be_installed
+                WillRemove   = [bool]$it.will_be_removed
+                NeedsUpdate  = [bool]$it.needs_update
+                Uninstallable= [bool]$it.uninstallable
+                Error        = $it.error_message
+            }
+        }
+    }
+    @($rows)
+}
+
+function Show-MscState {
+    <#  Renders what the Updates tab would show: pending installs + removals. #>
+    $all = Get-MscState
+    # Dedupe by Name -- an item can appear in both its primary section and
+    # optional_installs; the GUI shows it once.
+    $pendIn  = @($all | Where-Object { $_.WillInstall } | Sort-Object Name -Unique)
+    $pendOut = @($all | Where-Object { $_.WillRemove } | Sort-Object Name -Unique)
+    $probs   = @($all | Where-Object { $_.Section -eq 'problem_items' } | Sort-Object Name -Unique)
+
+    Write-Host "`nUpdates tab  --  $($pendIn.Count + $pendOut.Count) item(s) pending" -ForegroundColor Cyan
+    if ($pendIn.Count)  { Write-Host "`n  Pending Installs:" -ForegroundColor Green
+        $pendIn  | Format-Table Name, Version, Status -AutoSize | Out-Host }
+    if ($pendOut.Count) { Write-Host "  Pending Removals:" -ForegroundColor Yellow
+        $pendOut | Format-Table Name, Version, Status -AutoSize | Out-Host }
+    if ($probs.Count)   { Write-Host "  Problem Items:" -ForegroundColor Red
+        $probs   | Format-Table Name, Error -AutoSize | Out-Host }
+    if (-not ($pendIn.Count -or $pendOut.Count)) { Write-Host "  (nothing pending)`n" -ForegroundColor DarkGray }
+
+    Write-Host "SelfServeManifest:" -ForegroundColor Cyan
+    $ss = Get-MscSelfServe
+    Write-Host "  managed_installs  : $($ss.ManagedInstalls   -join ', ')"
+    Write-Host "  managed_uninstalls: $($ss.ManagedUninstalls -join ', ')`n"
+}
+
+# ----------------------------------------------------------------------------
+# GUI button equivalents
+# ----------------------------------------------------------------------------
+function Write-MscFlag {
+    <#  Mirrors TriggerService.WriteFlagFileAsync -- drops the bootstrap flag for
+        CimianWatcher to consume. Used by -ViaWatcher to exercise the real IPC. #>
+    param([Parameter(Mandatory)] [string] $ArgsLine)
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    "Bootstrap triggered at: $ts`nSource: MscHarness`nArgs: $ArgsLine`n" |
+        Set-Content -Path $script:FlagFile -Encoding utf8
+    Write-Host "  flag written: Args: $ArgsLine" -ForegroundColor DarkGray
+}
+
+function Wait-MscFlagConsumed {
+    param([int] $TimeoutSec = 120)
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        if (-not (Test-Path $script:FlagFile)) { return $true }   # watcher deleted it = consumed
+        Start-Sleep -Milliseconds 500
+    }
+    return $false
+}
+
+function Invoke-MscInstall {
+    <#  Mimics clicking "Install" on an optional item.
+        Default = plan mode (--checkonly): proves the engine WILL install it, no install.
+        -Apply  = actually install.  -ViaWatcher = go through the flag-file + service. #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string] $Name, [switch] $Apply, [switch] $ViaWatcher)
+
+    Write-Host "`n[Install click] $Name" -ForegroundColor Cyan
+    Add-MscInstallRequest $Name                                   # step 1: mutate SelfServe
+    Write-Host "  SelfServe.managed_installs += $Name" -ForegroundColor DarkGray
+
+    $a = @('--item', $Name, '--no-preflight', '-vv')             # step 2: run engine targeted
+    if (-not $Apply) { $a += '--checkonly' }
+
+    if ($ViaWatcher) {
+        Write-MscFlag (($a | Where-Object { $_ -ne '--checkonly' }) -join ' ')
+        if (Wait-MscFlagConsumed) { Write-Host "  watcher consumed the flag" -ForegroundColor DarkGray }
+        else { Write-Host "  TIMEOUT waiting for CimianWatcher" -ForegroundColor Red }
+    } else {
+        $r = Invoke-Msu @a
+        Write-Host "  engine exit=$($r.ExitCode) in $($r.Seconds)s" -ForegroundColor DarkGray
+    }
+    Show-MscItem $Name
+}
+
+function Invoke-MscRemove {
+    <#  Mimics clicking "Remove" on an installed item. Plan mode by default. #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string] $Name, [switch] $Apply, [switch] $ViaWatcher)
+
+    Write-Host "`n[Remove click] $Name" -ForegroundColor Cyan
+    Add-MscRemovalRequest $Name
+    Write-Host "  SelfServe.managed_uninstalls += $Name" -ForegroundColor DarkGray
+
+    $a = @('--item', $Name, '--no-preflight', '-vv')
+    if (-not $Apply) { $a += '--checkonly' }
+
+    if ($ViaWatcher) {
+        Write-MscFlag (($a | Where-Object { $_ -ne '--checkonly' }) -join ' ')
+        if (Wait-MscFlagConsumed) { Write-Host "  watcher consumed the flag" -ForegroundColor DarkGray }
+        else { Write-Host "  TIMEOUT waiting for CimianWatcher" -ForegroundColor Red }
+    } else {
+        $r = Invoke-Msu @a
+        Write-Host "  engine exit=$($r.ExitCode) in $($r.Seconds)s" -ForegroundColor DarkGray
+    }
+    Show-MscItem $Name
+}
+
+function Invoke-MscCancel {
+    <#  Mimics "Cancel" on a pending request -- drops it from SelfServe, refreshes state. #>
+    param([Parameter(Mandatory)] [string] $Name)
+    Write-Host "`n[Cancel click] $Name" -ForegroundColor Cyan
+    Remove-MscRequest $Name
+    [void](Invoke-Msu '--checkonly' '--no-preflight')
+    Show-MscItem $Name
+}
+
+function Invoke-MscInstallNow {
+    <#  Mimics the Updates tab "Install Now" -- one targeted batch over everything pending. #>
+    [CmdletBinding()] param([switch] $Apply, [switch] $ViaWatcher)
+    $targets = @(Get-MscState | Where-Object { $_.WillInstall -or $_.WillRemove } |
+                 Select-Object -Expand Name -Unique)
+    if (-not $targets) { Write-Host "Nothing pending." -ForegroundColor DarkGray; return }
+    Write-Host "`n[Install Now] $($targets -join ', ')" -ForegroundColor Cyan
+
+    $a = @(); foreach ($t in $targets) { $a += '--item'; $a += $t }
+    $a += '--no-preflight','-vv'
+    if (-not $Apply) { $a += '--checkonly' }
+
+    if ($ViaWatcher) {
+        Write-MscFlag (($a | Where-Object { $_ -ne '--checkonly' }) -join ' ')
+        if (-not (Wait-MscFlagConsumed)) { Write-Host "  TIMEOUT" -ForegroundColor Red }
+    } else {
+        $r = Invoke-Msu @a
+        Write-Host "  engine exit=$($r.ExitCode) in $($r.Seconds)s" -ForegroundColor DarkGray
+    }
+    Show-MscState
+}
+
+function Show-MscItem {
+    param([Parameter(Mandatory)] [string] $Name)
+    $row = Get-MscState | Where-Object { $_.Name -eq $Name } | Select-Object -First 1
+    if ($row) { $row | Format-List Name, Section, Installed, Status, WillInstall, WillRemove, Uninstallable | Out-Host }
+    else { Write-Host "  ($Name not present in InstallInfo)" -ForegroundColor DarkGray }
+}
+
+# ----------------------------------------------------------------------------
+# Stuck-state tooling
+# ----------------------------------------------------------------------------
+function Get-MscLoopState {
+    <#  Shows LoopGuard suppression -- why an item silently refuses to (re)install. #>
+    if (-not (Test-Path $script:StateJson)) { Write-Host "(no loop state)"; return }
+    $j = Get-Content $script:StateJson -Raw | ConvertFrom-Json
+    $j.loop_guard.packages.PSObject.Properties | ForEach-Object {
+        $p = $_.Value
+        [pscustomobject]@{
+            Package        = $p.package_name
+            Attempts       = $p.attempt_count
+            Sessions       = $p.session_count
+            SuppressedUntil= $p.suppressed_until
+            Reason         = $p.suppression_reason
+        }
+    } | Format-Table -AutoSize | Out-Host
+}
+
+function Clear-MscNsisOrphans {
+    <#  Kills orphaned NSIS installer/uninstaller dialogs left behind when an
+        installer is launched without a silent flag (e.g. the pre-fix VLC bug:
+        an uninstaller handed Inno /VERYSILENT, which NSIS ignores, pops a
+        "Installer Language" dialog and sits forever). NSIS relaunches its
+        (un)installer from %TEMP% as Au_.exe / Un_*.exe, and the engine runs as
+        SYSTEM, so these survive a user-context Stop-Process — elevate to clear.
+        Returns the number of processes killed. #>
+    [CmdletBinding()]
+    param()
+
+    $names = @('Un','Un_A','Au_','uninstall','setup')
+    $procs = Get-Process -Name $names -ErrorAction SilentlyContinue
+    if (-not $procs) { Write-Host "[NSIS sweep] no orphaned installer dialogs" -ForegroundColor DarkGray; return 0 }
+
+    $list = ($procs | ForEach-Object { "$($_.Name)#$($_.Id)" }) -join ', '
+    Write-Host "[NSIS sweep] killing $($procs.Count) orphan(s): $list" -ForegroundColor Yellow
+    # User-context first, then sudo for the elevated survivors.
+    $procs | Stop-Process -Force -ErrorAction SilentlyContinue
+    $survivors = Get-Process -Name $names -ErrorAction SilentlyContinue
+    if ($survivors) {
+        $nameArg = ($names | ForEach-Object { "'$_'" }) -join ','
+        & sudo pwsh -NoProfile -Command "Get-Process -Name $nameArg -ErrorAction SilentlyContinue | Stop-Process -Force" 2>$null
+    }
+    # Leftover NSIS temp dirs (~nsu*.tmp) — harmless but tidy up.
+    Get-ChildItem $env:TEMP -Directory -Filter '~nsu*' -ErrorAction SilentlyContinue |
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    $procs.Count
+}
+
+function Clear-MscStuck {
+    <#  Unsticks a wedged pending item:
+          1. drop it from SelfServeManifest (stop re-requesting it),
+          2. clear its LoopGuard suppression,
+          3. sweep orphaned NSIS installer dialogs,
+          4. refresh InstallInfo so the GUI stops showing it pending.
+        Use -All to clear every LoopGuard suppression. #>
+    [CmdletBinding()]
+    param([string] $Name, [switch] $All)
+
+    [void](Clear-MscNsisOrphans)
+
+    if ($All) {
+        Write-Host "`n[Clear stuck] ALL loop suppression" -ForegroundColor Cyan
+        [void](Invoke-Msu '--clear-loop' 'all')
+    } elseif ($Name) {
+        Write-Host "`n[Clear stuck] $Name" -ForegroundColor Cyan
+        Remove-MscRequest $Name
+        Write-Host "  removed $Name from SelfServeManifest" -ForegroundColor DarkGray
+        [void](Invoke-Msu '--clear-loop' $Name)
+    } else {
+        throw "Specify -Name <item> or -All"
+    }
+    [void](Invoke-Msu '--checkonly' '--no-preflight')
+    Show-MscState
+}
+
+# ----------------------------------------------------------------------------
+# Assertions + scenario runner
+# ----------------------------------------------------------------------------
+$script:Assertions = [Collections.Generic.List[object]]::new()
+function Assert-Msc {
+    param([Parameter(Mandatory)] [string] $Desc, [Parameter(Mandatory)] [bool] $Condition)
+    $ok = [bool]$Condition
+    $script:Assertions.Add([pscustomobject]@{ Pass = $ok; Desc = $Desc })
+    $glyph = if ($ok) { 'PASS' } else { 'FAIL' }
+    $color = if ($ok) { 'Green' } else { 'Red' }
+    Write-Host ("  [{0}] {1}" -f $glyph, $Desc) -ForegroundColor $color
+    $ok
+}
+
+function Get-MscItemRow { param([string] $Name) Get-MscState | Where-Object { $_.Name -eq $Name } | Select-Object -First 1 }
+
+function Invoke-MscScenario {
+    <#  Full round trip for one item, the headless equivalent of a manual click-test:
+          install (plan) -> assert will-be-installed
+          [-Apply] install -> assert installed
+          remove (plan)  -> assert will-be-removed
+          [-Apply] remove -> assert not installed
+        Default is plan mode (fast, no system change). -Apply does the real installs. #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string] $Name, [switch] $Apply)
+
+    $script:Assertions.Clear()
+    Write-Host "`n=== Scenario: $Name ($(if ($Apply) {'APPLY'} else {'PLAN'})) ===" -ForegroundColor Magenta
+
+    Invoke-MscInstall $Name -Apply:$Apply | Out-Null
+    $row = Get-MscItemRow $Name
+    if ($Apply) { Assert-Msc "$Name installed after Install"      ([bool]$row.Installed) | Out-Null }
+    else        { Assert-Msc "$Name marked will-be-installed"     ($row.Status -eq 'will-be-installed') | Out-Null }
+
+    Invoke-MscRemove $Name -Apply:$Apply | Out-Null
+    $row = Get-MscItemRow $Name
+    if ($Apply) { Assert-Msc "$Name not installed after Remove"   (-not [bool]$row.Installed) | Out-Null }
+    else        { Assert-Msc "$Name marked will-be-removed"       ($row.Status -eq 'will-be-removed') | Out-Null }
+
+    # Leave SelfServe clean so the scenario is repeatable.
+    Remove-MscRequest $Name
+
+    $pass = @($script:Assertions | Where-Object Pass).Count
+    $tot  = $script:Assertions.Count
+    $color = if ($pass -eq $tot) { 'Green' } else { 'Red' }
+    Write-Host "`n=== $pass/$tot passed ===`n" -ForegroundColor $color
+    return ($pass -eq $tot)
+}
+
+# ----------------------------------------------------------------------------
+# One-shot CLI dispatch (only when run as a script, not dot-sourced)
+# ----------------------------------------------------------------------------
+if ($MyInvocation.InvocationName -ne '.' -and $args.Count -gt 0) {
+    $cmd = $args[0]; $rest = @($args[1..($args.Count-1)])
+    $apply  = $rest -contains '-Apply';     $rest = @($rest | Where-Object { $_ -ne '-Apply' })
+    $viaW   = $rest -contains '-ViaWatcher'; $rest = @($rest | Where-Object { $_ -ne '-ViaWatcher' })
+    $item   = $rest | Select-Object -First 1
+    switch ($cmd.ToLower()) {
+        'state'      { Show-MscState }
+        'install'    { Invoke-MscInstall   $item -Apply:$apply -ViaWatcher:$viaW }
+        'remove'     { Invoke-MscRemove    $item -Apply:$apply -ViaWatcher:$viaW }
+        'cancel'     { Invoke-MscCancel    $item }
+        'installnow' { Invoke-MscInstallNow      -Apply:$apply -ViaWatcher:$viaW }
+        'clear'      { if ($item -eq 'all') { Clear-MscStuck -All } else { Clear-MscStuck -Name $item } }
+        'nsisweep'   { [void](Clear-MscNsisOrphans) }
+        'loops'      { Get-MscLoopState }
+        'scenario'   { Invoke-MscScenario  $item -Apply:$apply }
+        default      { Write-Host "Commands: state | install <n> | remove <n> | cancel <n> | installnow | clear <n|all> | nsisweep | loops | scenario <n>   [-Apply] [-ViaWatcher]" }
+    }
+}

--- a/tests/gui-harness/MscHarness.ps1
+++ b/tests/gui-harness/MscHarness.ps1
@@ -288,7 +288,9 @@ function Invoke-MscInstallNow {
     if (-not $targets) { Write-Host "Nothing pending." -ForegroundColor DarkGray; return }
     Write-Host "`n[Install Now] $($targets -join ', ')" -ForegroundColor Cyan
 
-    $a = @(); foreach ($t in $targets) { $a += '--item'; $a += $t }
+    # Single --item flag followed by all values. The engine's --item is a sequence
+    # option; repeating the flag ('--item A --item B') exits 1 ("defined multiple times").
+    $a = @('--item') + $targets
     $a += '--no-preflight','-vv'
     if (-not $Apply) { $a += '--checkonly' }
 

--- a/tests/gui-harness/README.md
+++ b/tests/gui-harness/README.md
@@ -1,0 +1,122 @@
+# MSC GUI test harness
+
+Drive every Managed Software Center self-service flow from the terminal — no
+window, no clicking, no waiting on the watcher poll. Use it to iterate on GUI
+features in seconds instead of build → deploy → click → squint.
+
+## Why this works
+
+The MSC window is a **thin shell**. No button installs anything directly. Every
+interaction does exactly two things, then reads the result back:
+
+```
+  [Install] / [Remove] click
+        │
+        ├─ 1. mutate  C:\ProgramData\ManagedInstalls\SelfServeManifest.yaml
+        │        managed_installs:   <- Install adds here
+        │        managed_uninstalls: <- Remove adds here
+        │
+        └─ 2. run     managedsoftwareupdate --item <Name> --no-preflight ...
+                 (GUI does this via a flag file the CimianWatcher service picks up)
+                          │
+                          ▼
+              C:\ProgramData\ManagedInstalls\InstallInfo.yaml   <- the result the GUI renders
+                 per item: installed / status / will_be_installed / will_be_removed / uninstallable
+```
+
+So the harness reproduces step 1 (mutate the manifest the same way the GUI's
+`SelfServiceManifestService` does) and step 2 (run the engine), then reads
+`InstallInfo.yaml` — exactly the data the Software/Updates tabs bind to.
+
+The big speed win: **plan mode**. Running the engine with `--checkonly` resolves
+the *decision* (`will-be-installed` / `will-be-removed`) and writes it to
+`InstallInfo.yaml` **without installing or removing anything**. That proves
+"clicking Install would install this / clicking Remove would remove this" in a
+couple of seconds. Only pass `-Apply` when you want the real install/removal.
+
+## Contract map (where the real code lives — mirror it, don't fork it)
+
+| Concern | File |
+|---|---|
+| SelfServe mutation (`AddInstallRequest` / `AddRemovalRequest` / `RemoveRequest`) | `shared/core/Services/SelfServiceManifestService.cs` |
+| GUI trigger / flag file | `gui/ManagedSoftwareCenter/Services/TriggerService.cs` |
+| Flag `Args:` line builder | `shared/core/Services/BootstrapArgsBuilder.cs` |
+| Engine result writer (`WriteInstallInfo`) | `cli/managedsoftwareupdate/Services/UpdateEngine.cs` |
+| Loop suppression | `shared/core/Services/LoopGuard.cs` |
+| Canonical paths | `shared/core/Services/CimianPaths.cs` |
+| ViewModel commands behind each button | `gui/ManagedSoftwareCenter/ViewModels/{Software,Updates,ItemDetail}ViewModel.cs` |
+
+## Usage
+
+Dot-source to get the functions:
+
+```powershell
+. .\tests\gui-harness\MscHarness.ps1
+
+Show-MscState                 # what the Updates tab would show right now
+Invoke-MscInstall Blender     # PLAN: mimic Install click (safe — no install)
+Invoke-MscInstall Blender -Apply   # actually install
+Invoke-MscRemove VLC          # PLAN: mimic Remove click
+Invoke-MscRemove VLC -Apply        # actually remove
+Invoke-MscCancel Blender      # mimic Cancel on a pending request
+Invoke-MscInstallNow          # mimic "Install Now" over everything pending
+Invoke-MscScenario Blender    # install → assert → remove → assert (plan mode)
+Invoke-MscScenario Blender -Apply  # same, end to end for real
+```
+
+Or one-shot, no dot-sourcing:
+
+```powershell
+pwsh .\tests\gui-harness\MscHarness.ps1 state
+pwsh .\tests\gui-harness\MscHarness.ps1 install Blender
+pwsh .\tests\gui-harness\MscHarness.ps1 scenario Blender -Apply
+```
+
+### `-ViaWatcher` (full IPC test)
+
+By default the harness runs the engine directly (fast, deterministic). Add
+`-ViaWatcher` to instead drop the bootstrap flag file and wait for the
+**CimianWatcher** service to pick it up — exercising the exact path the GUI
+uses, including the service hop. Slower, but it's how you verify the watcher
+contract itself.
+
+```powershell
+Invoke-MscInstall Blender -Apply -ViaWatcher
+```
+
+## Stuck items
+
+An item gets wedged in "Pending" when one of these is true:
+
+1. **It's in `SelfServeManifest.yaml` but never converges** — e.g. a pkginfo
+   whose `installs`/verification check never passes, so the engine reinstalls
+   it every run. Symptom: stays "will-be-installed" forever.
+2. **LoopGuard suppressed it.** After repeated reinstalls of the same version,
+   `LoopGuard` suppresses the package (see `reports\state.json`). It still shows
+   pending in the UI but the engine silently skips it.
+
+Diagnose and clear:
+
+```powershell
+Get-MscLoopState             # table of every suppressed package + reason + until-when
+Clear-MscStuck Gimp          # drop from SelfServe + clear its loop suppression + refresh
+Clear-MscStuck -All          # clear ALL loop suppression (nuclear)
+```
+
+`Clear-MscStuck <name>`:
+1. removes the item from `SelfServeManifest.yaml` (stop re-requesting it),
+2. runs `managedsoftwareupdate --clear-loop <name>` (lift suppression),
+3. runs a `--checkonly` to rewrite `InstallInfo.yaml` so the GUI drops it.
+
+> The real fix for a pkginfo-induced loop is the pkginfo (wrong `installs`
+> check, missing silent `installer.switches`, etc.). `Clear-MscStuck` unwedges
+> the client; correct the pkginfo in the deployment repo so it stops recurring.
+
+## Complementary layer: ViewModel unit tests
+
+This harness covers the **engine/contract** end (real files, real engine). The
+**GUI-logic** end — "does clicking Install call `AddInstallRequestAsync` then
+`TriggerInstallItemAsync` with the right name?" — belongs in fast xUnit tests
+that instantiate the ViewModels with fake `ISelfServiceManifestService` /
+`ITriggerService`. Together they cover the whole click-to-install path without a
+running window.


### PR DESCRIPTION
## Managed Software Center improvements (WIP — kept open for iteration)

Ongoing work on the MSC WinUI 3 GUI and the `managedsoftwareupdate` engine. This PR is a **draft** and will keep getting commits as we iterate; do not merge yet.

### Engine
- Surface install/uninstall failures with a parsed exit-code reason (common MSI codes glossed), streamed on the itemStatus pipe and written to `problem_items` in InstallInfo.yaml (durable, user-reportable).
- Emit an early `pending` stage per targeted `--item` so GUI rows show progress from t=0 instead of flashing at the end.
- Treat msiexec `1605`/`1614` (product already absent) as idempotent removal success.

### Managed Software Center
- **Per-row live stages**: pending → downloading → downloaded → installing → installed/removed/failed, streamed over the status pipe.
- **Removal UX**: My Items shows **Remove** for installed items, **Cancel** for pending; progress banner is verb-aware (Removing vs Installing).
- **Inline problems**: each problem's error renders on its own row; only orphan problems (no matching row) stay in the standalone Problem Items section.
- **Self-serve responsiveness**: cancelling a pending request clears it from the Updates tab immediately (`RequestsChanged` event); Updates surfaces self-serve install-requested items.
- **Log viewer**: hides DEBUG lines by default with a *Show debug* toggle; adds a Copy button.
- Adds `tests/gui-harness` to drive the install/remove path headlessly.

### Status
Built signed and deployed locally (MSU+MSC 2026.06.14). Iterating — next up includes install-side silent-flag inference for stub installers and a repo-wide uninstall-coverage audit (tracked separately in Azure Boards).
