### PR TITLE
managedsoftwareupdate: 404 fallback chain for primary manifest

### DIFF
--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -56,13 +56,13 @@ public class ManifestService
     public async Task<List<ManifestItem>> GetManifestItemsAsync()
     {
         var items = new List<ManifestItem>();
-        var processedManifests = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var manifestResults = new Dictionary<string, ManifestFetchResult>(StringComparer.OrdinalIgnoreCase);
         var pendingConditionals = new List<(List<ConditionalItem> Items, string SourceManifest)>();
 
         // PASS 1: Resolve and process the primary manifest, walking a 404 fallback
         // chain (configured identifier -> hostname -> serial -> Orphaned ->
         // site_default), collecting catalogs and deferring conditional items.
-        await ResolvePrimaryManifestAsync(items, processedManifests, pendingConditionals);
+        await ResolvePrimaryManifestAsync(items, manifestResults, pendingConditionals);
 
         // Log collected catalogs before processing conditionals
         ConsoleLogger.Info($"    Collected catalogs for conditional evaluation: [{string.Join(", ", _config.Catalogs)}]");
@@ -90,10 +90,12 @@ public class ManifestService
     public async Task<List<ManifestItem>> LoadSpecificManifestAsync(string manifestName)
     {
         var items = new List<ManifestItem>();
-        var processedManifests = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var manifestResults = new Dictionary<string, ManifestFetchResult>(StringComparer.OrdinalIgnoreCase);
         var pendingConditionals = new List<(List<ConditionalItem> Items, string SourceManifest)>();
 
-        await ProcessManifestAsync(manifestName, items, processedManifests, pendingConditionals);
+        // Explicitly-requested manifest: a 404 should stay visible (quiet404: false),
+        // unchanged from the pre-fallback-chain behavior.
+        await ProcessManifestAsync(manifestName, items, manifestResults, pendingConditionals, quiet404: false);
         
         // Process deferred conditional items
         foreach (var (conditionalItems, sourceManifest) in pendingConditionals)
@@ -140,7 +142,7 @@ public class ManifestService
     /// </summary>
     private async Task ResolvePrimaryManifestAsync(
         List<ManifestItem> items,
-        HashSet<string> processedManifests,
+        Dictionary<string, ManifestFetchResult> manifestResults,
         List<(List<ConditionalItem> Items, string SourceManifest)> pendingConditionals)
     {
         // Candidate kind drives log severity: a 404 on an explicitly configured
@@ -150,35 +152,41 @@ public class ManifestService
         const string Probe = "probe";
         const string CatchAll = "catch-all";
 
-        var candidates = new List<(string Name, string Kind)>();
-        void Add(string? name, string kind)
+        // Candidate names are resolved lazily so an expensive lookup (the serial
+        // number, which queries WMI) only runs once the chain actually reaches it.
+        // When the configured identifier resolves on the first try, or the chain
+        // aborts on a non-404, the WMI query is never issued.
+        var candidates = new List<(Func<string?> Resolve, string Kind)>
         {
-            if (string.IsNullOrWhiteSpace(name)) return;
-            var trimmed = name.Trim();
-            if (candidates.Any(c => string.Equals(c.Name, trimmed, StringComparison.OrdinalIgnoreCase)))
-                return;
-            candidates.Add((trimmed, kind));
-        }
+            // Configured identity: certificate CN takes precedence over the explicit
+            // ClientIdentifier, preserving the prior single-identifier selection.
+            (() => CimianHttpClientFactory.GetClientCertificateCN(_config), Configured),
+            (() => _config.ClientIdentifier, Configured),
+            // Opportunistic probes.
+            (() => Environment.MachineName, Probe),
+            (GetSerialNumber, Probe),
+            // Catch-all manifests of last resort.
+            (() => "Orphaned", CatchAll),
+            (() => "site_default", CatchAll),
+        };
 
-        // Configured identity: certificate CN takes precedence over the explicit
-        // ClientIdentifier, preserving the prior single-identifier selection.
-        Add(CimianHttpClientFactory.GetClientCertificateCN(_config), Configured);
-        Add(_config.ClientIdentifier, Configured);
-        // Opportunistic probes.
-        Add(Environment.MachineName, Probe);
-        Add(GetSerialNumber(), Probe);
-        // Catch-all manifests of last resort.
-        Add("Orphaned", CatchAll);
-        Add("site_default", CatchAll);
+        var tried = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var triedNames = new List<string>();
+        var resolvedAny = false;
 
-        for (var i = 0; i < candidates.Count; i++)
+        foreach (var (resolve, kind) in candidates)
         {
-            var (name, kind) = candidates[i];
-            var result = await ProcessManifestAsync(name, items, processedManifests, pendingConditionals);
+            var name = resolve()?.Trim();
+            // Skip blanks and de-duplicate candidates that resolve to the same name.
+            if (string.IsNullOrWhiteSpace(name) || !tried.Add(name))
+                continue;
+            triedNames.Add(name);
+
+            var result = await ProcessManifestAsync(name, items, manifestResults, pendingConditionals, quiet404: true);
 
             if (result == ManifestFetchResult.Ok)
             {
-                if (i > 0)
+                if (resolvedAny)
                 {
                     ConsoleLogger.Warn($"    Primary manifest resolved via fallback '{name}' ({kind}); " +
                         "device is running on a fallback/catch-all configuration.");
@@ -195,13 +203,14 @@ public class ManifestService
             }
 
             // NotFound: advance to the next candidate.
+            resolvedAny = true;
             if (kind == Configured)
                 ConsoleLogger.Warn($"    Configured manifest '{name}' returned 404; trying next fallback candidate.");
             else
                 ConsoleLogger.Detail($"    Manifest '{name}' ({kind}) returned 404; trying next fallback candidate.");
         }
 
-        ConsoleLogger.Warn($"    No primary manifest could be resolved from candidates: [{string.Join(", ", candidates.Select(c => c.Name))}]. Device will have no managed items this run.");
+        ConsoleLogger.Warn($"    No primary manifest could be resolved from candidates: [{string.Join(", ", triedNames)}]. Device will have no managed items this run.");
     }
 
     /// <summary>
@@ -230,16 +239,23 @@ public class ManifestService
     private async Task<ManifestFetchResult> ProcessManifestAsync(
         string manifestName,
         List<ManifestItem> items,
-        HashSet<string> processedManifests,
-        List<(List<ConditionalItem> Items, string SourceManifest)> pendingConditionals)
+        Dictionary<string, ManifestFetchResult> manifestResults,
+        List<(List<ConditionalItem> Items, string SourceManifest)> pendingConditionals,
+        bool quiet404 = false)
     {
-        // Avoid infinite loops from circular includes
-        if (processedManifests.Contains(manifestName))
+        // If we've already handled this manifest this run, return its actual prior
+        // outcome rather than a blanket Ok — a manifest that previously 404'd or
+        // errored must not be reported as successfully processed when referenced
+        // again (e.g. as an include of a later catch-all). A tentative Ok is seeded
+        // before the fetch below so circular includes still terminate.
+        if (manifestResults.TryGetValue(manifestName, out var priorResult))
         {
-            ConsoleLogger.Debug($"Skipping already-processed manifest: {manifestName}");
-            return ManifestFetchResult.Ok;
+            ConsoleLogger.Debug($"Skipping already-processed manifest: {manifestName} (prior result: {priorResult})");
+            return priorResult;
         }
-        processedManifests.Add(manifestName);
+        // Seed a tentative Ok so a circular include resolves to Ok and recursion stops;
+        // overwritten with the real result at each return path below.
+        manifestResults[manifestName] = ManifestFetchResult.Ok;
         ConsoleLogger.Debug($"Processing manifest originalName: {manifestName} processedName: {manifestName}.yaml");
 
         // Try to download the manifest
@@ -300,8 +316,10 @@ public class ManifestService
                             ConsoleLogger.Debug($"Processing included manifest: {includeName}");
                             
                             // Include paths are relative or absolute manifest references
-                            // They should be passed as-is to ProcessManifestAsync
-                            await ProcessManifestAsync(includeName, items, processedManifests, pendingConditionals);
+                            // They should be passed as-is to ProcessManifestAsync. A 404 on
+                            // an include stays visible (quiet404: false) — only the primary
+                            // fallback chain probes quietly.
+                            await ProcessManifestAsync(includeName, items, manifestResults, pendingConditionals);
                         }
                     }
 
@@ -330,24 +348,33 @@ public class ManifestService
                     }
                 }
 
+                manifestResults[manifestName] = ManifestFetchResult.Ok;
                 return ManifestFetchResult.Ok;
             }
 
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 // 404 is the only status that advances the primary-manifest fallback chain.
-                ConsoleLogger.Debug($"Manifest not found (404): {manifestName}");
+                // Quiet (Debug) for primary-candidate probes; visible (Warn) for includes
+                // and explicit LoadSpecificManifestAsync, matching pre-fallback behavior.
+                if (quiet404)
+                    ConsoleLogger.Debug($"Manifest not found (404): {manifestName}");
+                else
+                    ConsoleLogger.Warn($"Manifest not found (404): {manifestName}");
+                manifestResults[manifestName] = ManifestFetchResult.NotFound;
                 return ManifestFetchResult.NotFound;
             }
 
             // Non-404 (auth, 5xx, etc.): surface rather than treating it as missing.
             ConsoleLogger.Warn($"Failed to download manifest {manifestName}: {response.StatusCode}");
+            manifestResults[manifestName] = ManifestFetchResult.Error;
             return ManifestFetchResult.Error;
         }
         catch (Exception ex)
         {
             // Network/transport failure: surface, do not mask by falling back.
             ConsoleLogger.Warn($"Error processing manifest {manifestName}: {ex.Message}");
+            manifestResults[manifestName] = ManifestFetchResult.Error;
             return ManifestFetchResult.Error;
         }
     }

--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using YamlDotNet.Serialization;
@@ -58,20 +59,10 @@ public class ManifestService
         var processedManifests = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var pendingConditionals = new List<(List<ConditionalItem> Items, string SourceManifest)>();
 
-        // Start with the client identifier manifest
-        // If UseClientCertificateCNAsClientIdentifier is set, use the certificate CN
-        var clientIdentifier = CimianHttpClientFactory.GetClientCertificateCN(_config);
-        if (string.IsNullOrEmpty(clientIdentifier))
-        {
-            clientIdentifier = _config.ClientIdentifier;
-        }
-        if (string.IsNullOrEmpty(clientIdentifier))
-        {
-            clientIdentifier = Environment.MachineName;
-        }
-
-        // PASS 1: Process all manifests, collecting catalogs and deferring conditional items
-        await ProcessManifestAsync(clientIdentifier, items, processedManifests, pendingConditionals);
+        // PASS 1: Resolve and process the primary manifest, walking a 404 fallback
+        // chain (configured identifier -> hostname -> serial -> Orphaned ->
+        // site_default), collecting catalogs and deferring conditional items.
+        await ResolvePrimaryManifestAsync(items, processedManifests, pendingConditionals);
 
         // Log collected catalogs before processing conditionals
         ConsoleLogger.Info($"    Collected catalogs for conditional evaluation: [{string.Join(", ", _config.Catalogs)}]");
@@ -130,7 +121,113 @@ public class ManifestService
         return ConvertToManifestItems(manifest, Path.GetFileNameWithoutExtension(manifestPath));
     }
 
-    private async Task ProcessManifestAsync(
+    /// <summary>
+    /// Outcome of a single manifest fetch, used to drive the primary-manifest
+    /// fallback chain. Only NotFound (HTTP 404) advances to the next candidate;
+    /// Error (auth/5xx/network) aborts so a transient failure is never masked by
+    /// silently degrading to a catch-all manifest.
+    /// </summary>
+    private enum ManifestFetchResult { Ok, NotFound, Error }
+
+    /// <summary>
+    /// Resolves the primary manifest by walking an ordered candidate chain and
+    /// processing the first one the server returns:
+    ///   configured identifier (cert CN &gt; ClientIdentifier &gt; hostname)
+    ///   -&gt; serial number -&gt; Orphaned -&gt; site_default
+    /// Only an HTTP 404 advances to the next candidate. A non-404 failure
+    /// (auth, 5xx, network) aborts resolution immediately rather than degrading
+    /// to a catch-all, so genuine server problems stay visible.
+    /// </summary>
+    private async Task ResolvePrimaryManifestAsync(
+        List<ManifestItem> items,
+        HashSet<string> processedManifests,
+        List<(List<ConditionalItem> Items, string SourceManifest)> pendingConditionals)
+    {
+        // Candidate kind drives log severity: a 404 on an explicitly configured
+        // identifier is noteworthy (warn); a 404 on an opportunistic probe or a
+        // catch-all is routine (detail).
+        const string Configured = "configured";
+        const string Probe = "probe";
+        const string CatchAll = "catch-all";
+
+        var candidates = new List<(string Name, string Kind)>();
+        void Add(string? name, string kind)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return;
+            var trimmed = name.Trim();
+            if (candidates.Any(c => string.Equals(c.Name, trimmed, StringComparison.OrdinalIgnoreCase)))
+                return;
+            candidates.Add((trimmed, kind));
+        }
+
+        // Configured identity: certificate CN takes precedence over the explicit
+        // ClientIdentifier, preserving the prior single-identifier selection.
+        Add(CimianHttpClientFactory.GetClientCertificateCN(_config), Configured);
+        Add(_config.ClientIdentifier, Configured);
+        // Opportunistic probes.
+        Add(Environment.MachineName, Probe);
+        Add(GetSerialNumber(), Probe);
+        // Catch-all manifests of last resort.
+        Add("Orphaned", CatchAll);
+        Add("site_default", CatchAll);
+
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            var (name, kind) = candidates[i];
+            var result = await ProcessManifestAsync(name, items, processedManifests, pendingConditionals);
+
+            if (result == ManifestFetchResult.Ok)
+            {
+                if (i > 0)
+                {
+                    ConsoleLogger.Warn($"    Primary manifest resolved via fallback '{name}' ({kind}); " +
+                        "device is running on a fallback/catch-all configuration.");
+                }
+                return;
+            }
+
+            if (result == ManifestFetchResult.Error)
+            {
+                // Non-404 failure already logged in ProcessManifestAsync. Abort the
+                // chain so a transient server error is not mistaken for "no manifest".
+                ConsoleLogger.Error($"    Aborting primary manifest resolution at '{name}' due to a non-404 error; not falling through to catch-all.");
+                return;
+            }
+
+            // NotFound: advance to the next candidate.
+            if (kind == Configured)
+                ConsoleLogger.Warn($"    Configured manifest '{name}' returned 404; trying next fallback candidate.");
+            else
+                ConsoleLogger.Detail($"    Manifest '{name}' ({kind}) returned 404; trying next fallback candidate.");
+        }
+
+        ConsoleLogger.Warn($"    No primary manifest could be resolved from candidates: [{string.Join(", ", candidates.Select(c => c.Name))}]. Device will have no managed items this run.");
+    }
+
+    /// <summary>
+    /// Reads the hardware serial number from the system BIOS for use as a
+    /// manifest fallback identifier. Returns null if it cannot be determined.
+    /// </summary>
+    private static string? GetSerialNumber()
+    {
+        try
+        {
+            using var searcher = new System.Management.ManagementObjectSearcher("SELECT SerialNumber FROM Win32_BIOS");
+            foreach (var obj in searcher.Get())
+            {
+                var serial = obj["SerialNumber"]?.ToString()?.Trim();
+                if (!string.IsNullOrWhiteSpace(serial))
+                    return serial;
+            }
+        }
+        catch (Exception ex)
+        {
+            ConsoleLogger.Debug($"Serial number lookup for manifest fallback failed: {ex.Message}");
+        }
+        return null;
+    }
+
+    private async Task<ManifestFetchResult> ProcessManifestAsync(
         string manifestName,
         List<ManifestItem> items,
         HashSet<string> processedManifests,
@@ -140,7 +237,7 @@ public class ManifestService
         if (processedManifests.Contains(manifestName))
         {
             ConsoleLogger.Debug($"Skipping already-processed manifest: {manifestName}");
-            return;
+            return ManifestFetchResult.Ok;
         }
         processedManifests.Add(manifestName);
         ConsoleLogger.Debug($"Processing manifest originalName: {manifestName} processedName: {manifestName}.yaml");
@@ -232,15 +329,26 @@ public class ManifestService
                         pendingConditionals.Add((manifest.ConditionalItems, manifestName));
                     }
                 }
+
+                return ManifestFetchResult.Ok;
             }
-            else
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
             {
-                ConsoleLogger.Warn($"Failed to download manifest {manifestName}: {response.StatusCode}");
+                // 404 is the only status that advances the primary-manifest fallback chain.
+                ConsoleLogger.Debug($"Manifest not found (404): {manifestName}");
+                return ManifestFetchResult.NotFound;
             }
+
+            // Non-404 (auth, 5xx, etc.): surface rather than treating it as missing.
+            ConsoleLogger.Warn($"Failed to download manifest {manifestName}: {response.StatusCode}");
+            return ManifestFetchResult.Error;
         }
         catch (Exception ex)
         {
+            // Network/transport failure: surface, do not mask by falling back.
             ConsoleLogger.Warn($"Error processing manifest {manifestName}: {ex.Message}");
+            return ManifestFetchResult.Error;
         }
     }
 

--- a/tests/Managedsoftwareupdate/ManifestServiceTests.cs
+++ b/tests/Managedsoftwareupdate/ManifestServiceTests.cs
@@ -1,3 +1,7 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Cimian.CLI.managedsoftwareupdate.Models;
 using Cimian.CLI.managedsoftwareupdate.Services;
@@ -226,5 +230,83 @@ public class ManifestServiceTests
 
         Assert.Single(result);
         Assert.Equal("Real", result[0].Name);
+    }
+
+    // --- Primary-manifest 404 fallback chain -------------------------------
+    // configured identifier -> hostname -> serial -> Orphaned -> site_default.
+    // Only a 404 advances the chain; a non-404 aborts without degrading to a
+    // catch-all so a transient server error stays visible.
+
+    [Fact]
+    public async Task GetManifestItems_PrimaryManifest404_FallsBackToOrphaned()
+    {
+        var config = new CimianConfig
+        {
+            SoftwareRepoURL = "https://repo.example.test",
+            ClientIdentifier = "configured-pc",
+            ManifestsPath = Directory.CreateTempSubdirectory().FullName,
+        };
+
+        const string orphanedYaml = "catalogs:\n  - Production\nmanaged_installs:\n  - FallbackApp\n";
+        var handler = new StubHandler(url =>
+            url.EndsWith("/manifests/Orphaned.yaml", StringComparison.OrdinalIgnoreCase)
+                ? (HttpStatusCode.OK, orphanedYaml)
+                : (HttpStatusCode.NotFound, string.Empty));
+
+        var service = new ManifestService(config, new HttpClient(handler));
+
+        var items = await service.GetManifestItemsAsync();
+
+        var fallback = Assert.Single(items, i => i.Name == "FallbackApp");
+        Assert.Equal("install", fallback.Action);
+        Assert.Equal("Orphaned", fallback.SourceManifest);
+        Assert.Contains("Production", config.Catalogs);
+    }
+
+    [Fact]
+    public async Task GetManifestItems_PrimaryManifestNon404_AbortsWithoutCatchAll()
+    {
+        var config = new CimianConfig
+        {
+            SoftwareRepoURL = "https://repo.example.test",
+            ClientIdentifier = "configured-pc",
+            ManifestsPath = Directory.CreateTempSubdirectory().FullName,
+        };
+
+        // The configured identifier returns 500; everything else would 404.
+        var handler = new StubHandler(url =>
+            url.EndsWith("/manifests/configured-pc.yaml", StringComparison.OrdinalIgnoreCase)
+                ? (HttpStatusCode.InternalServerError, string.Empty)
+                : (HttpStatusCode.NotFound, string.Empty));
+
+        var service = new ManifestService(config, new HttpClient(handler));
+
+        await service.GetManifestItemsAsync();
+
+        // A non-404 must abort the chain: the catch-all manifests are never requested.
+        Assert.DoesNotContain(handler.RequestedUrls,
+            u => u.Contains("/manifests/Orphaned.yaml", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(handler.RequestedUrls,
+            u => u.Contains("/manifests/site_default.yaml", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Minimal HttpMessageHandler that answers each request from a URL-driven
+    /// responder and records every requested URL for assertions.
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<string, (HttpStatusCode Status, string Body)> _responder;
+        public List<string> RequestedUrls { get; } = new();
+
+        public StubHandler(Func<string, (HttpStatusCode, string)> responder) => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.ToString();
+            RequestedUrls.Add(url);
+            var (status, body) = _responder(url);
+            return Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) });
+        }
     }
 }


### PR DESCRIPTION
## What

When the primary manifest 404s, `managedsoftwareupdate` now walks an ordered fallback chain instead of giving up and running with no managed items:

1. configured identifier (client-cert CN > `ClientIdentifier` > hostname)
2. serial number (BIOS)
3. `Orphaned`
4. `site_default`

## Behavior

- **Only HTTP 404 advances** the chain.
- **Non-404 failures** (auth, 5xx, network/transport) **abort immediately** without falling through to a catch-all, so a transient server problem stays visible rather than being silently mistaken for "no manifest assigned."
- **Logging severity** reflects intent: a 404 on an explicitly configured identifier logs at warning; a 404 on an opportunistic probe (hostname/serial) or catch-all logs at detail; landing on any fallback logs a warning that the device is running on a fallback/catch-all configuration.
- Success on the first (configured) candidate is unchanged — no new logging, same path as before.

## Why

Previously `GetManifestItemsAsync` selected a single identifier and, on any failure, logged a warning and continued with an empty set — the device received no managed installs and the failure was easy to miss. The fallback chain gives a catch-all path and the 404-vs-error split keeps real server errors loud.

## Implementation

- `ProcessManifestAsync` now returns a `ManifestFetchResult` (`Ok` / `NotFound` / `Error`) so the caller can distinguish 404 from other failures.
- New `ResolvePrimaryManifestAsync` builds the de-duplicated candidate chain and drives resolution; included-manifest recursion is unchanged.
- New `GetSerialNumber()` reads `Win32_BIOS` (returns null and is skipped if unavailable).
- Only the primary manifest gets the chain; `LoadSpecificManifestAsync` and include resolution keep their existing semantics.

## Tests

Two added in `ManifestServiceTests` (45 matched tests green):
- primary 404 → falls back to `Orphaned` and picks up its items/catalogs
- primary 500 → aborts without ever requesting the catch-all manifests