### PR TITLE
loopguard: global LoopGuardEnabled config to disable suppression fleet-wide

### DIFF
--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -94,6 +94,16 @@ public class CimianConfig
     public bool AutoRemove { get; set; }
 
     /// <summary>
+    /// Master switch for install-loop prevention (LoopGuard). On by default.
+    /// Set to false in config.yaml to disable loop suppression fleet-wide — admins
+    /// who want packages installed every run regardless of loop heuristics can turn
+    /// it off entirely. When disabled, packages are never suppressed and no backoff
+    /// state is consulted; passive loop detection for reporting is unaffected.
+    /// </summary>
+    [YamlMember(Alias = "LoopGuardEnabled")]
+    public bool LoopGuardEnabled { get; set; } = true;
+
+    /// <summary>
     /// Master switch for unused-software removal (unused_software_removal_info).
     /// On by default — harmless fleet-wide because every package must still
     /// opt in via pkginfo, and the pass only ever touches self-serve/optional

--- a/cli/managedsoftwareupdate/Program.cs
+++ b/cli/managedsoftwareupdate/Program.cs
@@ -266,6 +266,7 @@ public class Program
         Console.WriteLine($"  PostflightFailureAction: {config.PostflightFailureAction}");
         Console.WriteLine($"  LocalOnlyManifest: {config.LocalOnlyManifest ?? "(not set)"}");
         Console.WriteLine($"  SkipSelfService: {config.SkipSelfService}");
+        Console.WriteLine($"  LoopGuardEnabled: {config.LoopGuardEnabled}");
         Console.WriteLine($"  AuthUser: {(string.IsNullOrEmpty(config.AuthUser) ? "(not set)" : "***")}");
         Console.WriteLine($"  AuthToken: {(string.IsNullOrEmpty(config.AuthToken) ? "(not set)" : "***")}");
 

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -228,11 +228,11 @@ public class UpdateEngine : IDisposable
         _showStatus = showStatus;
 
         // Initialize loop guard for install loop prevention. Admins can disable it
-        // fleet-wide via LoopGuardEnabled: false in config.yaml.
+        // fleet-wide via LoopGuardEnabled: false in config.yaml. The startup notice
+        // is emitted further down, once ConsoleLogger.Verbosity is set and the
+        // SessionLogger is attached, so it actually reaches the console and run.log.
         var loopGuardDisabled = !_config.LoopGuardEnabled;
         _loopGuard = new LoopGuard(_isBootstrap, disabled: loopGuardDisabled);
-        if (loopGuardDisabled)
-            ConsoleLogger.Info("LoopGuard disabled by config (LoopGuardEnabled: false) — install-loop suppression is off");
 
         // Track session duration for run.log summary
         var sessionStopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -279,6 +279,11 @@ public class UpdateEngine : IDisposable
         
         _sessionLogger.Log("INFO", $"Session started: {sessionId}");
         _sessionLogger.Log("INFO", $"Run type: {runType}");
+
+        // Now that verbosity is set and the SessionLogger is attached, surface the
+        // LoopGuard kill-switch so it reaches both the console and run.log.
+        if (loopGuardDisabled)
+            ConsoleLogger.Info("LoopGuard disabled by config (LoopGuardEnabled: false) — install-loop suppression is off");
 
         try
         {

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -227,8 +227,12 @@ public class UpdateEngine : IDisposable
         _verbosity = verbosity;
         _showStatus = showStatus;
 
-        // Initialize loop guard for install loop prevention
-        _loopGuard = new LoopGuard(_isBootstrap);
+        // Initialize loop guard for install loop prevention. Admins can disable it
+        // fleet-wide via LoopGuardEnabled: false in config.yaml.
+        var loopGuardDisabled = !_config.LoopGuardEnabled;
+        _loopGuard = new LoopGuard(_isBootstrap, disabled: loopGuardDisabled);
+        if (loopGuardDisabled)
+            ConsoleLogger.Info("LoopGuard disabled by config (LoopGuardEnabled: false) — install-loop suppression is off");
 
         // Track session duration for run.log summary
         var sessionStopwatch = System.Diagnostics.Stopwatch.StartNew();

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -228,6 +228,16 @@ public class LoopGuard
         if (string.IsNullOrEmpty(packageName))
             return;
 
+        // Globally disabled by config (LoopGuardEnabled: false): don't accumulate any
+        // suppression state. ShouldSuppress already short-circuits, but we also skip
+        // recording so the kill-switch is honest — re-enabling LoopGuard later behaves
+        // as if no loop history exists rather than instantly suppressing packages based
+        // on attempts logged during the disabled window. Passive loop reporting is
+        // unaffected: install_loop_detected in items.json is derived from the structured
+        // event history (DataExporter), not from this guard's internal state.
+        if (_disabled)
+            return;
+
         // Self-reported warnings are not install attempts for loop-detection purposes.
         // Skip counter updates entirely so the per-version count and rapid-fire window
         // are not polluted by intentional soft-fails. See remarks above.

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -60,14 +60,18 @@ public class LoopGuard
 
     private LoopGuardState _state;
     private readonly bool _isBootstrap;
+    private readonly bool _disabled;
 
     /// <summary>
-    /// Creates a new LoopGuard. If isBootstrap is true, suppression is disabled
-    /// to avoid blocking first-run provisioning.
+    /// Creates a new LoopGuard.
+    /// If isBootstrap is true, suppression is disabled to avoid blocking first-run provisioning.
+    /// If disabled is true, suppression is turned off entirely — the admin-facing global
+    /// kill-switch, driven by the LoopGuardEnabled config setting.
     /// </summary>
-    public LoopGuard(bool isBootstrap = false)
+    public LoopGuard(bool isBootstrap = false, bool disabled = false)
     {
         _isBootstrap = isBootstrap;
+        _disabled = disabled;
         _state = LoadState();
         BuildHistoryFromEvents();
     }
@@ -75,9 +79,10 @@ public class LoopGuard
     /// <summary>
     /// For unit testing — constructor that takes custom paths.
     /// </summary>
-    internal LoopGuard(string statePath, string logsDir, bool isBootstrap = false, string? cacheDir = null)
+    internal LoopGuard(string statePath, string logsDir, bool isBootstrap = false, string? cacheDir = null, bool disabled = false)
     {
         _isBootstrap = isBootstrap;
+        _disabled = disabled;
         StatePath_Override = statePath;
         LogsDir_Override = logsDir;
         CacheDir_Override = cacheDir;
@@ -125,6 +130,10 @@ public class LoopGuard
     {
         // Never suppress during bootstrap — first-run provisioning must complete
         if (_isBootstrap)
+            return (false, "");
+
+        // Globally disabled by config (LoopGuardEnabled: false) — admin opted out entirely
+        if (_disabled)
             return (false, "");
 
         if (string.IsNullOrEmpty(packageName))

--- a/tests/LoopGuardTests.cs
+++ b/tests/LoopGuardTests.cs
@@ -135,6 +135,23 @@ public class LoopGuardTests : IDisposable
         disabled.ShouldSuppress("StuckPkg", "1.0.0").Suppress.Should().BeFalse();
     }
 
+    [Fact]
+    public void Disabled_DoesNotAccumulateSuppressionState()
+    {
+        // Record enough attempts to normally trip rapid-fire suppression, but while
+        // globally disabled — no suppression state should be persisted.
+        var disabled = CreateGuard(disabled: true);
+        disabled.RecordAttempt("LaterPkg", "1.0.0", true);
+        disabled.RecordAttempt("LaterPkg", "1.0.0", true);
+        disabled.RecordAttempt("LaterPkg", "1.0.0", true);
+
+        // Re-enable LoopGuard (fresh guard loading the same state file). Because
+        // nothing was recorded while disabled, it behaves as if no loop history
+        // exists and does not instantly suppress the package.
+        var reEnabled = CreateGuard();
+        reEnabled.ShouldSuppress("LaterPkg", "1.0.0").Suppress.Should().BeFalse();
+    }
+
     #endregion
 
     #region Self-Reported Warning Carve-Out

--- a/tests/LoopGuardTests.cs
+++ b/tests/LoopGuardTests.cs
@@ -32,9 +32,9 @@ public class LoopGuardTests : IDisposable
         catch { /* cleanup best-effort */ }
     }
 
-    private LoopGuard CreateGuard(bool isBootstrap = false)
+    private LoopGuard CreateGuard(bool isBootstrap = false, bool disabled = false)
     {
-        return new LoopGuard(_statePath, _logsDir, isBootstrap, _cacheDir);
+        return new LoopGuard(_statePath, _logsDir, isBootstrap, _cacheDir, disabled);
     }
 
     #region Basic Behavior
@@ -98,6 +98,41 @@ public class LoopGuardTests : IDisposable
         // Even with 3 attempts, bootstrap mode should never suppress
         var (suppress, _) = guard.ShouldSuppress("LoopPkg", "1.0.0");
         suppress.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Globally Disabled (LoopGuardEnabled: false)
+
+    [Fact]
+    public void Disabled_NeverSuppresses()
+    {
+        var guard = CreateGuard(disabled: true);
+
+        // Simulate a package that would normally trip rapid-fire suppression
+        guard.RecordAttempt("LoopPkg", "1.0.0", true);
+        guard.RecordAttempt("LoopPkg", "1.0.0", true);
+        guard.RecordAttempt("LoopPkg", "1.0.0", true);
+
+        // With LoopGuard globally disabled, suppression is off entirely
+        var (suppress, reason) = guard.ShouldSuppress("LoopPkg", "1.0.0");
+        suppress.Should().BeFalse();
+        reason.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Disabled_IgnoresExistingSuppressionState()
+    {
+        // First, a guard that actually suppresses the package and persists state.
+        var enforcing = CreateGuard();
+        enforcing.RecordAttempt("StuckPkg", "1.0.0", true);
+        enforcing.RecordAttempt("StuckPkg", "1.0.0", true);
+        enforcing.RecordAttempt("StuckPkg", "1.0.0", true);
+        enforcing.ShouldSuppress("StuckPkg", "1.0.0").Suppress.Should().BeTrue();
+
+        // A disabled guard loading the same state must not act on it.
+        var disabled = CreateGuard(disabled: true);
+        disabled.ShouldSuppress("StuckPkg", "1.0.0").Suppress.Should().BeFalse();
     }
 
     #endregion

--- a/wiki/install-loop-prevention.md
+++ b/wiki/install-loop-prevention.md
@@ -65,6 +65,24 @@ This means you don't need to SSH into machines to run `--clear-loop` after fixin
 
 During **bootstrap mode** (first-run provisioning via CimianWatcher), LoopGuard is completely disabled. Many packages are legitimately installed back-to-back during initial machine setup.
 
+#### Global Disable (admin opt-out)
+
+Admins who want loop suppression off fleet-wide can set it in `config.yaml`:
+
+```yaml
+LoopGuardEnabled: false
+```
+
+Default is `true`. When set to `false`, LoopGuard never suppresses any package and ignores any persisted backoff state — every run behaves as if no loop history exists. The setting is read on each run by `UpdateEngine`, which logs `LoopGuard disabled by config (LoopGuardEnabled: false)` at startup so it's visible in the session log. Passive loop detection (the `install_loop_detected` flag in `items.json` for dashboards) is **not** affected — reporting still flags loops even when active suppression is off.
+
+Confirm the effective value with:
+
+```pwsh
+managedsoftwareupdate --show-config
+```
+
+Note: this is the global kill-switch. To bypass suppression for a single package on a single run without disabling LoopGuard everywhere, use `--item <name>` instead; to clear a specific suppression, use `--clear-loop <name>`.
+
 ## How It Works Internally
 
 ### State Persistence

--- a/wiki/install-loop-prevention.md
+++ b/wiki/install-loop-prevention.md
@@ -73,7 +73,7 @@ Admins who want loop suppression off fleet-wide can set it in `config.yaml`:
 LoopGuardEnabled: false
 ```
 
-Default is `true`. When set to `false`, LoopGuard never suppresses any package and ignores any persisted backoff state — every run behaves as if no loop history exists. The setting is read on each run by `UpdateEngine`, which logs `LoopGuard disabled by config (LoopGuardEnabled: false)` at startup so it's visible in the session log. Passive loop detection (the `install_loop_detected` flag in `items.json` for dashboards) is **not** affected — reporting still flags loops even when active suppression is off.
+Default is `true`. When set to `false`, LoopGuard never suppresses any package and ignores any persisted backoff state — every run behaves as if no loop history exists, and no new backoff state is formed while disabled (so re-enabling later won't instantly suppress packages based on attempts logged during the disabled window). The setting is read on each run by `UpdateEngine`, which logs a `LoopGuard disabled by config` notice near the start of the run; the message is written to the session log (`run.log`) and is shown on the console at `-v` or higher. Passive loop detection (the `install_loop_detected` flag in `items.json` for dashboards) is **not** affected — reporting still flags loops even when active suppression is off.
 
 Confirm the effective value with:
 


### PR DESCRIPTION
## What

Adds a global, admin-facing kill-switch for install-loop prevention (LoopGuard).

### Why

Previously LoopGuard could only be:
- disabled automatically during **bootstrap** mode, or
- bypassed **per-package** at runtime via `--item <name>`, or
- cleared per-package via `--clear-loop <name>`.

There was no `config.yaml` setting to turn it off **entirely** for admins who want packages installed every run regardless of loop heuristics. This gap was even flagged in `wiki/munki-loopguard-spec.md` ("Consider adding a ManagedPreferences key ... for admins who want to disable it entirely").

### Changes

- `CimianConfig.LoopGuardEnabled` — new config field, **default `true`** (no behavior change unless explicitly set).
- `LoopGuard` gains a `disabled` flag; `ShouldSuppress` short-circuits to never-suppress when set, ignoring any persisted backoff state.
- `UpdateEngine` reads `!_config.LoopGuardEnabled`, passes it to `LoopGuard`, and logs `LoopGuard disabled by config (...)` at startup for visibility.
- `--show-config` now prints `LoopGuardEnabled`.
- Wiki doc `install-loop-prevention.md` documents the setting.

Passive loop detection (`install_loop_detected` in `items.json` for dashboards) is **not** affected — reporting still flags loops even when active suppression is off.

### Usage

```yaml
# config.yaml
LoopGuardEnabled: false
```

### Tests

Added two tests (41 LoopGuard tests pass total):
- `Disabled_NeverSuppresses` — a disabled guard never suppresses despite rapid-fire attempts.
- `Disabled_IgnoresExistingSuppressionState` — a disabled guard ignores state that an enforcing guard had already suppressed.

Both `Cimian.Core` tests and the `managedsoftwareupdate` CLI build clean.

https://claude.ai/code/session_01A6em9MeeisDAqNNuiUyQDM