### PR TITLE
managedsoftwareupdate: honour OnDemand items

### DIFF
--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -446,6 +446,13 @@ public class CatalogItem
     [YamlMember(Alias = "precache")]
     public bool Precache { get; set; }
 
+    // OnDemand items are never considered installed and never get a ManagedInstalls
+    // receipt: they re-evaluate and (re)install on every run. Used by transient nopkg
+    // actions (provisioning/enrollment) that must keep running until their own script
+    // flips some external state and the item drops out of the active manifest.
+    [YamlMember(Alias = "OnDemand")]
+    public bool OnDemand { get; set; }
+
     [YamlMember(Alias = "installs")]
     public List<InstallCheckItem> Installs { get; set; } = new();
 

--- a/cli/managedsoftwareupdate/Services/CatalogService.cs
+++ b/cli/managedsoftwareupdate/Services/CatalogService.cs
@@ -14,17 +14,12 @@ namespace Cimian.CLI.managedsoftwareupdate.Services;
 public class CatalogService
 {
     private readonly HttpClient _httpClient;
-    private readonly IDeserializer _deserializer;
     private readonly CimianConfig _config;
 
     public CatalogService(CimianConfig config, HttpClient? httpClient = null)
     {
         _config = config;
         _httpClient = httpClient ?? CimianHttpClientFactory.CreateHttpClient(config);
-        _deserializer = new DeserializerBuilder()
-            .WithNamingConvention(UnderscoredNamingConvention.Instance)
-            .IgnoreUnmatchedProperties()
-            .Build();
     }
 
     /// <summary>
@@ -195,7 +190,10 @@ public class CatalogService
     {
         try
         {
-            var wrapper = _deserializer.Deserialize<CatalogWrapper>(yaml);
+            // Route through the canonical Cimian deserializer (no naming convention):
+            // it preserves explicit YamlMember aliases like `OnDemand`, which the old
+            // UnderscoredNamingConvention silently rewrote to `on_demand` and dropped.
+            var wrapper = YamlUtils.Deserializer.Deserialize<CatalogWrapper>(yaml);
             return wrapper?.Items ?? new List<CatalogItem>();
         }
         catch
@@ -203,7 +201,7 @@ public class CatalogService
             // Try parsing as a list directly
             try
             {
-                return _deserializer.Deserialize<List<CatalogItem>>(yaml) ?? new List<CatalogItem>();
+                return YamlUtils.Deserializer.Deserialize<List<CatalogItem>>(yaml) ?? new List<CatalogItem>();
             }
             catch
             {

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -1947,7 +1947,11 @@ exit 0
         }
         catch (Exception ex)
         {
-            ConsoleLogger.Debug($"OnDemand item '{item.Name}' - no receipt to remove: {ex.Message}");
+            // DeleteSubKey(..., throwOnMissingSubKey: false) does not throw when the key
+            // is absent (the common case) — it returns via the success path above. So any
+            // exception here is a real failure to remove an existing stale receipt
+            // (e.g. access denied), which must be surfaced rather than silently swallowed.
+            ConsoleLogger.Warn($"OnDemand item '{item.Name}' - failed to remove stale ManagedInstalls receipt: {ex.Message}");
         }
     }
 

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -523,6 +523,12 @@ public class InstallerService
     {
         try
         {
+            if (item.OnDemand)
+            {
+                RemoveManagedInstallReceipt(item);
+                return;
+            }
+
             using var key = Registry.LocalMachine.CreateSubKey($@"SOFTWARE\ManagedInstalls\{item.Name}");
             if (key == null) return;
 
@@ -1874,6 +1880,12 @@ exit 0
     {
         try
         {
+            if (item.OnDemand)
+            {
+                RemoveManagedInstallReceipt(item);
+                return;
+            }
+
             using var key = Registry.LocalMachine.CreateSubKey(
                 $@"SOFTWARE\ManagedInstalls\{item.Name}");
 
@@ -1916,6 +1928,26 @@ exit 0
         catch (Exception ex)
         {
             ConsoleLogger.Warn($"Failed to unregister installation: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Removes any ManagedInstalls receipt for an OnDemand item. OnDemand items are
+    /// never tracked as installed, so after a (re)install we drop the receipt instead
+    /// of writing one. This also self-heals stale receipts written by older clients
+    /// that ignored the OnDemand field and recorded the item as installed.
+    /// </summary>
+    private void RemoveManagedInstallReceipt(CatalogItem item)
+    {
+        try
+        {
+            Registry.LocalMachine.DeleteSubKey(
+                $@"SOFTWARE\ManagedInstalls\{item.Name}", false);
+            ConsoleLogger.Debug($"OnDemand item '{item.Name}' - not recording ManagedInstalls receipt");
+        }
+        catch (Exception ex)
+        {
+            ConsoleLogger.Debug($"OnDemand item '{item.Name}' - no receipt to remove: {ex.Message}");
         }
     }
 

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -107,6 +107,22 @@ public class StatusService
                 // Otherwise fall through to normal checks
             }
 
+            // Priority 0: OnDemand items are never considered installed. They always
+            // (re)install and are never recorded in the receipts store. This check
+            // deliberately precedes installcheck_script: an OnDemand item always needs
+            // action, so its installcheck_script is not consulted here.
+            if (item.OnDemand)
+            {
+                ConsoleLogger.Info($"OnDemand item - always treated as not installed item: {item.Name}");
+                result.Status = "pending";
+                result.NeedsAction = true;
+                result.IsUpdate = false;
+                result.Reason = "OnDemand item — always (re)installed, never tracked as installed";
+                result.ReasonCode = StatusReasonCode.OnDemand;
+                result.DetectionMethod = DetectionMethod.None;
+                return result;
+            }
+
             // Priority 1: Check installcheck_script if defined (Go parity - runs before anything else)
             if (!string.IsNullOrEmpty(item.InstallcheckScript))
             {

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -976,13 +976,17 @@ public class UpdateEngine : IDisposable
                         // --item targets specific packages by name; bypass LoopGuard for those
                         // (run-scoped only — persistent suppression state is left intact so
                         // future runs without --item still honor it).
-                        var bypassLoopGuard = itemFilterService != null
-                            && itemFilterService.HasFilter
-                            && itemFilterService.Items.Contains(catalogItem.Name);
+                        // OnDemand items also bypass: by design they (re)install every run, so
+                        // the loop guard would otherwise suppress legitimate repeat installs.
+                        var bypassLoopGuard = catalogItem.OnDemand
+                            || (itemFilterService != null
+                                && itemFilterService.HasFilter
+                                && itemFilterService.Items.Contains(catalogItem.Name));
 
                         if (bypassLoopGuard)
                         {
-                            var msg = $"--item: bypassing LoopGuard for '{catalogItem.Name}'";
+                            var bypassReason = catalogItem.OnDemand ? "OnDemand" : "--item";
+                            var msg = $"{bypassReason}: bypassing LoopGuard for '{catalogItem.Name}'";
                             ConsoleLogger.Info(msg);
                             _sessionLogger?.Log("INFO", msg);
                         }

--- a/shared/core/Models/StatusReasonCode.cs
+++ b/shared/core/Models/StatusReasonCode.cs
@@ -108,6 +108,9 @@ public static class StatusReasonCode
     /// <summary>installcheck_script indicates install needed (exit code 0)</summary>
     public const string InstallcheckNeeded = "installcheck_needed";
 
+    /// <summary>OnDemand item — never tracked as installed; always (re)installed each run</summary>
+    public const string OnDemand = "on_demand";
+
     /// <summary>Architecture not supported on this system</summary>
     public const string ArchitectureMismatch = "architecture_mismatch";
 

--- a/tests/Managedsoftwareupdate/CatalogDeserializationTests.cs
+++ b/tests/Managedsoftwareupdate/CatalogDeserializationTests.cs
@@ -1,0 +1,50 @@
+using Xunit;
+using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.Core.Services;
+
+namespace Cimian.Tests.Managedsoftwareupdate;
+
+/// <summary>
+/// Tests that the runtime catalog model deserializes the way CatalogService parses
+/// downloaded catalogs (via the shared YamlUtils.Deserializer, no naming convention).
+/// </summary>
+public class CatalogDeserializationTests
+{
+    [Fact]
+    public void CatalogItem_BindsOnDemand_FromPascalCaseAlias()
+    {
+        // Regression: the old CatalogService deserializer applied
+        // UnderscoredNamingConvention, which rewrote the `OnDemand` alias to
+        // `on_demand` on read and silently dropped `OnDemand: true` from catalogs.
+        // The provisioning/enrollment nopkg items depend on this field binding.
+        const string yaml = """
+            name: Ω ProvisioningManifestEnrollment
+            version: 2025.12.10
+            OnDemand: true
+            installer:
+              type: nopkg
+            """;
+
+        var item = YamlUtils.Deserializer.Deserialize<CatalogItem>(yaml);
+
+        Assert.NotNull(item);
+        Assert.Equal("Ω ProvisioningManifestEnrollment", item!.Name);
+        Assert.True(item.OnDemand, $"OnDemand was {item.OnDemand} — catalog field was dropped on parse");
+    }
+
+    [Fact]
+    public void CatalogItem_OnDemandDefaultsFalse_WhenAbsent()
+    {
+        const string yaml = """
+            name: RegularPackage
+            version: 1.0.0
+            installer:
+              type: msi
+            """;
+
+        var item = YamlUtils.Deserializer.Deserialize<CatalogItem>(yaml);
+
+        Assert.NotNull(item);
+        Assert.False(item!.OnDemand);
+    }
+}

--- a/tests/Managedsoftwareupdate/StatusServiceTests.cs
+++ b/tests/Managedsoftwareupdate/StatusServiceTests.cs
@@ -455,4 +455,51 @@ public class StatusServiceTests
     }
 
     #endregion
+
+    #region OnDemand Tests
+
+    [Fact]
+    public void CheckStatus_OnDemand_NoChecks_AlwaysNeedsAction()
+    {
+        // An item with no checks normally reports "installed" (see
+        // CheckStatus_NewItem_WithNoChecks_AssumesInstalled). OnDemand must override
+        // that: OnDemand items are never considered installed and always (re)install.
+        var item = new CatalogItem
+        {
+            Name = "OnDemandNoChecks",
+            Version = "1.0.0",
+            OnDemand = true
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.Equal("pending", result.Status);
+        Assert.True(result.NeedsAction);
+        Assert.False(result.IsUpdate);
+        Assert.Equal(Cimian.Core.Models.StatusReasonCode.OnDemand, result.ReasonCode);
+    }
+
+    [Fact]
+    public void CheckStatus_OnDemand_PrecedesInstallcheckScript()
+    {
+        // OnDemand short-circuits before installcheck_script: even an installcheck that
+        // says "not needed" (exit 1 => installed) must not stop an OnDemand item from
+        // re-running. This is the behavior the provisioning/enrollment nopkg items rely
+        // on so they keep running every cycle until they drop out of the manifest.
+        var item = new CatalogItem
+        {
+            Name = "OnDemandWithInstallcheck",
+            Version = "1.0.0",
+            OnDemand = true,
+            InstallcheckScript = "exit 1" // "not needed" — would normally mark installed
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.Equal("pending", result.Status);
+        Assert.True(result.NeedsAction);
+        Assert.Equal(Cimian.Core.Models.StatusReasonCode.OnDemand, result.ReasonCode);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Problem

`OnDemand: true` pkginfo items were silently ignored by the client, so the field could never function as intended. An OnDemand item is supposed to re-evaluate and (re)install on every run and never be recorded as installed.

Two independent gaps broke this end to end:

1. **The catalog deserializer dropped the field.** `CatalogService` built its own `DeserializerBuilder` with `UnderscoredNamingConvention`, which re-aliases the explicit `[YamlMember(Alias="OnDemand")]` to `on_demand` on read — so `OnDemand: true` never bound and came back `false`.
2. **The runtime model had no field or logic.** `CatalogItem` had no `OnDemand` property and nothing honoured it, so these items got a normal `ManagedInstalls` receipt written and then short-circuited as "Installed" forever on subsequent runs.

Net effect: an OnDemand item would run once, record a receipt, report "Installed / up to date", and never run again.

## Fix

- **`UpdateModels.cs`** — add `OnDemand` to the runtime `CatalogItem`.
- **`CatalogService.cs`** — parse catalogs through the canonical `YamlUtils.Deserializer` (no naming convention) so aliased fields like `OnDemand` bind; removes the duplicate buggy deserializer.
- **`StatusService.CheckStatus`** — OnDemand items short-circuit to "always needs install" before `installcheck_script`; never treated as installed.
- **`InstallerService.cs`** — never write a `ManagedInstalls` receipt for OnDemand items, and delete any stale receipt (self-heals receipts written by older clients that ignored the field).
- **`UpdateEngine.cs`** — OnDemand items bypass the LoopGuard (they reinstall every run by design).
- **`StatusReasonCode.cs`** — add `on_demand` reason code.

## Tests

- `StatusServiceTests`: OnDemand overrides the no-checks "installed" assumption; OnDemand precedes `installcheck_script`.
- `CatalogDeserializationTests`: `OnDemand` actually binds from a catalog through the shared deserializer (regression for gap #1).

Full suite: 84/84 pass against `main`. Build clean, 0 warnings.

Claude-Session: https://claude.ai/code/session_01AaUS8UfLZJcqodyG6MjLXJ