### PR TITLE
osversion: match Windows 11 marketing version in OS eligibility gate

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -141,7 +141,7 @@ public class UpdateEngine : IDisposable
         var current = Cimian.Core.Version.VersionService.GetCurrentOsVersion();
 
         if (!string.IsNullOrWhiteSpace(min) &&
-            Cimian.Core.Version.VersionService.CompareVersions(current, min) < 0)
+            Cimian.Core.Version.VersionService.CompareOsVersion(current, min) < 0)
         {
             reason = $"requires OS {min} or newer, running {current}";
             reasonCode = StatusReasonCode.OsVersionTooOld;
@@ -149,7 +149,7 @@ public class UpdateEngine : IDisposable
         }
 
         if (!string.IsNullOrWhiteSpace(max) &&
-            Cimian.Core.Version.VersionService.CompareVersions(current, max) > 0)
+            Cimian.Core.Version.VersionService.CompareOsVersion(current, max) > 0)
         {
             reason = $"requires OS {max} or older, running {current}";
             reasonCode = StatusReasonCode.OsVersionTooNew;

--- a/shared/core/Version/VersionService.cs
+++ b/shared/core/Version/VersionService.cs
@@ -121,6 +121,100 @@ public static class VersionService
     }
 
     /// <summary>
+    /// Build number at which the Windows kernel began shipping as Windows 11.
+    /// Windows 11 kept the 10.0 major.minor of Windows 10 and is distinguished
+    /// only by build number, so Environment.OSVersion reports it as "10.0.22000+".
+    /// </summary>
+    private const long Windows11MinimumBuild = 22000;
+
+    /// <summary>
+    /// Compares a running Windows OS version against a minimum/maximum requirement
+    /// with awareness that Windows 11 reports a "10.0.&lt;build&gt;" kernel version.
+    /// Package authors write the marketing version ("11" / "11.0") in
+    /// minimum_os_version / maximum_os_version, so a literal numeric compare against
+    /// the running "10.0.26200" would wrongly reject Windows 11.
+    ///
+    /// When the requirement is a bare marketing major ("10" or "11"), the comparison
+    /// is by Windows generation only, so any Windows 11 build satisfies an "11" floor
+    /// or ceiling (and any Windows 10 build satisfies a "10" one). When the requirement
+    /// pins a build (e.g. "10.0.22631"), versions are compared numerically.
+    ///
+    /// Returns: -1 if current is older than required, 0 if equivalent, 1 if newer.
+    /// </summary>
+    public static int CompareOsVersion(string? current, string? requirement)
+    {
+        if (string.IsNullOrWhiteSpace(current) && string.IsNullOrWhiteSpace(requirement))
+            return 0;
+        if (string.IsNullOrWhiteSpace(current))
+            return -1;
+        if (string.IsNullOrWhiteSpace(requirement))
+            return 1;
+
+        // Bare marketing major ("10" / "11"): compare by Windows generation only.
+        if (TryGetMarketingMajor(Normalize(requirement), out var requiredGen))
+        {
+            return WindowsGenerationOf(current).CompareTo(requiredGen);
+        }
+
+        // Build-pinned requirement: compare numerically, but first fold any
+        // marketing "11.x.<build>" form (the example cimiimport prints for
+        // --maximum_os_version, e.g. "11.0.22000") into the "10.0.<build>"
+        // kernel version Windows actually reports — otherwise a build-pinned
+        // Win 11 value would compare as newer than the running "10.0.<build>".
+        return CompareVersions(ToKernelWindowsVersion(current), ToKernelWindowsVersion(requirement));
+    }
+
+    /// <summary>
+    /// Folds a marketing Windows 11 version ("11.x.&lt;build&gt;") into the kernel
+    /// version Windows reports ("10.0.&lt;build&gt;"). Windows 11 kept the 10.0
+    /// major.minor and differs only by build, so the build tail is preserved.
+    /// Versions that don't lead with a "11" major pass through unchanged.
+    /// </summary>
+    private static string ToKernelWindowsVersion(string version)
+    {
+        var parts = version.Trim().Split('.');
+        if (parts.Length >= 2 && parts[0] == "11")
+        {
+            // Keep everything after major.minor (the build[.revision] tail).
+            var tail = parts.Skip(2).ToArray();
+            return tail.Length > 0 ? $"10.0.{string.Join('.', tail)}" : "10.0";
+        }
+        return version;
+    }
+
+    /// <summary>
+    /// True when a normalized version is a bare Windows marketing major ("10" or "11"),
+    /// i.e. has no build segment that would pin it to a specific release.
+    /// </summary>
+    private static bool TryGetMarketingMajor(string normalized, out int major)
+    {
+        major = 0;
+        var parts = normalized.Split('.');
+        if (parts.Length == 1 && int.TryParse(parts[0], out var m) && (m == 10 || m == 11))
+        {
+            major = m;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Maps a running Windows version (e.g. "10.0.26200.0") to its marketing
+    /// generation: build >= 22000 is Windows 11, otherwise Windows 10.
+    /// </summary>
+    private static int WindowsGenerationOf(string version)
+    {
+        var parts = Normalize(version).Split('.');
+        // Build number lives in the third segment of major.minor.build[.revision].
+        if (parts.Length >= 3 && long.TryParse(parts[2], out var build))
+        {
+            return build >= Windows11MinimumBuild ? 11 : 10;
+        }
+        // No build present: fall back to the literal major.
+        return long.TryParse(parts[0], out var major) ? (int)major : 0;
+    }
+
+    /// <summary>
     /// Normalizes a version string by trimming trailing ".0" segments.
     /// Migrated from Go: pkg/version/version.go Normalize()
     /// </summary>

--- a/tests/VersionServiceTests.cs
+++ b/tests/VersionServiceTests.cs
@@ -158,9 +158,50 @@ public class VersionServiceTests
         else if (expectedSign > 0) result.Should().BePositive();
         else result.Should().Be(0);
     }
-    
+
     #endregion
-    
+
+    #region CompareOsVersion Tests
+
+    [Theory]
+    // Windows 11 reports a 10.0.<build> kernel version; a bare "11" requirement
+    // must match by generation (build >= 22000), not by literal major.
+    [InlineData("10.0.26200.0", "11.0", 0)]    // Win 11 25H2 satisfies "11"
+    [InlineData("10.0.26200.0", "11", 0)]      // bare major, no minor
+    [InlineData("10.0.22000.0", "11.0", 0)]    // first Win 11 build
+    [InlineData("10.0.19045.0", "11.0", -1)]   // Win 10 is older than "11"
+    [InlineData("10.0.26200.0", "10.0", 1)]    // Win 11 is newer than "10"
+    [InlineData("10.0.26200.0", "10", 1)]      // bare "10"
+    [InlineData("10.0.19045.0", "10.0", 0)]    // Win 10 satisfies "10"
+    // Build-pinned requirements compare numerically (no marketing mapping).
+    [InlineData("10.0.26200.0", "10.0.22631", 1)]
+    [InlineData("10.0.19045.0", "10.0.22631", -1)]
+    // Build-pinned marketing form ("11.0.<build>", as cimiimport's --maximum_os_version
+    // help prints) folds to the kernel "10.0.<build>" before the numeric compare.
+    [InlineData("10.0.26200.0", "11.0.22000", 1)]    // Win 11 25H2 newer than 11.0.22000 floor
+    [InlineData("10.0.22000.0", "11.0.22000", 0)]    // exact build match
+    [InlineData("10.0.19045.0", "11.0.22000", -1)]   // Win 10 older than 11.0.22000
+    public void CompareOsVersion_ReturnsCorrectSign(string current, string requirement, int expectedSign)
+    {
+        var result = VersionService.CompareOsVersion(current, requirement);
+
+        if (expectedSign < 0) result.Should().BeNegative();
+        else if (expectedSign > 0) result.Should().BePositive();
+        else result.Should().Be(0);
+    }
+
+    [Fact]
+    public void CompareOsVersion_Win11_SatisfiesBothMinAndMax11()
+    {
+        // Regression: a "11.0" minimum AND a "11.0" maximum must both admit Win 11.
+        const string win11 = "10.0.26200.0";
+
+        VersionService.CompareOsVersion(win11, "11.0").Should().Be(0, "Win 11 is not older than min 11.0");
+        VersionService.CompareOsVersion(win11, "11.0").Should().Be(0, "Win 11 is not newer than max 11.0");
+    }
+
+    #endregion
+
     #region Real-World Catalog Version Tests
     
     /// <summary>


### PR DESCRIPTION
## Problem

`Environment.OSVersion.Version` reports Windows 11 as `10.0.26200.0` — Microsoft never bumped the kernel major to 11. Package authors write the marketing version (`11.0`) in `minimum_os_version` / `maximum_os_version`, so the eligibility gate did a literal numeric compare of `10.0.26200 < 11.0`, concluded "too old," and skipped the item on every Windows 11 machine:

```
Skipping ProvisioningManifestEnrollment: requires OS 11.0 or newer, running 10.0.26200.0
```

## Fix

- **`VersionService.CompareOsVersion(current, requirement)`** — new OS-aware comparison:
  - A bare marketing major (`10` / `11`) is matched by **Windows generation**: build >= 22000 is Windows 11, else Windows 10. So `10.0.26200` resolves to generation 11 and satisfies a `11.0` floor *and* ceiling (returns 0).
  - A build-pinned requirement (e.g. `10.0.22631`) still compares numerically via the existing `CompareVersions`, so precise targeting is unchanged.
  - The generic `CompareVersions` is left untouched — it is also used for Chrome/date/package versions that must stay literal.
- **`UpdateEngine.IsEligibleForOsVersion`** — the min (too-old) and max (too-new) checks now call `CompareOsVersion`.
- **Tests** — added a `CompareOsVersion` region covering Win 11 vs `11.0`, Win 10 vs `11.0` (too old), Win 11 vs `10.0` (newer), build-pinned numeric compares, and a regression that Win 11 satisfies both a `11.0` minimum and a `11.0` maximum.

All 77 `VersionServiceTests` pass.