### PR TITLE
import: don't emit hidden-wrapper ProductCode for installer-type MSIs

### DIFF
--- a/cli/makepkginfo/Services/MetadataExtractor.cs
+++ b/cli/makepkginfo/Services/MetadataExtractor.cs
@@ -22,7 +22,15 @@ public class MetadataExtractor
         string Developer,
         string Description,
         string ProductCode,
-        string UpgradeCode);
+        string UpgradeCode)
+    {
+        /// <summary>
+        /// True when the MSI is a cimipkg installer-type wrapper (ARPSYSTEMCOMPONENT=1):
+        /// the ProductCode is the hidden per-build wrapper, not the wrapped app, so it must
+        /// not be emitted as installs[] detection.
+        /// </summary>
+        public bool IsInstallerType { get; init; }
+    }
 
     /// <summary>
     /// NUPKG metadata extraction result
@@ -63,7 +71,13 @@ public class MetadataExtractor
                 ReadProp("Comments")?.Trim() ?? "",
                 ReadProp("ProductCode")?.Trim() ?? "",
                 ReadProp("UpgradeCode")?.Trim() ?? ""
-            );
+            )
+            {
+                // cimipkg sets ARPSYSTEMCOMPONENT=1 on installer-type wrappers (empty
+                // install_location). Their ProductCode is the hidden per-build wrapper, not
+                // the wrapped app — don't emit it as detection.
+                IsInstallerType = ReadProp("ARPSYSTEMCOMPONENT")?.Trim() == "1"
+            };
         }
         catch
         {

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -117,7 +117,11 @@ public class PkgInfoBuilder
                 productCode = msiMeta.ProductCode;
                 upgradeCode = msiMeta.UpgradeCode;
 
-                installs.Add(BuildMsiInstallItem(msiMeta));
+                // Installer-type wrappers (ARPSYSTEMCOMPONENT=1) carry a hidden per-build
+                // ProductCode that detects the WRAPPER, not the wrapped app — never emit it.
+                // Wrapped-app detection is authored in the repo (pre-commit enforces it).
+                if (!msiMeta.IsInstallerType)
+                    installs.Add(BuildMsiInstallItem(msiMeta));
                 break;
 
             case ".exe":

--- a/shared/import/Models/ImportModels.cs
+++ b/shared/import/Models/ImportModels.cs
@@ -246,6 +246,15 @@ public class InstallerMetadata
     /// display_name. Empty for normal MSIs.
     /// </summary>
     public string ArpDisplayName { get; set; } = "";
+
+    /// <summary>
+    /// True when this is a cimipkg "installer-type" wrapper: empty install_location,
+    /// ARPSYSTEMCOMPONENT=1, a fresh per-build ProductCode, and a payload that is itself a
+    /// vendor installer run by the postinstall. The MSI's own ProductCode and BOM are the
+    /// HIDDEN wrapper / staged payload — NOT the wrapped app — so they must never be emitted
+    /// as detection. Wrapped-app installs[] is authored in the repo (pre-commit enforces it).
+    /// </summary>
+    public bool IsInstallerType { get; set; }
 }
 
 /// <summary>

--- a/shared/import/Services/ImportService.cs
+++ b/shared/import/Services/ImportService.cs
@@ -590,6 +590,33 @@ public class ImportService
                 }
             ];
         }
+        else if (metadata.IsInstallerType)
+        {
+            // Installer-type wrapper (empty install_location, hidden ARPSYSTEMCOMPONENT, fresh
+            // per-build ProductCode): the MSI's own ProductCode/BOM are the wrapper + staged
+            // payload, NOT the wrapped app — never emit them as detection. If build-info gave a
+            // key_path (pointing at the wrapped app's binary), emit a type=file check; else
+            // leave installs[] empty so the wrapped-app detection is authored in the repo
+            // (the pre-commit installer-type check enforces it for these hidden wrappers).
+            if (!string.IsNullOrWhiteSpace(metadata.KeyPath))
+            {
+                prompter.ReportInfo($"Installer-type wrapper — wrapped-app key_path => {metadata.KeyPath}");
+                finalInstalls =
+                [
+                    new InstallItem
+                    {
+                        Type = "file",
+                        Path = metadata.KeyPath,
+                        Version = packageVersion
+                    }
+                ];
+            }
+            else
+            {
+                prompter.ReportInfo("Installer-type wrapper (hidden ARPSYSTEMCOMPONENT) — installs[] must describe the WRAPPED app; none derivable from the wrapper, leaving empty for repo authoring.");
+                finalInstalls = [];
+            }
+        }
         else if (metadata.InstallerType == "msi"
             && (!string.IsNullOrEmpty(metadata.ProductCode) || !string.IsNullOrEmpty(metadata.UpgradeCode)))
         {
@@ -633,7 +660,9 @@ public class ImportService
             finalInstalls = [];
         }
 
-        if (metadata.Installs.Count > 0)
+        // Skip the MSI BOM file checks for installer-type wrappers — those enumerate the
+        // staged vendor installer under temp, not the wrapped app.
+        if (!metadata.IsInstallerType && metadata.Installs.Count > 0)
         {
             finalInstalls.AddRange(metadata.Installs);
         }

--- a/shared/import/Services/MetadataExtractor.cs
+++ b/shared/import/Services/MetadataExtractor.cs
@@ -159,6 +159,14 @@ public partial class MetadataExtractor
             if (!string.IsNullOrEmpty(fullVersion))
                 metadata.Version = ParseVersion(fullVersion);
 
+            // Installer-type wrapper detection: cimipkg leaves install_location empty and sets
+            // ARPSYSTEMCOMPONENT=1 when the payload is itself a vendor installer run by the
+            // postinstall. The MSI's ProductCode is then the hidden per-build wrapper and its
+            // BOM is the staged payload — neither is the wrapped app, so neither may become
+            // detection (see PopulateMsiBom below + ImportService + the pre-commit check).
+            metadata.IsInstallerType = buildInfo != null
+                && string.IsNullOrWhiteSpace(buildInfo.InstallLocation);
+
             // Auto-populate the defense-in-depth file checks from the MSI's
             // native bill of materials (File ⨯ Component ⨯ Directory tables).
             // The pkginfo gets either:
@@ -208,6 +216,14 @@ public partial class MetadataExtractor
 
             if (buildInfo != null)
             {
+                // Installer-type wrapper: the BOM is the STAGED vendor installer (e.g.
+                // setup.exe under the [INSTALLDIR] temp folder), not the wrapped app. Picking
+                // it as the key_path would produce bogus detection, so leave KeyPath empty
+                // unless build-info supplied an explicit key_path (handled in branch 1 above,
+                // which the user would point at the WRAPPED app).
+                if (metadata.IsInstallerType)
+                    return;
+
                 // cimipkg MSI, no override — pick single primary binary by heuristic.
                 var productName = buildInfo.Product?.Name ?? metadata.Title;
                 metadata.KeyPath = MsiBomReader.PickPrimaryBinary(exes, productName) ?? "";


### PR DESCRIPTION
## Problem
cimipkg "installer-type" packages (empty `install_location`) build an MSI that wraps a vendor installer run by the postinstall, and set `ARPSYSTEMCOMPONENT=1` so the wrapper hides from Add/Remove Programs. That wrapper's ProductCode is a fresh per-build GUID for the **hidden wrapper**, not the wrapped app — yet both import paths auto-emitted it as the `installs[]` type=msi detection (and the BOM heuristic picked the staged vendor installer under temp as the key_path). Result: managedsoftwareupdate can't actually tell when the wrapped app is installed.

## Fix
Detect installer-type and never emit the wrapper's identity as detection:
- **shared/import** (cimiimport + the `--emit-installs` autopkg path): `MetadataExtractor` sets `InstallerMetadata.IsInstallerType` from the decoded build-info's empty `install_location`; `PopulateMsiBom` skips the staged-payload key_path heuristic; `BuildFinalInstallsArray` skips the wrapper-ProductCode branch and the BOM file-checks. If build-info supplies a `key_path` (the wrapped app's binary) it emits a type=file check; otherwise installs[] is left empty so wrapped-app detection is authored in the repo (a pre-commit check in the deployment repo enforces it). Coexists with the existing `ArpDisplayName` wrapper handling.
- **makepkginfo**: detects installer-type via `ARPSYSTEMCOMPONENT=1` and skips emitting the wrapper ProductCode.

Detection for these wrappers must target the WRAPPED app and lives in the repo pkgsinfo, never the endpoint registry.

## Test
`dotnet build` clean (both projects). Verified against built installer-type and copy-type cimipkg MSIs through **both** makepkginfo and cimiimport: installer-type → no product_code; copy-type → product_code + upgrade_code emitted (no regression).