### PR TITLE
managedsoftwareupdate: install SbinInstaller MSI via msiexec to avoid self-replacement lock

### DIFF
--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -833,10 +833,22 @@ public class InstallerService
         // cimipkg-built MSI have CIMIAN_PKG_BUILD_INFO in the Property table.
         // Route these through sbin-installer (deterministic structure, tested path).
         // Commercial/vendor MSI go straight to msiexec (battle-tested, 25 years of edge cases).
-        if (IsCimianBuiltMsi(localFile) && IsSbinInstallerAvailable())
+        //
+        // Exception: SbinInstaller's own MSI must NOT go through sbin-installer.
+        // The running sbin-installer.exe locks C:\Program Files\sbin\installer.exe,
+        // so the MSI either fails with 1603 (file in use) or schedules a
+        // reboot-replace that lab machines never perform — the installed version
+        // pins at the old build and the item reinstall-loops every session until
+        // LoopGuard suppresses it (73 devices, AB#3709).
+        var replacesSbinInstaller = string.Equals(item.Name, "SbinInstaller", StringComparison.OrdinalIgnoreCase);
+        if (!replacesSbinInstaller && IsCimianBuiltMsi(localFile) && IsSbinInstallerAvailable())
         {
             ConsoleLogger.Info($"[INSTALLER METHOD: sbin-installer] cimipkg-built MSI detected: {item.Name}");
             return await RunSbinInstallerAsync(localFile, item, cancellationToken);
+        }
+        if (replacesSbinInstaller)
+        {
+            ConsoleLogger.Info($"[INSTALLER METHOD: msiexec] {item.Name} replaces sbin-installer itself - bypassing sbin-installer to avoid self-replacement file lock");
         }
 
         ConsoleLogger.Info($"[INSTALLER METHOD: msiexec] Installing MSI: {item.Name}");


### PR DESCRIPTION
The MSI routing in InstallMsiAsync sends every cimipkg-built MSI through sbin-installer â€” including SbinInstaller's own update. The running sbin-installer.exe locks C:\Program Files\sbin\installer.exe, so the replace either dies with 1603 (file in use) or schedules a reboot-rename that lab machines never perform. The installed version pins at the old build and the item reinstall-loops every session until LoopGuard suppresses it â€” currently 73 devices warning fleet-wide (Azure Boards , ReportMate warning remediation).

Fix: bypass sbin-installer for the SbinInstaller item and use the msiexec path directly; sbin-installer is not running there, so the binary replaces cleanly. Observed on TARYNPORTER (0F348XK24333HH): catalog 2026.06.23.1045 'installed 6 times across 3 sessions' while installedVersion stayed 2026.05.26.1753.

Related follow-up worth a separate look: ResolveExpandedVersion prefers any date-format ManagedInstalls receipt over compressed MSI versions (2026.x always > 26.x), so a stale receipt pins detection even when the exact per-version ProductCode is registered.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
