### PR TITLE
recurring loop-exempt field for idempotent maintenance items

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -178,6 +178,14 @@ public class PkgsInfo
     [YamlMember(Alias = "OnDemand")]
     public bool OnDemand { get; set; }
 
+    // Recurring items are idempotent maintenance actions (cache clears, time sync,
+    // account/user checks) that are DESIGNED to run every session, so their
+    // installcheck legitimately returns "install needed" run after run. This flag
+    // exempts them from LoopGuard suppression (see UpdateEngine) without the OnDemand
+    // no-receipt/never-installed semantics. Round-trips pkgsinfo -> catalog here.
+    [YamlMember(Alias = "recurring")]
+    public bool Recurring { get; set; }
+
     /// <summary>
     /// Source file path (not serialized)
     /// </summary>

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -124,6 +124,11 @@ public class PkgsInfo
     [YamlMember(Alias = "OnDemand", Order = 22, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
     public bool OnDemand { get; set; }
 
+    // Exempts idempotent recurring-maintenance items from LoopGuard suppression
+    // (see UpdateEngine). Omitted from output unless set true.
+    [YamlMember(Alias = "recurring", Order = 22, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public bool Recurring { get; set; }
+
     [YamlMember(Alias = "managed_profiles", Order = 23, DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
     public List<string>? ManagedProfiles { get; set; }
 

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -472,6 +472,15 @@ public class CatalogItem
     [YamlMember(Alias = "OnDemand")]
     public bool OnDemand { get; set; }
 
+    // Recurring maintenance items (idempotent nopkg scripts DESIGNED to run every
+    // session — cache clears, time sync, user/account checks) legitimately re-run
+    // with the same version. LoopGuard would otherwise count those repeats as an
+    // install loop and suppress them with a warning (the whole recurring-script tail
+    // of AB#3709). This flag exempts the item from loop suppression WITHOUT OnDemand's
+    // no-receipt/never-installed semantics, so the item still tracks normally.
+    [YamlMember(Alias = "recurring")]
+    public bool Recurring { get; set; }
+
     [YamlMember(Alias = "installs")]
     public List<InstallCheckItem> Installs { get; set; } = new();
 

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1043,14 +1043,19 @@ public class UpdateEngine : IDisposable
                         // future runs without --item still honor it).
                         // OnDemand items also bypass: by design they (re)install every run, so
                         // the loop guard would otherwise suppress legitimate repeat installs.
+                        // Recurring items bypass for the same reason: idempotent maintenance
+                        // scripts (cache clears, time sync, account checks) are meant to run
+                        // every session, so their repeated same-version runs are not a loop.
                         var bypassLoopGuard = catalogItem.OnDemand
+                            || catalogItem.Recurring
                             || (itemFilterService != null
                                 && itemFilterService.HasFilter
                                 && itemFilterService.Items.Contains(catalogItem.Name));
 
                         if (bypassLoopGuard)
                         {
-                            var bypassReason = catalogItem.OnDemand ? "OnDemand" : "--item";
+                            var bypassReason = catalogItem.OnDemand ? "OnDemand"
+                                : catalogItem.Recurring ? "recurring" : "--item";
                             var msg = $"{bypassReason}: bypassing LoopGuard for '{catalogItem.Name}'";
                             ConsoleLogger.Info(msg);
                             _sessionLogger?.Log("INFO", msg);


### PR DESCRIPTION
## Problem
Idempotent maintenance nopkg scripts (ClearSoftwareCaches, SystemKeepTime, AdobeUserChecker, DeadlineWorkerDisableGUI, etc.) are designed to run every session. Their installcheck legitimately returns "install needed" run after run, so LoopGuard counts the same-version repeats as an install loop and suppresses them with a warning â€” a long tail of false-positive `LOOP SUPPRESSED` warnings in ReportMate.

## Fix
Add a `recurring` pkgsinfo bool that exempts the item from LoopGuard the same way `OnDemand` does (in the bypassLoopGuard check in UpdateEngine), but **without** OnDemand's never-installed / no-receipt semantics â€” so the item still tracks its version normally and only the loop suppression is skipped.

Round-trips pkgsinfo â†’ catalog via makecatalogs; read by the client (UpdateModels); emitted by makepkginfo. All three CLIs build clean (`dotnet build -c Release`, 0 warnings/errors).

## Usage
```yaml
recurring: true   # in the pkgsinfo of a designed-recurring maintenance item
```

Once released, the recurring maintenance pkgsinfo get marked and the false-positive loop warnings clear fleet-wide.
