### PR TITLE
ApplyPolicyOverrides: never override per-device ClientIdentifier/SoftwareRepoURL (orphan guardrail)

### DIFF
--- a/cli/managedsoftwareupdate/Services/ConfigurationService.cs
+++ b/cli/managedsoftwareupdate/Services/ConfigurationService.cs
@@ -39,8 +39,17 @@ public class ConfigurationService
     /// <summary>
     /// MDM policy overrides delivered by the CimianPrefs Intune profile
     /// (ADMX-ingested Policy CSP writing to HKLM\SOFTWARE\Policies\Cimian).
-    /// Policy wins over Config.yaml so fleet-wide settings can ship as an
+    /// Policy wins over Config.yaml so genuinely fleet-STATIC settings can ship as an
     /// Intune configuration profile instead of per-device file edits (AB#3709).
+    ///
+    /// ONLY fleet-static values are honored here. Per-device / runtime-computed values —
+    /// ClientIdentifier (derived from the serial via Snipe-IT by preflight) and
+    /// SoftwareRepoURL (preflight picks the local-cache/Mars vs central endpoint at run
+    /// time) — are deliberately NOT policy-overridable: preflight recomputes them every
+    /// cycle, so letting a static policy win silently overrides the correct per-device
+    /// value. A stale/placeholder ClientIdentifier ("EnrollClient") shipped this way once
+    /// forced the whole fleet onto the enrollment manifest and ORPHANED devices (AB#3709);
+    /// this exclusion is the guardrail so that class of profile mistake can never recur.
     /// </summary>
     private const string PolicyRegistryPath = @"SOFTWARE\Policies\Cimian";
 
@@ -54,15 +63,9 @@ public class ConfigurationService
                 return config;
             }
 
-            if (key.GetValue("SoftwareRepoURL") is string repoUrl && !string.IsNullOrWhiteSpace(repoUrl))
-            {
-                config.SoftwareRepoURL = repoUrl.Trim();
-            }
-
-            if (key.GetValue("ClientIdentifier") is string clientId && !string.IsNullOrWhiteSpace(clientId))
-            {
-                config.ClientIdentifier = clientId.Trim();
-            }
+            // NOTE: SoftwareRepoURL and ClientIdentifier are intentionally NOT read from
+            // policy — they are per-device / runtime values owned by preflight. See the
+            // method summary. Only fleet-static settings (InstallerTimeout) are honored.
 
             // ADMX decimal elements arrive as REG_DWORD; the Policy CSP has also
             // been observed delivering numerics as strings, so accept both.


### PR DESCRIPTION
## Incident
v0.1.4's `ApplyPolicyOverrides` reads `HKLM\SOFTWARE\Policies\Cimian` and let it win over Config.yaml. It overrode **ClientIdentifier** (per-device, computed by preflight from serialâ†’Snipe-IT) and **SoftwareRepoURL** (preflight's runtime Mars/central choice) in addition to InstallerTimeout. A stale placeholder `ClientIdentifier=EnrollClient` shipped in the CimianPrefs profile therefore forced the whole fleet onto the enrollment manifest â†’ **orphaned devices**.

## Fix
Restrict policy override to genuinely fleet-static settings â€” **InstallerTimeout only**. ClientIdentifier and SoftwareRepoURL are per-device/runtime values owned by preflight and are no longer policy-overridable, so no future profile mistake can orphan the fleet through them. Builds clean (`dotnet build -c Release`, 0 warn/err).
