### PR TITLE
VersionService: compare Cimian calendar build stamps by build time

### DIFF
--- a/shared/core/Version/VersionService.cs
+++ b/shared/core/Version/VersionService.cs
@@ -66,21 +66,7 @@ public static class VersionService
         if (string.IsNullOrWhiteSpace(remote))
             return false; // Any local is not older than empty remote
         
-        // Normalize both versions
-        var localNormalized = Normalize(local);
-        var remoteNormalized = Normalize(remote);
-        
-        // Parse and compare
-        var localParsed = ParseVersion(localNormalized);
-        var remoteParsed = ParseVersion(remoteNormalized);
-        
-        if (localParsed == null || remoteParsed == null)
-        {
-            // Fallback to string comparison if parsing fails
-            return string.Compare(localNormalized, remoteNormalized, StringComparison.OrdinalIgnoreCase) < 0;
-        }
-        
-        return localParsed.CompareTo(remoteParsed) < 0;
+        return CompareVersions(local, remote) < 0;
     }
     
     /// <summary>
@@ -97,7 +83,18 @@ public static class VersionService
             
         if (string.IsNullOrWhiteSpace(v2))
             return 1;
-        
+
+        // When both are Cimian calendar build stamps, compare by decoded build time.
+        // Element-wise numeric comparison mis-orders the legacy 3-component form:
+        // "2026.7.2006" -> [2026,7,2006] sorts newer than "2026.07.20.0632" ->
+        // [2026,7,20,632] because 2006 > 20, which would let a stale agent consider
+        // itself current and suppress its own self-update. See TryParseCalendarBuildStamp.
+        if (TryParseCalendarBuildStamp(v1, out var stamp1) &&
+            TryParseCalendarBuildStamp(v2, out var stamp2))
+        {
+            return stamp1.CompareTo(stamp2);
+        }
+
         var v1Normalized = Normalize(v1);
         var v2Normalized = Normalize(v2);
         
@@ -241,6 +238,98 @@ public static class VersionService
         return string.Join(".", trimmedParts);
     }
     
+    /// <summary>
+    /// Bounds for treating a leading 4-digit component as a calendar year rather
+    /// than a large version major (e.g. Unity's 6000.x). Mirrors cimipkg's
+    /// VersionParser year gate.
+    /// </summary>
+    private const int CalendarYearMin = 2000;
+    private const int CalendarYearMax = 2100;
+
+    /// <summary>
+    /// Decodes a Cimian calendar build stamp into a sortable YYYYMMDDHHMM key.
+    ///
+    /// The client stamps builds as <c>yyyy.MM.dd.HHmm</c> (canonical, e.g.
+    /// <c>2026.07.20.0632</c>). Older builds emitted a 3-component <c>yyyy.M.DDHH</c>
+    /// form with day and hour merged and no minutes (<c>2026.7.2006</c> is
+    /// 2026-07-20 06:00), or a plain <c>yyyy.M.d</c>. All encode a build datetime;
+    /// this returns them on one comparable scale so agent-version currency is reliable.
+    ///
+    /// Requires an explicit 4-digit year in [<see cref="CalendarYearMin"/>,
+    /// <see cref="CalendarYearMax"/>]. Semantic versions, Windows build numbers, and
+    /// Chrome-style versions therefore never match and fall through to the general
+    /// comparison unchanged. The 2-digit MSI ProductVersion form (<c>26.7.2118</c>) is
+    /// deliberately not matched — it never enters the agent version path and matching
+    /// it would collide with ordinary two-digit-major semver.
+    /// </summary>
+    /// <returns>True and sets <paramref name="sortKey"/> if <paramref name="version"/>
+    /// is a recognizable calendar build stamp; otherwise false.</returns>
+    internal static bool TryParseCalendarBuildStamp(string? version, out long sortKey)
+    {
+        sortKey = 0;
+        if (string.IsNullOrWhiteSpace(version))
+            return false;
+
+        var parts = version.Trim().Split('.');
+        if (parts.Length < 3)
+            return false;
+        foreach (var part in parts)
+        {
+            if (part.Length == 0 || !part.All(char.IsDigit))
+                return false;
+        }
+
+        // 4-digit calendar-year gate.
+        if (parts[0].Length != 4 || !int.TryParse(parts[0], out var year))
+            return false;
+        if (year < CalendarYearMin || year > CalendarYearMax)
+            return false;
+
+        var month = int.Parse(parts[1]);
+        if (month < 1 || month > 12)
+            return false;
+
+        int day, hour, minute;
+        if (parts.Length >= 4)
+        {
+            // yyyy.MM.dd.HHmm
+            day = int.Parse(parts[2]);
+            var hhmm = int.Parse(parts[3]);
+            hour = hhmm / 100;
+            minute = hhmm % 100;
+        }
+        else
+        {
+            // Exactly 3 components.
+            var third = int.Parse(parts[2]);
+            if (third <= 31)
+            {
+                // yyyy.M.d — plain calendar day, no time component.
+                day = third;
+                hour = 0;
+                minute = 0;
+            }
+            else if (third >= 100)
+            {
+                // yyyy.M.DDHH — day and hour merged, minutes dropped.
+                day = third / 100;
+                hour = third % 100;
+                minute = 0;
+            }
+            else
+            {
+                // 32..99: neither a valid day nor a DDHH pair.
+                return false;
+            }
+        }
+
+        if (day < 1 || day > 31 || hour < 0 || hour > 23 || minute < 0 || minute > 59)
+            return false;
+
+        sortKey = ((((long)year * 100 + month) * 100 + day) * 100 + hour) * 100 + minute;
+        return true;
+    }
+
     /// <summary>
     /// Parses a version string into a comparable Version object.
     /// Handles various formats: semantic, Windows build, Chrome-style, date-based.

--- a/tests/VersionServiceTests.cs
+++ b/tests/VersionServiceTests.cs
@@ -218,6 +218,60 @@ public class VersionServiceTests
     {
         VersionService.IsOlderVersion(local, remote).Should().Be(expected);
     }
-    
+
+    #endregion
+
+    #region Calendar Build Stamp Tests (AB#3754)
+
+    [Theory]
+    // The core bug: the legacy 3-component "yyyy.M.DDHH" stamp (day+hour merged, no
+    // minutes) must not sort newer than the 4-component "yyyy.MM.dd.HHmm" stamp.
+    // "2026.7.2006" is 2026-07-20 06:00; "2026.07.20.0632" is 2026-07-20 06:32.
+    [InlineData("2026.7.2006", "2026.07.20.0632", true)]    // 06:00 older than 06:32
+    [InlineData("2026.07.20.0632", "2026.7.2006", false)]   // and the reverse
+    [InlineData("2026.6.2405", "2026.06.24.0519", true)]    // 2026-06-24 05:00 < 05:19
+    [InlineData("2026.6.2418", "2026.06.24.0519", false)]   // 2026-06-24 18:00 > 05:19
+    [InlineData("2026.6.511", "2026.06.05.0221", false)]    // 2026-06-05 11:00 > 02:21
+    // Same build in both encodings compares equal enough for "not older".
+    [InlineData("2026.07.20.0632", "2026.07.20.0632", false)]
+    // Cross-encoding across months / year boundary.
+    [InlineData("2025.12.17.2120", "2026.01.20.1609", true)]
+    [InlineData("2026.7.2006", "2026.06.24.0519", false)]   // July build newer than June
+    public void IsOlderVersion_CalendarBuildStamps_ReturnsCorrectResult(string local, string remote, bool expected)
+    {
+        VersionService.IsOlderVersion(local, remote).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("2026.07.20.0632", 202607200632L)]  // canonical yyyy.MM.dd.HHmm
+    [InlineData("2026.7.2006", 202607200600L)]       // 3-component yyyy.M.DDHH -> 06:00
+    [InlineData("2026.6.511", 202606051100L)]        // DDHH with single-digit day
+    [InlineData("2026.6.2418", 202606241800L)]       // DDHH, hour 18
+    [InlineData("2026.7.5", 202607050000L)]          // plain yyyy.M.d -> midnight
+    [InlineData("2025.09.13.2245", 202509132245L)]
+    public void TryParseCalendarBuildStamp_ValidStamps_DecodeToSortKey(string version, long expected)
+    {
+        VersionService.TryParseCalendarBuildStamp(version, out var sortKey).Should().BeTrue();
+        sortKey.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("1.2.3")]              // semver
+    [InlineData("10.0.22621")]         // Windows build number
+    [InlineData("139.0.7258.139")]     // Chrome
+    [InlineData("26.7.2118")]          // MSI 2-digit-year form (out of scope by design)
+    [InlineData("2.55.0.windows.1")]   // NuGet-style suffix
+    [InlineData("2026.07.20.0632-beta1")] // pre-release suffix is not a bare stamp
+    [InlineData("2101.01.01.0000")]    // year above range
+    [InlineData("2026.13.01.0000")]    // month out of range
+    [InlineData("2026.7.99")]          // 32..99 third component: neither day nor DDHH
+    [InlineData("2026")]               // too few components
+    [InlineData("2026.7")]             // too few components
+    [InlineData("")]
+    public void TryParseCalendarBuildStamp_NonStamps_ReturnFalse(string version)
+    {
+        VersionService.TryParseCalendarBuildStamp(version, out _).Should().BeFalse();
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Why

Part of the fleet Cimian version-currency initiative. The agent's own
version-currency check mis-orders the legacy build-stamp encoding, which suppresses
self-update on exactly the devices that are behind.

The agent stamps builds as `yyyy.MM.dd.HHmm` (canonical, e.g. `2026.07.20.0632`).
Older builds emitted a 3-component `yyyy.M.DDHH` form with day and hour merged and no
minutes â€” `2026.7.2006` is 2026-07-20 06:00. `ParseVersion` splits on `.`, so:

- `2026.7.2006`     -> `[2026, 7, 2006]`
- `2026.07.20.0632` -> `[2026, 7, 20, 632]`

Element-wise, index 2 gives `2006 > 20`, so `IsOlderVersion("2026.7.2006",
"2026.07.20.0632")` returns **false** â€” the stale 3-component build is judged newer,
and the self-update gate (`UpdateEngine`, `ManifestService`) skips the update.

## Change

- `TryParseCalendarBuildStamp` decodes a Cimian calendar stamp to a sortable
  `YYYYMMDDHHMM` key, handling `yyyy.MM.dd.HHmm`, 3-component `yyyy.M.DDHH`
  (day+hour merged), and plain `yyyy.M.d`.
- `CompareVersions` short-circuits to that key **only when both operands are
  4-digit-year calendar stamps**. Semver, Windows build numbers (`10.0.x`), and
  Chrome versions (`139.0.x`) don't match the 4-digit-year gate and fall through to
  the existing comparison unchanged.
- `IsOlderVersion` now delegates to `CompareVersions` (proven equivalent for its
  null/empty semantics) so both share the fix.

The 2-digit MSI ProductVersion form (`26.7.2118`) is deliberately **not** matched â€”
it never enters the agent version path and matching it would collide with ordinary
two-digit-major semver.

## Tests

Added to `VersionServiceTests.cs`: the `2026.7.2006 < 2026.07.20.0632` inversion,
cross-encoding ordering across days/months/year boundary, stamp decode to sort key,
and non-stamp rejection (semver / Windows / Chrome / MSI form / pre-release). All
existing VersionService cases are unchanged as a regression guard. **106 pass**
(`dotnet test --filter VersionServiceTests`).

## Scope

Client-side self-update correctness. The ReportMate reader-side normalizer that feeds
the fleet currency metric is a sibling PR (reportmate-app-web#32); both implement the
same canonical `YYYY.MM.DD.HHMM` decode.

Work item: .

