### PR TITLE
makecatalogs/makepkginfo: carry installs[].display_name (wrapper-MSI ARP detection)

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -72,6 +72,16 @@ public class InstallItem
     [YamlMember(Alias = "upgrade_code")]
     public string? UpgradeCode { get; set; }
 
+    /// <summary>
+    /// ARP DisplayName fallback for wrapper MSIs (empty File table; payload
+    /// installed by an embedded setup.exe, e.g. Mozilla Firefox) that keep no
+    /// Windows Installer registration. The client (managedsoftwareupdate) opts
+    /// in per entry for its ARP substring match; makecatalogs must carry the
+    /// field through so it is not stripped out of the generated catalog.
+    /// </summary>
+    [YamlMember(Alias = "display_name")]
+    public string? DisplayName { get; set; }
+
     /// <summary>MSIX/APPX package identity name (from AppxManifest Identity/@Name).</summary>
     [YamlMember(Alias = "identity_name")]
     public string? IdentityName { get; set; }

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -50,6 +50,11 @@ public class InstallItem
 
     [YamlMember(Alias = "upgrade_code")]
     public string? UpgradeCode { get; set; }
+
+    // ARP DisplayName fallback for wrapper MSIs (e.g. Firefox) that keep no
+    // Windows Installer registration; carried through so it survives round-trips.
+    [YamlMember(Alias = "display_name")]
+    public string? DisplayName { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
The client (`managedsoftwareupdate`) supports an ARP DisplayName fallback on `type=msi` installs entries for wrapper MSIs that keep no Windows Installer registration (e.g. Mozilla Firefox) â€” see `UpdateModels.cs` InstallItem.DisplayName and the fallbacks in StatusService/InstallerService.

But `makecatalogs` and `makepkginfo` InstallItem models omitted `display_name`, so the field was **stripped out of generated catalogs** and the feature was inert fleet-wide. This adds the field to both models so it survives generation.

Verified: round-trip through the rebuilt makecatalogs now preserves `display_name` on the type=msi installs entry in the generated catalog.

Context: example-org  /  (Firefox install-loop remediation).
