### PR TITLE
Identify GPUs by PCI hardware ID so driver predicates survive a missing driver

### DIFF
--- a/cli/managedsoftwareupdate/Services/ManifestService.cs
+++ b/cli/managedsoftwareupdate/Services/ManifestService.cs
@@ -485,7 +485,7 @@ public class ManifestService
             var collector = new SystemFactsCollector(new ConsoleForwardingLogger<SystemFactsCollector>());
             collector.SetCatalogs(_config.Catalogs);
             _systemFacts = collector.CollectAsync().GetAwaiter().GetResult();
-            ConsoleLogger.Info($"    SystemFacts: machine_model='{_systemFacts.MachineModel}' machine_type='{_systemFacts.MachineType}' gpu_names=[{string.Join(", ", _systemFacts.GpuNames)}] arch='{_systemFacts.Architecture}'");
+            ConsoleLogger.Info($"    SystemFacts: machine_model='{_systemFacts.MachineModel}' machine_type='{_systemFacts.MachineType}' gpu_names=[{string.Join(", ", _systemFacts.GpuNames)}] gpu_pci_ids=[{string.Join(", ", _systemFacts.GpuPciIds)}] gpu_vendors=[{string.Join(", ", _systemFacts.GpuVendors)}] gpu_driver_missing={_systemFacts.GpuDriverMissing} arch='{_systemFacts.Architecture}'");
         }
         catch (Exception ex)
         {

--- a/shared/core/CimianPaths.cs
+++ b/shared/core/CimianPaths.cs
@@ -34,7 +34,16 @@ public static class CimianPaths
     public static readonly string ConditionsDir  = Path.Combine(ManagedInstallsRoot, "conditions");
     public static readonly string ReceiptsDir    = Path.Combine(ManagedInstallsRoot, "Receipts");
     public static readonly string SbinDir        = Path.Combine(ManagedInstallsRoot, "sbin");
+    public static readonly string FactsDir       = Path.Combine(ManagedInstallsRoot, "facts");
     public static readonly string SelfUpdateBackupDir = Path.Combine(ManagedInstallsRoot, "SelfUpdateBackup");
+
+    // ── Persisted hardware facts ─────────────────────────────────────────────
+    /// <summary>
+    /// Last known display adapter identity, keyed by PCI hardware ID. Windows only
+    /// reports a GPU's model name while its vendor driver is bound, so this cache is
+    /// what lets driver predicates keep matching after a driver goes missing.
+    /// </summary>
+    public static readonly string GpuFactsCache = Path.Combine(FactsDir, "gpu-adapters.json");
 
     // ── Script hooks (sbin) ──────────────────────────────────────────────────
     public static readonly string PreflightScript  = Path.Combine(SbinDir, "preflight.ps1");

--- a/shared/core/Models/SystemFacts.cs
+++ b/shared/core/Models/SystemFacts.cs
@@ -188,6 +188,28 @@ public class SystemFacts
     /// </summary>
     public long GpuVramGb { get; set; }
 
+    /// <summary>
+    /// Normalized PCI hardware ID of every display adapter, e.g. "PCI\VEN_10DE&amp;DEV_24B0".
+    /// Read from the PCI enumerator rather than the driver, so a card still reports its
+    /// identity when no vendor driver is installed and it has no model name.
+    /// Maps to 'gpu_pci_ids' / 'gpu_pci_id' fact keys (used with CONTAINS)
+    /// </summary>
+    public List<string> GpuPciIds { get; set; } = new();
+
+    /// <summary>
+    /// GPU vendors resolved from PCI vendor IDs ("NVIDIA", "AMD", "Intel", ...).
+    /// Driver-independent, so a card whose driver is missing still reports its vendor.
+    /// Maps to 'gpu_vendors' / 'gpu_vendor' fact keys (used with CONTAINS)
+    /// </summary>
+    public List<string> GpuVendors { get; set; } = new();
+
+    /// <summary>
+    /// True when at least one display adapter has no vendor driver bound - Windows is
+    /// showing a generic adapter, or the device sits unclaimed under "Other devices".
+    /// Maps to 'gpu_driver_missing' fact key
+    /// </summary>
+    public bool GpuDriverMissing { get; set; }
+
     // --- CPU Facts (predicate-friendly shortcuts from ProcessorInfo) ---
 
     /// <summary>
@@ -291,6 +313,9 @@ public class SystemFacts
             "gpu_names" or "gpu_name" => GpuNames,
             "gpu_driver_version" => GpuDriverVersion,
             "gpu_vram_gb" => GpuVramGb,
+            "gpu_pci_ids" or "gpu_pci_id" => GpuPciIds,
+            "gpu_vendors" or "gpu_vendor" => GpuVendors,
+            "gpu_driver_missing" => GpuDriverMissing,
             
             // CPU facts
             "cpu_name" => CpuName,

--- a/shared/infrastructure/System/GpuIdentity.cs
+++ b/shared/infrastructure/System/GpuIdentity.cs
@@ -1,0 +1,104 @@
+namespace Cimian.Infrastructure.System;
+
+/// <summary>
+/// Driver-independent display adapter identity.
+///
+/// Windows only reports a GPU's model name while its vendor driver is bound. The PCI
+/// hardware ID is supplied by the bus enumerator instead, so it survives a missing,
+/// broken or uninstalled driver - which is exactly when Cimian needs to work out that
+/// a driver package should be reinstalled.
+/// </summary>
+public static class GpuIdentity
+{
+    /// <summary>
+    /// Placeholder names Windows supplies when no vendor driver is bound. They identify a
+    /// slot, not a model, so they must never be all a driver predicate has to match on.
+    /// </summary>
+    private static readonly string[] GenericAdapterNames =
+    {
+        "microsoft basic display adapter",
+        "microsoft basic render driver",
+        "microsoft remote display adapter",
+        "microsoft hyper-v video",
+        "standard vga graphics adapter",
+        "vga compatible controller",
+        "video controller",
+        "display controller",
+        "graphics controller"
+    };
+
+    /// <summary>PCI vendor IDs for everything that ships a GPU we deploy drivers for.</summary>
+    private static readonly Dictionary<string, string> PciVendorNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["10DE"] = "NVIDIA",
+        ["1002"] = "AMD",
+        ["1022"] = "AMD",
+        ["8086"] = "Intel",
+        ["5143"] = "Qualcomm",
+        ["1414"] = "Microsoft",
+        ["15AD"] = "VMware",
+        ["1AF4"] = "Red Hat"
+    };
+
+    /// <summary>
+    /// True when a name came from Windows' fallback rather than a vendor driver, and so
+    /// tells us nothing about which driver package the card needs.
+    /// </summary>
+    public static bool IsGenericAdapterName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return true;
+
+        var lower = name.ToLowerInvariant();
+        return GenericAdapterNames.Any(generic => lower.Contains(generic));
+    }
+
+    /// <summary>
+    /// Reduces a full PNP instance ID to the stable hardware identity, dropping the
+    /// subsystem, revision and instance suffixes:
+    /// <c>PCI\VEN_10DE&amp;DEV_24B0&amp;SUBSYS_14AD10DE&amp;REV_A1\4&amp;2C4C8C34&amp;0&amp;0008</c>
+    /// becomes <c>PCI\VEN_10DE&amp;DEV_24B0</c>. Returns an empty string for anything that
+    /// is not a PCI device with both IDs present.
+    /// </summary>
+    public static string NormalizePciId(string? pnpDeviceId)
+    {
+        if (string.IsNullOrWhiteSpace(pnpDeviceId)) return "";
+
+        var id = pnpDeviceId.Trim();
+        if (!id.StartsWith("PCI\\", StringComparison.OrdinalIgnoreCase)) return "";
+
+        var vendor = ExtractHexToken(id, "VEN_");
+        var device = ExtractHexToken(id, "DEV_");
+        if (vendor.Length == 0 || device.Length == 0) return "";
+
+        return $"PCI\\VEN_{vendor}&DEV_{device}";
+    }
+
+    /// <summary>
+    /// Resolves the vendor name from a PCI ID, e.g. "PCI\VEN_10DE&amp;DEV_24B0" to "NVIDIA".
+    /// Returns an empty string for vendors we do not deploy drivers for.
+    /// </summary>
+    public static string VendorFromPciId(string? pciId)
+    {
+        if (string.IsNullOrWhiteSpace(pciId)) return "";
+
+        var vendor = ExtractHexToken(pciId, "VEN_");
+        return vendor.Length > 0 && PciVendorNames.TryGetValue(vendor, out var name) ? name : "";
+    }
+
+    /// <summary>
+    /// Reads the hex digits following <paramref name="prefix"/>. Hardware IDs are fixed
+    /// width in practice, but scanning to the first non-hex character avoids depending on
+    /// that and on the separator that follows.
+    /// </summary>
+    private static string ExtractHexToken(string id, string prefix)
+    {
+        var index = id.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+        if (index < 0) return "";
+
+        var start = index + prefix.Length;
+        var end = start;
+        while (end < id.Length && Uri.IsHexDigit(id[end])) end++;
+
+        return id.Substring(start, end - start).ToUpperInvariant();
+    }
+}

--- a/shared/infrastructure/System/SystemFactsCollector.cs
+++ b/shared/infrastructure/System/SystemFactsCollector.cs
@@ -1,7 +1,9 @@
 using System.Management;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
+using Cimian.Core;
 using Cimian.Core.Models;
 
 namespace Cimian.Infrastructure.System;
@@ -476,54 +478,246 @@ public class SystemFactsCollector : ISystemFactsCollector
     // GPU Collection
     // ==========================================================================
 
+    /// <summary>
+    /// Collects display adapter facts.
+    ///
+    /// Win32_VideoController only reports a GPU's model name while its vendor driver is
+    /// bound. Once that driver is missing the card either falls back to a generic adapter
+    /// name or drops out of the Display class entirely, which used to make driver
+    /// predicates like 'gpu_names CONTAINS "Quadro"' stop matching on exactly the machines
+    /// that need the driver reinstalled. So identity is also read from the PCI enumerator,
+    /// and model names seen in earlier runs are remembered per hardware ID.
+    /// </summary>
     private void CollectGpuInfo(SystemFacts facts)
     {
+        var adapters = new List<GpuAdapter>();
+
         try
         {
-            using var searcher = new ManagementObjectSearcher(
-                "SELECT Name, DriverVersion, AdapterRAM FROM Win32_VideoController");
-
-            string? discreteGpuName = null;
-            string? discreteDriverVersion = null;
-            long discreteVram = 0;
-
-            foreach (ManagementObject mo in searcher.Get())
-            {
-                var name = mo["Name"]?.ToString() ?? "";
-                var driverVersion = mo["DriverVersion"]?.ToString() ?? "";
-                var adapterRam = Convert.ToInt64(mo["AdapterRAM"] ?? 0);
-
-                if (string.IsNullOrWhiteSpace(name))
-                    continue;
-
-                facts.GpuNames.Add(name);
-
-                // Prioritize discrete GPUs for driver version and VRAM
-                if (IsDiscreteGpu(name))
-                {
-                    discreteGpuName = name;
-                    discreteDriverVersion = driverVersion;
-                    discreteVram = adapterRam;
-                }
-                else if (discreteGpuName == null)
-                {
-                    // Use first GPU as fallback if no discrete found yet
-                    discreteDriverVersion = driverVersion;
-                    discreteVram = adapterRam;
-                }
-            }
-
-            facts.GpuDriverVersion = discreteDriverVersion ?? "";
-            facts.GpuVramGb = RoundToCommonVramSize(discreteVram);
-
-            _logger.LogDebug("GPU info collected: {Count} GPUs, primary={Primary}, driver={Driver}, VRAM={Vram}GB",
-                facts.GpuNames.Count,
-                discreteGpuName ?? (facts.GpuNames.Count > 0 ? facts.GpuNames[0] : "none"),
-                facts.GpuDriverVersion, facts.GpuVramGb);
+            CollectVideoControllers(adapters);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to collect GPU info");
+            _logger.LogWarning(ex, "Failed to query Win32_VideoController for GPU info");
+        }
+
+        try
+        {
+            MergePnpGpuDevices(adapters);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to query Win32_PnPEntity for GPU hardware IDs");
+        }
+
+        RestoreLastKnownGpuNames(adapters);
+
+        string? discreteGpuName = null;
+        string? discreteDriverVersion = null;
+        long discreteVram = 0;
+
+        foreach (var adapter in adapters)
+        {
+            if (!string.IsNullOrWhiteSpace(adapter.Name))
+                facts.GpuNames.Add(adapter.Name);
+
+            if (adapter.PciId.Length > 0 && !facts.GpuPciIds.Contains(adapter.PciId))
+                facts.GpuPciIds.Add(adapter.PciId);
+
+            var vendor = GpuIdentity.VendorFromPciId(adapter.PciId);
+            if (vendor.Length > 0 && !facts.GpuVendors.Contains(vendor))
+                facts.GpuVendors.Add(vendor);
+
+            // Prioritize discrete GPUs for driver version and VRAM
+            if (IsDiscreteGpu(adapter.Name))
+            {
+                discreteGpuName = adapter.Name;
+                discreteDriverVersion = adapter.DriverVersion;
+                discreteVram = adapter.VramBytes;
+            }
+            else if (discreteGpuName == null)
+            {
+                // Use first GPU as fallback if no discrete found yet
+                discreteDriverVersion = adapter.DriverVersion;
+                discreteVram = adapter.VramBytes;
+            }
+        }
+
+        facts.GpuDriverVersion = discreteDriverVersion ?? "";
+        facts.GpuVramGb = RoundToCommonVramSize(discreteVram);
+        facts.GpuDriverMissing = adapters.Any(a => a.DriverMissing);
+
+        _logger.LogDebug("GPU info collected: {Count} GPUs, primary={Primary}, driver={Driver}, VRAM={Vram}GB, pci=[{Pci}], driverMissing={DriverMissing}, namesRestoredFromCache={Restored}",
+            facts.GpuNames.Count,
+            discreteGpuName ?? (facts.GpuNames.Count > 0 ? facts.GpuNames[0] : "none"),
+            facts.GpuDriverVersion, facts.GpuVramGb,
+            string.Join(", ", facts.GpuPciIds), facts.GpuDriverMissing,
+            adapters.Count(a => a.RestoredFromCache));
+    }
+
+    /// <summary>
+    /// Reads adapters Windows has bound a display driver to.
+    /// </summary>
+    private void CollectVideoControllers(List<GpuAdapter> adapters)
+    {
+        using var searcher = new ManagementObjectSearcher(
+            "SELECT Name, DriverVersion, AdapterRAM, PNPDeviceID FROM Win32_VideoController");
+
+        foreach (ManagementObject mo in searcher.Get())
+        {
+            var name = mo["Name"]?.ToString()?.Trim() ?? "";
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            var instanceId = mo["PNPDeviceID"]?.ToString() ?? "";
+
+            adapters.Add(new GpuAdapter
+            {
+                InstanceId = instanceId,
+                PciId = GpuIdentity.NormalizePciId(instanceId),
+                Name = name,
+                NameIsGeneric = GpuIdentity.IsGenericAdapterName(name),
+                DriverVersion = mo["DriverVersion"]?.ToString() ?? "",
+                VramBytes = ToInt64(mo["AdapterRAM"])
+            });
+        }
+    }
+
+    /// <summary>
+    /// Adds GPUs the PCI enumerator can see but Win32_VideoController cannot. A card with
+    /// no driver installed lands under "Other devices" with no PNPClass and a placeholder
+    /// name such as "3D Video Controller", so it never appears as a display adapter.
+    /// </summary>
+    private void MergePnpGpuDevices(List<GpuAdapter> adapters)
+    {
+        // Doubled backslashes are WQL escaping: this matches PNP device IDs starting "PCI\VEN".
+        // The trailing underscore is left off the pattern because '_' is a WQL wildcard.
+        using var searcher = new ManagementObjectSearcher(
+            "SELECT DeviceID, Name, PNPClass, ConfigManagerErrorCode FROM Win32_PnPEntity WHERE DeviceID LIKE 'PCI\\\\VEN%'");
+
+        foreach (ManagementObject mo in searcher.Get())
+        {
+            var deviceId = mo["DeviceID"]?.ToString() ?? "";
+            var pciId = GpuIdentity.NormalizePciId(deviceId);
+            if (pciId.Length == 0)
+                continue;
+
+            var pnpClass = mo["PNPClass"]?.ToString() ?? "";
+            var name = mo["Name"]?.ToString()?.Trim() ?? "";
+            var errorCode = (int)ToInt64(mo["ConfigManagerErrorCode"]);
+
+            var isDisplayClass = string.Equals(pnpClass, "Display", StringComparison.OrdinalIgnoreCase);
+            var isUnclaimed = pnpClass.Length == 0
+                || string.Equals(pnpClass, "Unknown", StringComparison.OrdinalIgnoreCase);
+            if (!isDisplayClass && !(isUnclaimed && GpuIdentity.IsGenericAdapterName(name)))
+                continue;
+
+            // Match on instance ID, falling back to name for the rare adapter that reports
+            // no PNPDeviceID - otherwise it would be counted twice.
+            var existing = adapters.FirstOrDefault(a =>
+                    string.Equals(a.InstanceId, deviceId, StringComparison.OrdinalIgnoreCase))
+                ?? adapters.FirstOrDefault(a =>
+                    a.PciId.Length == 0 && string.Equals(a.Name, name, StringComparison.OrdinalIgnoreCase));
+
+            if (existing != null)
+            {
+                existing.InstanceId = deviceId;
+                existing.PciId = pciId;
+                existing.ConfigManagerErrorCode = errorCode;
+                continue;
+            }
+
+            adapters.Add(new GpuAdapter
+            {
+                InstanceId = deviceId,
+                PciId = pciId,
+                Name = name,
+                NameIsGeneric = GpuIdentity.IsGenericAdapterName(name),
+                ConfigManagerErrorCode = errorCode
+            });
+        }
+    }
+
+    /// <summary>
+    /// Remembers every model name a vendor driver currently reports, and substitutes the
+    /// remembered name for any adapter that has since lost its driver. This is what keeps
+    /// a driver predicate matching after the driver it installs disappears.
+    ///
+    /// Driver version is deliberately not restored - the driver really is gone, and the
+    /// package's own installcheck must still see that.
+    /// </summary>
+    private void RestoreLastKnownGpuNames(List<GpuAdapter> adapters)
+    {
+        var cache = LoadGpuCache();
+        var changed = false;
+
+        foreach (var adapter in adapters.Where(a => !a.NameIsGeneric && a.PciId.Length > 0))
+        {
+            if (cache.TryGetValue(adapter.PciId, out var known) && known.Name == adapter.Name)
+                continue;
+
+            cache[adapter.PciId] = new GpuCacheEntry
+            {
+                Name = adapter.Name,
+                VramBytes = adapter.VramBytes,
+                LastSeenUtc = DateTime.UtcNow
+            };
+            changed = true;
+        }
+
+        foreach (var adapter in adapters.Where(a => a.NameIsGeneric && a.PciId.Length > 0))
+        {
+            if (!cache.TryGetValue(adapter.PciId, out var known) || known.Name.Length == 0)
+                continue;
+
+            _logger.LogInformation(
+                "GPU {PciId} has no vendor driver bound (Windows reports '{Generic}'); using last known model '{Known}' so driver predicates still match",
+                adapter.PciId, adapter.Name, known.Name);
+
+            adapter.Name = known.Name;
+            adapter.RestoredFromCache = true;
+            if (adapter.VramBytes == 0)
+                adapter.VramBytes = known.VramBytes;
+        }
+
+        if (changed)
+            SaveGpuCache(cache);
+    }
+
+    private Dictionary<string, GpuCacheEntry> LoadGpuCache()
+    {
+        try
+        {
+            if (!File.Exists(CimianPaths.GpuFactsCache))
+                return new Dictionary<string, GpuCacheEntry>(StringComparer.OrdinalIgnoreCase);
+
+            var json = File.ReadAllText(CimianPaths.GpuFactsCache);
+            var loaded = JsonSerializer.Deserialize<Dictionary<string, GpuCacheEntry>>(json);
+            return loaded == null
+                ? new Dictionary<string, GpuCacheEntry>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, GpuCacheEntry>(loaded, StringComparer.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read GPU fact cache {Path}; starting a fresh one",
+                CimianPaths.GpuFactsCache);
+            return new Dictionary<string, GpuCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private void SaveGpuCache(Dictionary<string, GpuCacheEntry> cache)
+    {
+        try
+        {
+            Directory.CreateDirectory(CimianPaths.FactsDir);
+            File.WriteAllText(
+                CimianPaths.GpuFactsCache,
+                JsonSerializer.Serialize(cache, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: without the cache the collector simply loses driver-less recovery.
+            _logger.LogWarning(ex, "Could not write GPU fact cache {Path}", CimianPaths.GpuFactsCache);
         }
     }
 
@@ -558,6 +752,54 @@ public class SystemFactsCollector : ISystemFactsCollector
         double gb = bytes / (1024.0 * 1024.0 * 1024.0);
         int[] commonSizes = { 1, 2, 3, 4, 6, 8, 10, 12, 16, 20, 24, 32, 48, 64 };
         return commonSizes.OrderBy(s => Math.Abs(s - gb)).First();
+    }
+
+    private static long ToInt64(object? value)
+    {
+        try
+        {
+            return value == null ? 0 : Convert.ToInt64(value);
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException)
+        {
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// One display adapter for the duration of a collection run, merged from
+    /// Win32_VideoController (driver-supplied detail) and Win32_PnPEntity (hardware identity).
+    /// </summary>
+    private sealed class GpuAdapter
+    {
+        /// <summary>Full PNP instance ID, used to match the two WMI views to each other.</summary>
+        public string InstanceId { get; set; } = "";
+
+        /// <summary>Stable hardware identity, e.g. "PCI\VEN_10DE&amp;DEV_24B0".</summary>
+        public string PciId { get; set; } = "";
+
+        public string Name { get; set; } = "";
+        public string DriverVersion { get; set; } = "";
+        public long VramBytes { get; set; }
+
+        /// <summary>True when Name came from Windows' fallback rather than a vendor driver.</summary>
+        public bool NameIsGeneric { get; set; }
+
+        /// <summary>True once Name has been replaced with a previously observed model name.</summary>
+        public bool RestoredFromCache { get; set; }
+
+        /// <summary>Device Manager status; 28 means no driver is installed.</summary>
+        public int ConfigManagerErrorCode { get; set; }
+
+        public bool DriverMissing => NameIsGeneric || ConfigManagerErrorCode != 0;
+    }
+
+    /// <summary>One remembered adapter, persisted to <see cref="CimianPaths.GpuFactsCache"/>.</summary>
+    private sealed class GpuCacheEntry
+    {
+        public string Name { get; set; } = "";
+        public long VramBytes { get; set; }
+        public DateTime LastSeenUtc { get; set; }
     }
 
     // ==========================================================================

--- a/tests/GpuIdentityTests.cs
+++ b/tests/GpuIdentityTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Cimian.Infrastructure.System;
+using Xunit;
+
+namespace Cimian.Tests;
+
+/// <summary>
+/// Tests for driver-independent GPU identity parsing.
+///
+/// These cover the path that matters when a vendor driver is missing: Windows stops
+/// reporting a model name, so the PCI hardware ID is the only thing left to identify
+/// the card by.
+/// </summary>
+public class GpuIdentityTests
+{
+    [Theory]
+    // Full instance ID as Win32_VideoController reports it
+    [InlineData(@"PCI\VEN_10DE&DEV_24B0&SUBSYS_14AD10DE&REV_A1\4&2C4C8C34&0&0008", @"PCI\VEN_10DE&DEV_24B0")]
+    // Already normalized
+    [InlineData(@"PCI\VEN_10DE&DEV_24B0", @"PCI\VEN_10DE&DEV_24B0")]
+    // Lower case from the PnP enumerator
+    [InlineData(@"pci\ven_8086&dev_3e92&subsys_86941043&rev_00\3&11583659&0&10", @"PCI\VEN_8086&DEV_3E92")]
+    // Not a PCI device
+    [InlineData(@"USB\VID_045E&PID_07A5\6&38D62F2A&0&2", "")]
+    // PCI device with no device ID
+    [InlineData(@"PCI\VEN_10DE", "")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void NormalizePciId_ReducesToStableHardwareIdentity(string? instanceId, string expected)
+    {
+        GpuIdentity.NormalizePciId(instanceId).Should().Be(expected);
+    }
+
+    [Fact]
+    public void NormalizePciId_IsStableAcrossSlotsForIdenticalCards()
+    {
+        // Two of the same card differ only by instance suffix, so both must normalize
+        // to the same cache key.
+        var first = GpuIdentity.NormalizePciId(@"PCI\VEN_10DE&DEV_24B0&SUBSYS_14AD10DE&REV_A1\4&2C4C8C34&0&0008");
+        var second = GpuIdentity.NormalizePciId(@"PCI\VEN_10DE&DEV_24B0&SUBSYS_14AD10DE&REV_A1\4&2C4C8C34&0&0010");
+
+        second.Should().Be(first);
+    }
+
+    [Theory]
+    [InlineData(@"PCI\VEN_10DE&DEV_24B0", "NVIDIA")]
+    [InlineData(@"PCI\VEN_1002&DEV_73FF", "AMD")]
+    [InlineData(@"PCI\VEN_8086&DEV_3E92", "Intel")]
+    [InlineData(@"PCI\VEN_FFFF&DEV_0001", "")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void VendorFromPciId_ResolvesKnownVendors(string? pciId, string expected)
+    {
+        GpuIdentity.VendorFromPciId(pciId).Should().Be(expected);
+    }
+
+    [Theory]
+    // Fallbacks Windows uses when no vendor driver is bound
+    [InlineData("Microsoft Basic Display Adapter", true)]
+    [InlineData("3D Video Controller", true)]
+    [InlineData("Video Controller (VGA Compatible)", true)]
+    [InlineData("Standard VGA Graphics Adapter", true)]
+    [InlineData("", true)]
+    [InlineData(null, true)]
+    // Real model names a driver supplies
+    [InlineData("NVIDIA RTX A4000", false)]
+    [InlineData("NVIDIA Quadro RTX 5000", false)]
+    [InlineData("NVIDIA GeForce RTX 2060", false)]
+    [InlineData("Intel(R) UHD Graphics 630", false)]
+    [InlineData("AMD Radeon Pro W6600", false)]
+    public void IsGenericAdapterName_SeparatesPlaceholdersFromModels(string? name, bool expected)
+    {
+        GpuIdentity.IsGenericAdapterName(name).Should().Be(expected);
+    }
+}

--- a/tests/PredicateEngineTests.cs
+++ b/tests/PredicateEngineTests.cs
@@ -680,6 +680,64 @@ public class PredicateEngineTests
         (await _engine.EvaluateConditionAsync(condition, factsGeforce)).Should().BeFalse("GeForce should not match Quadro/RTX A");
     }
 
+    [Theory]
+    [InlineData("gpu_pci_ids CONTAINS 'VEN_10DE'", true)]
+    [InlineData("gpu_pci_ids CONTAINS 'DEV_24B0'", true)]
+    [InlineData("gpu_pci_ids CONTAINS 'DEV_1B80'", false)]
+    public async Task EvaluateCondition_GpuPciIds_ContainsCheck(string condition, bool expected)
+    {
+        var facts = CreateFacts(gpuPciIds: new[] { @"PCI\VEN_10DE&DEV_24B0", @"PCI\VEN_8086&DEV_3E92" });
+
+        (await _engine.EvaluateConditionAsync(condition, facts)).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task EvaluateCondition_GpuVendors_MatchesWithoutAModelName()
+    {
+        // A card whose driver has been removed reports no model, but the PCI enumerator
+        // still names the vendor.
+        var facts = CreateFacts(
+            gpuNames: new[] { "Microsoft Basic Display Adapter" },
+            gpuPciIds: new[] { @"PCI\VEN_10DE&DEV_24B0" },
+            gpuVendors: new[] { "NVIDIA" },
+            gpuDriverMissing: true);
+
+        (await _engine.EvaluateConditionAsync("gpu_vendors CONTAINS 'NVIDIA'", facts)).Should().BeTrue();
+        (await _engine.EvaluateConditionAsync("gpu_names CONTAINS 'NVIDIA'", facts)).Should().BeFalse(
+            "the generic adapter name carries no vendor");
+    }
+
+    [Fact]
+    public async Task EvaluateCondition_GpuDriverMissing_BooleanComparison()
+    {
+        var missing = CreateFacts(gpuVendors: new[] { "NVIDIA" }, gpuDriverMissing: true);
+        var healthy = CreateFacts(gpuVendors: new[] { "NVIDIA" }, gpuDriverMissing: false);
+
+        var condition = "gpu_vendors CONTAINS 'NVIDIA' AND gpu_driver_missing == 'true'";
+
+        (await _engine.EvaluateConditionAsync(condition, missing)).Should().BeTrue();
+        (await _engine.EvaluateConditionAsync(condition, healthy)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateCondition_QuadroDriverStillMatchesAfterDriverGoesMissing()
+    {
+        // Regression: when a workstation's Quadro driver disappeared, Windows fell back to a
+        // generic adapter name and the manifest stopped offering the driver that would have
+        // fixed it. The collector now re-supplies the last known model name, so a model-name
+        // condition has to keep matching.
+        var condition = "gpu_names CONTAINS 'Quadro' OR gpu_names CONTAINS 'RTX A' OR gpu_names CONTAINS 'RTX PRO'";
+
+        var recovered = CreateFacts(
+            gpuNames: new[] { "NVIDIA RTX A4000" },   // restored from the GPU fact cache
+            gpuPciIds: new[] { @"PCI\VEN_10DE&DEV_24B0" },
+            gpuVendors: new[] { "NVIDIA" },
+            gpuDriverVersion: "",                     // deliberately not restored - the driver is gone
+            gpuDriverMissing: true);
+
+        (await _engine.EvaluateConditionAsync(condition, recovered)).Should().BeTrue();
+    }
+
     #endregion
 
     #region CPU Predicate Tests
@@ -841,6 +899,9 @@ public class PredicateEngineTests
         string[]? gpuNames = null,
         string gpuDriverVersion = "",
         long gpuVramGb = 0,
+        string[]? gpuPciIds = null,
+        string[]? gpuVendors = null,
+        bool gpuDriverMissing = false,
         string cpuName = "",
         string cpuManufacturer = "",
         int cpuCores = 0,
@@ -866,6 +927,9 @@ public class PredicateEngineTests
             GpuNames = gpuNames?.ToList() ?? new List<string>(),
             GpuDriverVersion = gpuDriverVersion,
             GpuVramGb = gpuVramGb,
+            GpuPciIds = gpuPciIds?.ToList() ?? new List<string>(),
+            GpuVendors = gpuVendors?.ToList() ?? new List<string>(),
+            GpuDriverMissing = gpuDriverMissing,
             CpuName = cpuName,
             CpuManufacturer = cpuManufacturer,
             CpuCores = cpuCores,

--- a/wiki/conditional-items-guide.md
+++ b/wiki/conditional-items-guide.md
@@ -36,9 +36,12 @@ Cimian automatically gathers the following system facts for conditional evaluati
 - **date**: Current date in `YYYY-MM-DD` format
 
 ### Hardware Facts
-- **gpu_names** / **gpu_name**: GPU names from `Win32_VideoController` (array — use with `ANY` / `CONTAINS`)
-- **gpu_driver_version**: Driver version of the primary GPU
+- **gpu_names** / **gpu_name**: GPU names from `Win32_VideoController` (array — use with `ANY` / `CONTAINS`). Falls back to the last known model name when a driver is missing — see [Targeting a GPU whose driver is missing](#targeting-a-gpu-whose-driver-is-missing).
+- **gpu_driver_version**: Driver version of the primary GPU. Empty when no vendor driver is bound.
 - **gpu_vram_gb**: VRAM of primary GPU in GB
+- **gpu_pci_ids** / **gpu_pci_id**: PCI hardware ID of every adapter (array — use with `CONTAINS`), e.g. `["PCI\VEN_10DE&DEV_24B0"]`. Read from the PCI enumerator, so it is present with no driver installed.
+- **gpu_vendors** / **gpu_vendor**: Vendors resolved from PCI vendor IDs (array — use with `CONTAINS`): `NVIDIA`, `AMD`, `Intel`, `Qualcomm`, ...
+- **gpu_driver_missing**: Boolean — whether at least one adapter has no vendor driver bound
 - **cpu_name**: Cleaned processor name (e.g., "Core i9-13900K")
 - **cpu_manufacturer**: CPU manufacturer (Intel, AMD, Qualcomm, ARM)
 - **cpu_cores**: Physical core count
@@ -55,6 +58,32 @@ Cimian automatically gathers the following system facts for conditional evaluati
 - **isdomainjoined**: Boolean — whether the system is domain-joined
 
 > **Note**: There is no `enrolled_usage`, `enrolled_area`, `device_id`, `build_number`, or `serial_number` fact in the current fact map. Use `os_build_number` for the build number. If you need a per-device custom fact, populate `SystemFacts.CustomFacts`, `EnvironmentVariables`, or `RegistryValues` — `GetFactValue` will look these up by name as a fallback.
+
+### Targeting a GPU whose driver is missing
+
+Windows only reports a model name in `gpu_names` while the vendor driver is bound. Once
+that driver is gone the card falls back to a placeholder such as "Microsoft Basic Display
+Adapter" or "3D Video Controller", which would otherwise stop a driver predicate matching
+on exactly the machines that need the driver reinstalled.
+
+Two facts are driver-independent because they come from the PCI enumerator rather than the
+driver: `gpu_pci_ids` and `gpu_vendors`. In addition, `managedsoftwareupdate` remembers each
+adapter's model name against its PCI hardware ID in
+`%ProgramData%\ManagedInstalls\facts\gpu-adapters.json`, and re-supplies that name in
+`gpu_names` when the driver disappears — so a model-name condition keeps matching on any
+machine Cimian has previously seen with a working driver.
+
+`gpu_driver_version` is deliberately *not* restored from that cache, so a package's own
+installcheck still sees that no driver is present.
+
+For a machine that has never had the driver there is nothing cached, and a vendor ID alone
+cannot distinguish Quadro from GeForce. Target those by exact device ID:
+
+```yaml
+- condition: gpu_pci_ids CONTAINS "DEV_24B0"
+  managed_installs:
+    - YourWorkstationGpuDriver
+```
 
 ### Available Operators
 


### PR DESCRIPTION
## Problem

`gpu_names` is populated purely from `Win32_VideoController.Name`, which is the *driver-provided* friendly name. Once a GPU's vendor driver is gone the card either falls back to "Microsoft Basic Display Adapter" or leaves the Display class entirely and sits in "Other devices" as "3D Video Controller". Either way a condition like:

```yaml
- condition: gpu_names CONTAINS "Quadro" OR gpu_names CONTAINS "RTX A" OR gpu_names CONTAINS "RTX PRO"
```

stops matching, so the driver package is never even considered. The driver has to already be present for Cimian to work out that it needs the driver.

## Change

`CollectGpuInfo` now:

1. reads `PNPDeviceID` from `Win32_VideoController` alongside the existing fields;
2. merges in `Win32_PnPEntity WHERE DeviceID LIKE 'PCI\\VEN%'`, catching the card that has no driver at all and therefore never appears as a display adapter;
3. remembers each adapter's model name against its PCI hardware ID in `%ProgramData%\ManagedInstalls\facts\gpu-adapters.json`, and re-supplies it when the driver later disappears.

Step 3 is what closes the gap: a machine that once had a working driver still knows its card is an RTX A-series, so the existing model-name condition matches again — **no manifest change needed**. `gpu_driver_version` is deliberately *not* restored from cache, so the package's own installcheck still sees the driver is gone and proceeds.

New facts, wired into `GetFactValue` (without that they are invisible to predicates):

| Fact | Type | Notes |
|---|---|---|
| `gpu_pci_ids` / `gpu_pci_id` | list | `PCI\VEN_10DE&DEV_24B0` — from the PCI enumerator, driver-independent |
| `gpu_vendors` / `gpu_vendor` | list | `NVIDIA`, `AMD`, `Intel`, ... |
| `gpu_driver_missing` | bool | any adapter with no vendor driver bound |

`CONTAINS` already fans out over list facts, so the predicate engine is unchanged.

Identity parsing is split into `GpuIdentity` so it is testable without WMI. `NormalizePciId` reduces a full instance ID to `PCI\VEN_10DE&DEV_24B0`, stable across slots so two identical cards share a cache key.

`managedsoftwareupdate -v` now prints the PCI IDs and vendors, so a machine's device IDs can be read straight off a verbose run.

## Testing

- `GpuIdentityTests` — 25 cases over PCI ID normalization, vendor resolution, generic-vs-model name classification.
- `PredicateEngineTests` — new cases for the three facts plus a regression test for the driver-loss scenario. 139 pass.
- Builds verified for `Cimian.Infrastructure`, `Cimian.CLI.managedsoftwareupdate`, `Cimian.Tests`.

**Not yet verified on real hardware.** Built and tested on macOS, so the WMI paths and the cache write under `%ProgramData%` have never actually executed. Needs a signed build and one `--checkonly` run on an affected machine before merge.

## Follow-up, not in this PR

- A machine that has *never* had the driver has nothing cached, and `VEN_10DE` alone cannot distinguish Quadro from GeForce. Those need exact `gpu_pci_ids CONTAINS "DEV_XXXX"` rules, with device IDs taken from real hardware rather than guesswork.
- `gpu_vram_gb` derives from `AdapterRAM`, a uint32, so it silently reports 4 for any 8 GB+ card. Pre-existing, untouched here.
