### PR TITLE
Fix packed-GUID conversion so upgrade_code MSI detection works

### DIFF
--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -865,40 +865,48 @@ if ($results.Count -gt 0) {{
 
     /// <summary>
     /// Converts a standard GUID format to Windows Installer packed GUID format.
-    /// Example: {C1DFDF69-5945-32F2-A35E-EE94C99C7CF4} -> 96FDFD1C5495F232A3E5EE499CC9C74F
+    /// Example: {31AB5147-9A97-4452-8443-D9709F0516E1} -> 7415BA1379A9254448349D07F950611E
+    /// (verified against HKLM\SOFTWARE\Classes\Installer\UpgradeCodes for the
+    /// PowerShell 7-x64 MSI).
     /// </summary>
-    private static string PackGuid(string guid)
+    internal static string PackGuid(string guid)
     {
         // Remove braces and hyphens
         guid = guid.Replace("{", "").Replace("}", "").Replace("-", "").ToUpperInvariant();
-        
+
         if (guid.Length != 32)
             return string.Empty;
-        
-        // Packed format reverses specific sections
+
+        // Sections 1-3 are stored little-endian, so each is written out fully
+        // reversed character by character. Sections 4-5 keep their byte order and
+        // only swap the two hex digits within each byte.
+        //
+        // Reversing merely the ORDER of the character pairs (without also
+        // reversing within each pair) yields a GUID that no key ever matches, so
+        // every UpgradeCode lookup silently missed and any pkgsinfo relying on an
+        // upgrade_code-only installs[] entry reinstalled every session until
+        // LoopGuard suppressed it (AB#4416: PowerShell + AzureCLI, ~540 devices).
         var result = new char[32];
-        
-        // Section 1: first 8 chars, reversed in pairs
-        result[0] = guid[6]; result[1] = guid[7];
-        result[2] = guid[4]; result[3] = guid[5];
-        result[4] = guid[2]; result[5] = guid[3];
-        result[6] = guid[0]; result[7] = guid[1];
-        
-        // Section 2: next 4 chars, reversed in pairs
-        result[8] = guid[10]; result[9] = guid[11];
-        result[10] = guid[8]; result[11] = guid[9];
-        
-        // Section 3: next 4 chars, reversed in pairs  
-        result[12] = guid[14]; result[13] = guid[15];
-        result[14] = guid[12]; result[15] = guid[13];
-        
-        // Section 4+5: remaining 16 chars, reversed in pairs
+
+        // Section 1: first 8 chars, fully reversed
+        for (int i = 0; i < 8; i++)
+            result[i] = guid[7 - i];
+
+        // Section 2: next 4 chars, fully reversed
+        for (int i = 0; i < 4; i++)
+            result[8 + i] = guid[11 - i];
+
+        // Section 3: next 4 chars, fully reversed
+        for (int i = 0; i < 4; i++)
+            result[12 + i] = guid[15 - i];
+
+        // Section 4+5: remaining 16 chars, hex digits swapped within each byte
         for (int i = 16; i < 32; i += 2)
         {
             result[i] = guid[i + 1];
             result[i + 1] = guid[i];
         }
-        
+
         return new string(result);
     }
 

--- a/tests/Managedsoftwareupdate/StatusServiceTests.cs
+++ b/tests/Managedsoftwareupdate/StatusServiceTests.cs
@@ -502,4 +502,54 @@ public class StatusServiceTests
     }
 
     #endregion
+
+    #region PackGuid Tests
+
+    // Windows Installer stores sections 1-3 of a GUID little-endian (each written
+    // out fully reversed) and swaps the two hex digits within each byte of
+    // sections 4-5. Expected values below were read out of
+    // HKLM\SOFTWARE\Classes\Installer\UpgradeCodes on real fleet machines, so they
+    // are ground truth rather than a restatement of the implementation.
+    //
+    // Regression guard for AB#4416: the previous implementation reversed only the
+    // ORDER of character pairs in sections 1-3 without reversing within each pair,
+    // producing a packed GUID that matched no registry key. Every UpgradeCode
+    // lookup missed, so upgrade_code-only installs[] entries (PowerShell 7.6.4.0,
+    // AzureCLI 2.89.0) reinstalled every session until LoopGuard suppressed them.
+    [Theory]
+    [InlineData("{31AB5147-9A97-4452-8443-D9709F0516E1}", "7415BA1379A9254448349D07F950611E")] // PowerShell 7-x64 UpgradeCode
+    [InlineData("{90762FEC-9554-4729-A107-C6A8EA316698}", "CEF26709455992741A706C8AAE136689")] // Azure CLI UpgradeCode
+    public void PackGuid_MatchesWindowsInstallerPackedForm(string guid, string expected)
+    {
+        Assert.Equal(expected, StatusService.PackGuid(guid));
+    }
+
+    [Fact]
+    public void PackGuid_AcceptsUnbracedAndLowercaseInput()
+    {
+        Assert.Equal(
+            "7415BA1379A9254448349D07F950611E",
+            StatusService.PackGuid("31ab5147-9a97-4452-8443-d9709f0516e1"));
+    }
+
+    [Fact]
+    public void PackGuid_DoesNotMerelyTransposePairs()
+    {
+        // The exact wrong value the old implementation produced. Pinning it keeps a
+        // future refactor from silently reintroducing the pair-transposition bug.
+        Assert.NotEqual(
+            "4751AB31979A524448349D07F950611E",
+            StatusService.PackGuid("{31AB5147-9A97-4452-8443-D9709F0516E1}"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-guid")]
+    [InlineData("{31AB5147-9A97-4452-8443-D9709F0516}")] // too short
+    public void PackGuid_ReturnsEmptyForMalformedInput(string guid)
+    {
+        Assert.Equal(string.Empty, StatusService.PackGuid(guid));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## What broke

`StatusService.PackGuid()` reversed only the **order of character pairs** in GUID sections 1â€“3, never the characters *within* each pair. Windows Installer stores those sections little-endian â€” fully reversed â€” so the packed GUID the client computed matched no registry key.

Packed GUIDs are used solely by `FindMsiByUpgradeCode`, so **every UpgradeCode lookup missed** and returned not-installed. `CheckMsiProductWithVersion` matches the literal ProductCode GUID string and was unaffected, which is why only pkgsinfo carrying an `upgrade_code` and no `product_code` broke.

Those items installed successfully every session, were re-detected as missing on the next run, and ended up LoopGuard-suppressed.

## Fleet impact

PowerShell 7.6.4.0 and AzureCLI 2.89.0 â€” whose autopkg RecipeOverrides pin `installs[]` to an `upgrade_code`-only MSI entry to strip bogus file checks â€” accounted for **~540 of ~950 live loop-suppression warnings**, across ~270 of 308 live Windows devices. The preceding builds of both packages still carry `product_code` and detect correctly today, which is the clean before/after.

Ground truth from a looping device (Rendering Node 08, client 2026.07.30.2035, `managedsoftwareupdate -v --checkonly`):

```
Found Cimian-managed registry version item: PowerShell registryVersion: 7.6.4.0
MSI product not installed item: PowerShell productCode:  upgradeCode: {31AB5147-...}
File verification failed - reinstallation required item: PowerShell
LOOP SUPPRESSED: PowerShell - Install loop: version 7.6.4.0 installed 4 times across 3 sessions
```

PowerShell 7.6.4.0 was in fact correctly installed and registered on that device, and the UpgradeCode key was present holding packed product `CD5A9D2946C85D041BCB89BDC9F7BDF7`. The registry was healthy; only the packed-GUID computation was wrong.

## The fix

Sections 1â€“3 are now fully reversed. Sections 4â€“5 (hex-digit swap within each byte) were already correct and are unchanged.

Verified against `HKLM\SOFTWARE\Classes\Installer\UpgradeCodes` on two machines:

| GUID | registry (truth) | old output |
|---|---|---|
| `{31AB5147-9A97-4452-8443-D9709F0516E1}` | `7415BA1379A9254448349D07F950611E` | `4751AB31979A524448349D07F950611E` |
| `{90762FEC-9554-4729-A107-C6A8EA316698}` | `CEF26709455992741A706C8AAE136689` | `EC2F7690549529471A706C8AAE136689` |

This restores UpgradeCode detection as designed â€” the mechanism intended for apps whose ProductCode changes per version (Chrome and similar) â€” so other latent cases likely clear too.

## Tests

7 new tests in `StatusServiceTests`, with expected values taken from real registry keys rather than restating the implementation. One test pins the exact wrong value the old code produced so a future refactor cannot silently reintroduce it. `PackGuid` becomes `internal`; `InternalsVisibleTo` for `Cimian.Tests` was already declared.

Full suite: **897 passed, 2 failed** â€” both failures are in `ConfigurationServiceTests`, are environment-dependent, and reproduce identically on clean `main`.

## Notes for review

- No safe pkgsinfo-only mitigation exists: the overrides pin the installs array precisely to avoid the auto-generated file checks, and `product_code` changes with every release so it cannot be hardcoded in an override. The client fix is the fix.
- Needs a client release + pipeline 57 deploy to reach the fleet.

Refs , parent effort , related .
