### PR TITLE
Stop re-hashing the package cache every run and give the task room to finish

### DIFF
--- a/build/msi/install-tasks.ps1
+++ b/build/msi/install-tasks.ps1
@@ -61,9 +61,14 @@ try {
     # Task trigger: start immediately and repeat every hour indefinitely (adds randomization across deployments)
     $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(5) -RepetitionInterval (New-TimeSpan -Hours 1)
     
-    # Task settings: 30 minute timeout, restart on failure, hidden, run on battery
+    # Task settings: 4 hour timeout, restart on failure, hidden, run on battery.
+    # A first run on a freshly imaged machine downloads and installs the whole
+    # manifest, including packages over 9GB whose own download timeout is ~190
+    # minutes; the previous 30 minute limit killed the run every time, so those
+    # machines never converged. The hourly trigger cannot stack on top of a long
+    # run because MultipleInstances defaults to IgnoreNew.
     $settings = New-ScheduledTaskSettingsSet `
-        -ExecutionTimeLimit (New-TimeSpan -Minutes 30) `
+        -ExecutionTimeLimit (New-TimeSpan -Hours 4) `
         -RestartCount 3 `
         -RestartInterval (New-TimeSpan -Minutes 10) `
         -RunOnlyIfNetworkAvailable `

--- a/build/nupkg/scripts/chocolateyInstall.ps1
+++ b/build/nupkg/scripts/chocolateyInstall.ps1
@@ -259,9 +259,14 @@ try {
         # Task trigger: start immediately and repeat every hour indefinitely (adds randomization across deployments)
         $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(5) -RepetitionInterval (New-TimeSpan -Hours 1)
         
-        # Task settings: 30 minute timeout, restart on failure, hidden, run on battery
+        # Task settings: 4 hour timeout, restart on failure, hidden, run on battery.
+        # A first run on a freshly imaged machine downloads and installs the whole
+        # manifest, including packages over 9GB whose own download timeout is ~190
+        # minutes; the previous 30 minute limit killed the run every time, so those
+        # machines never converged. The hourly trigger cannot stack on top of a long
+        # run because MultipleInstances defaults to IgnoreNew.
         $settings = New-ScheduledTaskSettingsSet `
-            -ExecutionTimeLimit (New-TimeSpan -Minutes 30) `
+            -ExecutionTimeLimit (New-TimeSpan -Hours 4) `
             -RestartCount 3 `
             -RestartInterval (New-TimeSpan -Minutes 10) `
             -RunOnlyIfNetworkAvailable `

--- a/build/pkg/postinstall.ps1
+++ b/build/pkg/postinstall.ps1
@@ -89,7 +89,7 @@ try {
     $action = New-ScheduledTaskAction -Execute $managedSoftwareUpdateExe -Argument "--auto" -WorkingDirectory $InstallDir
     $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(5) -RepetitionInterval (New-TimeSpan -Hours 1)
     $settings = New-ScheduledTaskSettingsSet `
-        -ExecutionTimeLimit (New-TimeSpan -Minutes 30) `
+        -ExecutionTimeLimit (New-TimeSpan -Hours 4) `
         -RestartCount 3 `
         -RestartInterval (New-TimeSpan -Minutes 10) `
         -RunOnlyIfNetworkAvailable `

--- a/cli/managedsoftwareupdate/Services/DownloadService.cs
+++ b/cli/managedsoftwareupdate/Services/DownloadService.cs
@@ -27,6 +27,9 @@ public class DownloadService
     private const int BandwidthLogIntervalSeconds = 10;
     private const int MaxRetries = 5;
     private const int BufferSize = 64 * 1024; // 64KB buffer
+    private const int HashBufferSize = 1024 * 1024; // 1MB buffer for hashing multi-GB packages
+    private const int HashLogIntervalSeconds = 10;
+    private const string VerifiedMarkerSuffix = ".verified";
 
     public DownloadService(CimianConfig config, HttpClient? httpClient = null)
     {
@@ -54,15 +57,28 @@ public class DownloadService
         // Check if file exists and matches hash
         if (File.Exists(localPath) && !string.IsNullOrEmpty(expectedHash))
         {
+            // A prior run already hashed this exact file: skip the re-read.
+            // Hashing a 10GB package costs 2-3 minutes, and the scheduled task
+            // only gets so long to live — spending it re-verifying an unchanged
+            // cache means nothing ever installs.
+            if (IsVerificationCurrent(localPath, expectedHash))
+            {
+                ConsoleLogger.Info($"Using cached file: {Path.GetFileName(localPath)}");
+                ConsoleLogger.Detail($"    Cached file previously verified (size and mtime unchanged): {localPath}");
+                return true;
+            }
+
             ConsoleLogger.Detail($"    Verifying cached file: {localPath}");
-            var existingHash = CalculateSHA256(localPath);
+            var existingHash = CalculateSHA256(localPath, Path.GetFileName(localPath));
             if (existingHash.Equals(expectedHash, StringComparison.OrdinalIgnoreCase))
             {
                 ConsoleLogger.Info($"Using cached file: {Path.GetFileName(localPath)}");
                 ConsoleLogger.Detail($"    Hash verification passed for cached file: {localPath}");
+                RecordVerification(localPath, expectedHash);
                 return true;
             }
             ConsoleLogger.Detail($"    Cached file hash mismatch, re-downloading expected: {expectedHash.Substring(0, 12)}... got: {existingHash.Substring(0, 12)}...");
+            ClearVerification(localPath);
         }
 
         var tempPath = localPath + ".downloading";
@@ -187,6 +203,12 @@ public class DownloadService
 
                 // Move temp file to final path
                 File.Move(tempPath, localPath, overwrite: true);
+
+                // Freshly hashed above — record it so the next run skips the re-read.
+                if (!string.IsNullOrEmpty(expectedHash))
+                {
+                    RecordVerification(localPath, expectedHash);
+                }
 
                 ConsoleLogger.Detail($"    File saved successfully file: {localPath}");
                 return true;
@@ -451,14 +473,124 @@ public class DownloadService
     }
 
     /// <summary>
+    /// Path of the sidecar recording that a cached file was hash-verified.
+    /// </summary>
+    private static string VerifiedMarkerPath(string localPath) => localPath + VerifiedMarkerSuffix;
+
+    /// <summary>
+    /// True when a previous run verified this exact file against this exact hash and
+    /// nothing about it has changed since. The marker records the expected hash, the
+    /// file length and the last-write time; any difference in any of the three — a
+    /// re-download, a truncation, a new version in the catalog — invalidates it and
+    /// forces a full re-hash.
+    /// </summary>
+    private static bool IsVerificationCurrent(string localPath, string expectedHash)
+    {
+        var markerPath = VerifiedMarkerPath(localPath);
+        if (!File.Exists(markerPath))
+            return false;
+
+        try
+        {
+            var parts = File.ReadAllText(markerPath).Trim().Split('|');
+            if (parts.Length != 3)
+                return false;
+
+            var info = new FileInfo(localPath);
+            return parts[0].Equals(expectedHash, StringComparison.OrdinalIgnoreCase)
+                && long.TryParse(parts[1], out var length) && length == info.Length
+                && long.TryParse(parts[2], out var ticks) && ticks == info.LastWriteTimeUtc.Ticks;
+        }
+        catch (Exception ex)
+        {
+            // An unreadable marker just means we re-hash — never a failure.
+            ConsoleLogger.Detail($"    Could not read verification marker {markerPath}: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static void RecordVerification(string localPath, string expectedHash)
+    {
+        try
+        {
+            var info = new FileInfo(localPath);
+            File.WriteAllText(
+                VerifiedMarkerPath(localPath),
+                $"{expectedHash.ToLowerInvariant()}|{info.Length}|{info.LastWriteTimeUtc.Ticks}");
+        }
+        catch (Exception ex)
+        {
+            ConsoleLogger.Detail($"    Could not write verification marker for {localPath}: {ex.Message}");
+        }
+    }
+
+    private static void ClearVerification(string localPath)
+    {
+        try
+        {
+            var markerPath = VerifiedMarkerPath(localPath);
+            if (File.Exists(markerPath))
+                File.Delete(markerPath);
+        }
+        catch { /* best effort */ }
+    }
+
+    /// <summary>
     /// Calculates SHA256 hash of a file
     /// </summary>
     public static string CalculateSHA256(string filePath)
     {
+        return CalculateSHA256(filePath, null);
+    }
+
+    /// <summary>
+    /// Calculates SHA256 hash of a file, optionally logging throughput while it runs.
+    /// Reads with a 1MB sequential-scan buffer: File.OpenRead defaults to 4KB, which
+    /// costs minutes on the multi-GB packages in the cache.
+    /// </summary>
+    public static string CalculateSHA256(string filePath, string? progressLabel)
+    {
         using var sha256 = SHA256.Create();
-        using var stream = File.OpenRead(filePath);
-        var hash = sha256.ComputeHash(stream);
-        return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        using var stream = new FileStream(
+            filePath, FileMode.Open, FileAccess.Read, FileShare.Read,
+            HashBufferSize, FileOptions.SequentialScan);
+
+        var totalSize = stream.Length;
+        var buffer = new byte[HashBufferSize];
+        long read = 0;
+        var stopwatch = Stopwatch.StartNew();
+        var lastLog = DateTime.UtcNow;
+
+        while (true)
+        {
+            var bytesRead = stream.Read(buffer, 0, buffer.Length);
+            if (bytesRead == 0)
+                break;
+
+            sha256.TransformBlock(buffer, 0, bytesRead, null, 0);
+            read += bytesRead;
+
+            // Without this a multi-minute verify emits nothing at all and is
+            // indistinguishable from a hung process.
+            if (progressLabel != null && (DateTime.UtcNow - lastLog).TotalSeconds >= HashLogIntervalSeconds)
+            {
+                var speed = read / stopwatch.Elapsed.TotalSeconds;
+                var percent = totalSize > 0 ? (double)read / totalSize * 100 : 0;
+                ConsoleLogger.Detail($"    Verify progress file: {progressLabel} hashed_mb: {read / (1024 * 1024)} total_mb: {totalSize / (1024 * 1024)} percent: {percent:F1}% speed: {FormatSpeed(speed)}");
+                lastLog = DateTime.UtcNow;
+            }
+        }
+
+        sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+        stopwatch.Stop();
+
+        if (progressLabel != null && stopwatch.Elapsed.TotalSeconds >= HashLogIntervalSeconds)
+        {
+            var avgSpeed = read / stopwatch.Elapsed.TotalSeconds;
+            ConsoleLogger.Detail($"    Verify completed file: {progressLabel} size_mb: {read / (1024 * 1024)} duration: {FormatDuration(stopwatch.Elapsed)} avg_speed: {FormatSpeed(avgSpeed)}");
+        }
+
+        return Convert.ToHexString(sha256.Hash!).ToLowerInvariant();
     }
 
     /// <summary>
@@ -474,6 +606,7 @@ public class DownloadService
         var files = Directory.GetFiles(_config.CachePath, "*", SearchOption.AllDirectories);
         var corruptCount = 0;
         var abandonedDownloads = 0;
+        var orphanedMarkers = 0;
 
         foreach (var file in files)
         {
@@ -494,6 +627,25 @@ public class DownloadService
                 }
             }
             
+            // Drop verification markers whose package is no longer cached
+            if (file.EndsWith(VerifiedMarkerSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                var packagePath = file.Substring(0, file.Length - VerifiedMarkerSuffix.Length);
+                if (!File.Exists(packagePath))
+                {
+                    try
+                    {
+                        File.Delete(file);
+                        orphanedMarkers++;
+                    }
+                    catch (Exception ex)
+                    {
+                        ConsoleLogger.Warn($"Failed to remove orphaned verification marker {file}: {ex.Message}");
+                    }
+                }
+                continue;
+            }
+
             // Clean up old abandoned .downloading files (older than 24 hours)
             if (file.EndsWith(".downloading", StringComparison.OrdinalIgnoreCase))
             {
@@ -517,9 +669,9 @@ public class DownloadService
             }
         }
 
-        if (corruptCount > 0 || abandonedDownloads > 0)
+        if (corruptCount > 0 || abandonedDownloads > 0 || orphanedMarkers > 0)
         {
-            ConsoleLogger.Info($"Cache cleanup: removed {corruptCount} corrupt files, {abandonedDownloads} abandoned downloads");
+            ConsoleLogger.Info($"Cache cleanup: removed {corruptCount} corrupt files, {abandonedDownloads} abandoned downloads, {orphanedMarkers} orphaned verification markers");
         }
     }
 

--- a/tests/Managedsoftwareupdate/DownloadServiceTests.cs
+++ b/tests/Managedsoftwareupdate/DownloadServiceTests.cs
@@ -319,4 +319,116 @@ public class DownloadServiceTests : IDisposable
     }
 
     #endregion
+
+    #region Cached-file verification memo
+
+    // Re-hashing a multi-GB package on every hourly run is what starved the
+    // scheduled task of its 30-minute budget. Once a file has been verified,
+    // an unchanged size and mtime stand in for the hash.
+
+    private static string MarkerFor(string path) => path + ".verified";
+
+    private string WriteCachedFile(string name, string content)
+    {
+        var path = Path.Combine(_testCacheDir, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_CacheHit_RecordsVerificationMarker()
+    {
+        var path = WriteCachedFile("cached.msi", "Hello, World!");
+        var hash = DownloadService.CalculateSHA256(path);
+
+        var result = await _service.DownloadFileAsync("https://test.example.com/unused", path, hash);
+
+        Assert.True(result);
+        Assert.True(File.Exists(MarkerFor(path)));
+
+        var parts = File.ReadAllText(MarkerFor(path)).Split('|');
+        var info = new FileInfo(path);
+        Assert.Equal(hash, parts[0]);
+        Assert.Equal(info.Length.ToString(), parts[1]);
+        Assert.Equal(info.LastWriteTimeUtc.Ticks.ToString(), parts[2]);
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_MarkerForDifferentHash_IsIgnoredAndRewritten()
+    {
+        // A new version in the catalog means a new expected hash; the old marker
+        // must not be allowed to vouch for the file.
+        var path = WriteCachedFile("stale-marker.msi", "Hello, World!");
+        var hash = DownloadService.CalculateSHA256(path);
+        var info = new FileInfo(path);
+        File.WriteAllText(MarkerFor(path), $"{new string('a', 64)}|{info.Length}|{info.LastWriteTimeUtc.Ticks}");
+
+        var result = await _service.DownloadFileAsync("https://test.example.com/unused", path, hash);
+
+        Assert.True(result);
+        Assert.StartsWith(hash, File.ReadAllText(MarkerFor(path)));
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_MarkerWithStaleMtime_IsIgnoredAndRewritten()
+    {
+        var path = WriteCachedFile("touched.msi", "Hello, World!");
+        var hash = DownloadService.CalculateSHA256(path);
+        var info = new FileInfo(path);
+        var staleTicks = info.LastWriteTimeUtc.AddDays(-1).Ticks;
+        File.WriteAllText(MarkerFor(path), $"{hash}|{info.Length}|{staleTicks}");
+
+        var result = await _service.DownloadFileAsync("https://test.example.com/unused", path, hash);
+
+        Assert.True(result);
+        Assert.EndsWith(new FileInfo(path).LastWriteTimeUtc.Ticks.ToString(), File.ReadAllText(MarkerFor(path)));
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_MalformedMarker_FallsBackToHashing()
+    {
+        var path = WriteCachedFile("garbage-marker.msi", "Hello, World!");
+        var hash = DownloadService.CalculateSHA256(path);
+        File.WriteAllText(MarkerFor(path), "not a marker");
+
+        var result = await _service.DownloadFileAsync("https://test.example.com/unused", path, hash);
+
+        Assert.True(result);
+        Assert.StartsWith(hash, File.ReadAllText(MarkerFor(path)));
+    }
+
+    [Fact]
+    public void ValidateAndCleanCache_RemovesOrphanedVerificationMarkers()
+    {
+        var kept = WriteCachedFile("present.msi", "content");
+        File.WriteAllText(MarkerFor(kept), "hash|7|123");
+        var orphanMarker = MarkerFor(Path.Combine(_testCacheDir, "deleted.msi"));
+        File.WriteAllText(orphanMarker, "hash|7|123");
+
+        _service.ValidateAndCleanCache();
+
+        Assert.True(File.Exists(MarkerFor(kept)));
+        Assert.False(File.Exists(orphanMarker));
+    }
+
+    #endregion
+
+    #region Hashing
+
+    [Fact]
+    public void CalculateSHA256_FileLargerThanBuffer_MatchesSingleShotHash()
+    {
+        // Hashing now streams through a 1MB buffer in TransformBlock chunks
+        // rather than one ComputeHash(stream) call — guard the equivalence.
+        var path = Path.Combine(_testCacheDir, "large.bin");
+        var data = new byte[(3 * 1024 * 1024) + 7];
+        new Random(1234).NextBytes(data);
+        File.WriteAllBytes(path, data);
+
+        var expected = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(data)).ToLowerInvariant();
+
+        Assert.Equal(expected, DownloadService.CalculateSHA256(path));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
A newly imaged machine could fail to converge. Two causes.

**The scheduled task is killed at 30 minutes.** `Cimian Managed Software Update Hourly` registers with `-ExecutionTimeLimit (New-TimeSpan -Minutes 30)`. A first run has to fetch and install an entire manifest, which can include packages of several GB. The download layer computes its own timeout from file size and will allot well over an hour to a single large package; the task itself gets 30 minutes. Each run resumed the same partial download and was killed again at the same point.

**Cache verification re-hashes everything, every run.** This is the part that would have survived a bigger timeout. `DownloadFileAsync` re-computed SHA-256 over each cached package before accepting it, and `CalculateSHA256` read through `File.OpenRead` — a 4 KB buffer with no `SequentialScan`. On multi-GB packages that costs minutes each. With enough large packages, an already fully-cached machine can spend its entire budget re-reading files it verified an hour earlier and install nothing. Slower disks make it worse.

## Changes

- **Verification memo.** Once a cached file's hash matches, write a sidecar recording the expected hash, the file length and the last-write time. A later run accepts the cache on a `stat` instead of a re-read. Any difference in any of the three — a re-download, a truncation, a new version in the catalog — invalidates the memo and forces a full re-hash. `ValidateAndCleanCache` prunes markers whose package is gone.
- **Hash through a 1 MB sequential-scan buffer.** The class already had a 64 KB `BufferSize` constant, but it was only ever applied to the download copy loop, never to hashing.
- **Log throughput while hashing.** Nothing was emitted between `Verifying cached file` and `Using cached file`, so a multi-minute verify was indistinguishable from a hung process. The download path already reports percent/current_speed/avg_speed/eta every 10s; hashing now does the same.
- **`ExecutionTimeLimit` 30 minutes to 4 hours** in all three installer paths (`build/msi/install-tasks.ps1`, `build/nupkg/scripts/chocolateyInstall.ps1`, `build/pkg/postinstall.ps1`), where the value was hardcoded three times over. The hourly trigger cannot stack on a long run because `MultipleInstances` defaults to `IgnoreNew`. The 5-minute watchdog task is untouched.

4 hours rather than 1: a one-hour ceiling would still truncate a first run whose largest single download is allotted more than that on its own.

## Considered and not needed

Setting an `install_window` on large packages would not avoid the verify cost, and isn't necessary — `UpdateEngine` removes out-of-window items from the install/update/uninstall lists *before* the download phase, so a deferred package is never downloaded or hash-verified. (One gap, out of scope here: `precache: true` optional items are fetched without consulting the window.)

## Verification

- `dotnet build` clean. Full suite passes, apart from two `ConfigurationServiceTests` failures that reproduce unchanged on a pristine `main` and predate this branch.
- Six new tests in `DownloadServiceTests` cover marker creation, invalidation by a changed expected hash, invalidation by a changed mtime, malformed-marker fallback, orphan pruning, and hash equivalence for a file larger than the new buffer.
- `managedsoftwareupdate.exe` published, signed and smoke-tested.

## Rollout

Existing installs carry the 30-minute task. The installer re-registers it with `-Force` on upgrade, so a new build corrects it without separate remediation. The first run after upgrading still performs one full verification pass, since no markers exist yet; the saving begins on the run after.
