### PR TITLE
Drop internal tracker ids and device counts from code comments

### DIFF
--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -486,7 +486,7 @@ public class CatalogItem
     // session — cache clears, time sync, user/account checks) legitimately re-run
     // with the same version. LoopGuard would otherwise count those repeats as an
     // install loop and suppress them with a warning (the whole recurring-script tail
-    // of AB#3709). This flag exempts the item from loop suppression WITHOUT OnDemand's
+    // of the loop-suppression work). This flag exempts the item from loop suppression WITHOUT OnDemand's
     // no-receipt/never-installed semantics, so the item still tracks normally.
     [YamlMember(Alias = "recurring")]
     public bool Recurring { get; set; }

--- a/cli/managedsoftwareupdate/Services/ConfigurationService.cs
+++ b/cli/managedsoftwareupdate/Services/ConfigurationService.cs
@@ -40,7 +40,7 @@ public class ConfigurationService
     /// MDM policy overrides delivered by the CimianPrefs Intune profile
     /// (ADMX-ingested Policy CSP writing to HKLM\SOFTWARE\Policies\Cimian).
     /// Policy wins over Config.yaml so fleet-wide settings can ship as an
-    /// Intune configuration profile instead of per-device file edits (AB#3709).
+    /// Intune configuration profile instead of per-device file edits.
     /// </summary>
     private const string PolicyRegistryPath = @"SOFTWARE\Policies\Cimian";
 

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -839,7 +839,7 @@ public class InstallerService
         // so the MSI either fails with 1603 (file in use) or schedules a
         // reboot-replace that lab machines never perform — the installed version
         // pins at the old build and the item reinstall-loops every session until
-        // LoopGuard suppresses it (73 devices, AB#3709).
+        // LoopGuard suppresses it.
         var replacesSbinInstaller = string.Equals(item.Name, "SbinInstaller", StringComparison.OrdinalIgnoreCase);
         if (!replacesSbinInstaller && IsCimianBuiltMsi(localFile) && IsSbinInstallerAvailable())
         {

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -885,7 +885,7 @@ if ($results.Count -gt 0) {{
         // reversing within each pair) yields a GUID that no key ever matches, so
         // every UpgradeCode lookup silently missed and any pkgsinfo relying on an
         // upgrade_code-only installs[] entry reinstalled every session until
-        // LoopGuard suppressed it (AB#4416: PowerShell + AzureCLI, ~540 devices).
+        // LoopGuard suppressed it (PowerShell + AzureCLI).
         var result = new char[32];
 
         // Section 1: first 8 chars, fully reversed

--- a/tests/Managedsoftwareupdate/StatusServiceTests.cs
+++ b/tests/Managedsoftwareupdate/StatusServiceTests.cs
@@ -511,7 +511,7 @@ public class StatusServiceTests
     // HKLM\SOFTWARE\Classes\Installer\UpgradeCodes on real fleet machines, so they
     // are ground truth rather than a restatement of the implementation.
     //
-    // Regression guard for AB#4416: the previous implementation reversed only the
+    // Regression guard: the previous implementation reversed only the
     // ORDER of character pairs in sections 1-3 without reversing within each pair,
     // producing a packed GUID that matched no registry key. Every UpgradeCode
     // lookup missed, so upgrade_code-only installs[] entries (PowerShell 7.6.4.0,

--- a/tests/VersionServiceTests.cs
+++ b/tests/VersionServiceTests.cs
@@ -221,7 +221,7 @@ public class VersionServiceTests
 
     #endregion
 
-    #region Calendar Build Stamp Tests (AB#3754)
+    #region Calendar Build Stamp Tests
 
     [Theory]
     // The core bug: the legacy 3-component "yyyy.M.DDHH" stamp (day+hour merged, no


### PR DESCRIPTION
These comments referenced a private tracker, and in two places how many machines a behaviour had been observed on. Neither means anything to a reader of this repo. The explanations themselves are unchanged; two sentences were reworded so they still read correctly once the id is removed.

Comments only — no behaviour change.