### PR TITLE
Detect installcheck defects at first install and make loop clears stick

### DIFF
--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -114,6 +114,16 @@ public class CimianConfig
     public int LoopMaxTime { get; set; } = 7;
 
     /// <summary>
+    /// How often, in hours, a package flagged as non-converged (its installcheck
+    /// still reports "action needed" immediately after a successful install — a
+    /// proven pkgsinfo defect) is re-probed with a fresh install attempt. Between
+    /// probes the package is suppressed with a message naming the defect. Default
+    /// 24; capped at LoopMaxTime. Any pkgsinfo change clears the flag immediately.
+    /// </summary>
+    [YamlMember(Alias = "LoopReprobeHours")]
+    public int LoopReprobeHours { get; set; } = 24;
+
+    /// <summary>
     /// Master switch for unused-software removal (unused_software_removal_info).
     /// On by default — harmless fleet-wide because every package must still
     /// opt in via pkginfo, and the pass only ever touches self-serve/optional

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -128,6 +128,14 @@ public class UpdateEngine : IDisposable
         sb.Append(item.Check?.File?.Hash ?? "");
         sb.Append(':');
         sb.Append(item.Check?.Script ?? "");
+        sb.Append('|');
+        // Running agent version: a Cimian client update may itself be the fix for a
+        // loop (installer semantics, detection logic — e.g. the packed-GUID MSI
+        // detection bug). Folding it in means every client update auto-clears all
+        // suppressions once, fleet-wide, on the first post-update run — without
+        // this, a client-side fix could never break through standing suppression
+        // and an MDM-side clear was the only way out.
+        sb.Append(VersionService.GetRunningAgentVersion());
 
         return LoopGuard.ComputeFingerprint(sb.ToString());
     }
@@ -415,7 +423,7 @@ public class UpdateEngine : IDisposable
             // and in a sibling reports/loop_suppressed.json for dashboards.
             var loopSuppressedByName = loopSuppressed.ToDictionary(
                 x => x.Item.Name.ToLowerInvariant(),
-                x => (x.Reason, x.InstalledVersion, x.WasUpdate));
+                x => (x.Reason, x.InstalledVersion, x.WasUpdate, x.PendingRestart));
 
             // AutoRemove: queue uninstall for packages installed by Cimian but no longer in any manifest
             if (_config.AutoRemove)
@@ -932,7 +940,7 @@ public class UpdateEngine : IDisposable
     }
 
     private (List<CatalogItem> ToInstall, List<CatalogItem> ToUpdate, List<CatalogItem> ToUninstall,
-             List<(CatalogItem Item, string Reason, string? InstalledVersion, bool WasUpdate)> LoopSuppressed)
+             List<(CatalogItem Item, string Reason, string? InstalledVersion, bool WasUpdate, bool PendingRestart)> LoopSuppressed)
         IdentifyActions(List<ManifestItem> manifestItems, Dictionary<string, CatalogItem> catalogMap,
                         ItemFilterService? itemFilterService = null)
     {
@@ -941,7 +949,9 @@ public class UpdateEngine : IDisposable
         var toUninstall = new List<CatalogItem>();
         // Items LoopGuard refused this run. Tracked separately so CollectSessionItems
         // can stamp them as Warning instead of letting them fall through to "Installed".
-        var loopSuppressed = new List<(CatalogItem, string, string?, bool)>();
+        // PendingRestart entries are the benign flavor: a prior install just needs a
+        // reboot to finalize — surfaced as Pending, not Warning.
+        var loopSuppressed = new List<(CatalogItem, string, string?, bool, bool)>();
 
         var sysArch = StatusService.GetSystemArchitecture();
 
@@ -1065,6 +1075,29 @@ public class UpdateEngine : IDisposable
                         if (_loopGuard != null && !bypassLoopGuard)
                         {
                             var fingerprint = ComputeCatalogFingerprint(catalogItem);
+
+                            // A prior successful install may be awaiting a reboot to
+                            // finalize (restart_action items whose installcheck can't
+                            // pass until the machine restarts). Defer instead of
+                            // reinstalling every session until the reboot happens.
+                            var (defer, deferReason) = _loopGuard.ShouldDeferForRestart(catalogItem.Name, fingerprint);
+                            if (defer)
+                            {
+                                ConsoleLogger.Info(deferReason);
+                                _sessionLogger?.Log("INFO", deferReason);
+                                _sessionLogger?.LogStatusCheck(
+                                    catalogItem.Name,
+                                    catalogItem.Version,
+                                    "deferred",
+                                    deferReason,
+                                    Cimian.Core.Models.StatusReasonCode.PendingReboot,
+                                    Cimian.Core.Models.DetectionMethod.None,
+                                    status.InstalledVersion,
+                                    false);
+                                loopSuppressed.Add((catalogItem, deferReason, status.InstalledVersion, status.IsUpdate, true));
+                                break; // Skip this item
+                            }
+
                             var (suppress, loopReason) = _loopGuard.ShouldSuppress(catalogItem.Name, catalogItem.Version, fingerprint);
                             if (suppress)
                             {
@@ -1079,7 +1112,7 @@ public class UpdateEngine : IDisposable
                                     Cimian.Core.Models.DetectionMethod.None,
                                     status.InstalledVersion,
                                     false);
-                                loopSuppressed.Add((catalogItem, loopReason, status.InstalledVersion, status.IsUpdate));
+                                loopSuppressed.Add((catalogItem, loopReason, status.InstalledVersion, status.IsUpdate, false));
                                 break; // Skip this item
                             }
                         }
@@ -1895,7 +1928,21 @@ public class UpdateEngine : IDisposable
         }
 
         var (success, output, warningMessage) = await _installerService.InstallAsync(item, localFile ?? "", cancellationToken);
-        outcomes.Add(new ItemOutcome(item.Name, item.Version, "install", success, success ? null : output, DateTime.UtcNow, warningMessage));
+
+        // Convergence verification: a successful install must flip its own
+        // installcheck to "no action needed", or the pkgsinfo is provably broken
+        // and would loop every session until the counting thresholds gag it with
+        // a generic warning 3+ sessions later. Prove it here, on the first
+        // install, with a message that names the actual defect. Items whose
+        // restart_action finalizes at reboot are the legitimate exception.
+        string? convergenceWarning = null;
+        var convergencePendingRestart = false;
+        if (success && warningMessage == null)
+        {
+            (convergenceWarning, convergencePendingRestart) = VerifyConvergence(item);
+        }
+
+        outcomes.Add(new ItemOutcome(item.Name, item.Version, "install", success, success ? null : output, DateTime.UtcNow, warningMessage ?? convergenceWarning));
 
         if (success)
         {
@@ -1939,6 +1986,19 @@ public class UpdateEngine : IDisposable
                 success: true,
                 ComputeCatalogFingerprint(item),
                 selfReportedWarning: warningMessage != null);
+
+            // Act on the convergence verdict from above.
+            if (convergencePendingRestart)
+            {
+                LogInfo($"{item.Name} installed but is finalized by a reboot (restart_action: {item.RestartAction}) — reinstalls deferred until the machine restarts");
+                _loopGuard?.RecordPendingRestart(item.Name, item.Version, ComputeCatalogFingerprint(item));
+            }
+            else if (convergenceWarning != null)
+            {
+                ConsoleLogger.Warn(convergenceWarning);
+                _sessionLogger?.Log("WARN", convergenceWarning);
+                _loopGuard?.MarkNonConverged(item.Name, item.Version, ComputeCatalogFingerprint(item), _config.LoopReprobeHours);
+            }
 
             // Add to installed items
             if (!installedItems.Contains(item.Name, StringComparer.OrdinalIgnoreCase))
@@ -2782,7 +2842,7 @@ public class UpdateEngine : IDisposable
         List<CatalogItem> toUninstall,
         Dictionary<string, CatalogItem> catalogMap,
         IReadOnlyDictionary<string, ItemOutcome> outcomesByName,
-        IReadOnlyDictionary<string, (string Reason, string? InstalledVersion, bool WasUpdate)> loopSuppressedByName)
+        IReadOnlyDictionary<string, (string Reason, string? InstalledVersion, bool WasUpdate, bool PendingRestart)> loopSuppressedByName)
     {
         if (_sessionLogger == null) return;
 
@@ -2825,23 +2885,27 @@ public class UpdateEngine : IDisposable
             // acted on, but it is broken — surface as Warning so dashboards flag it.
             // Keep the conditional short-circuited so suppressed items don't fall
             // through to outcome/plan logic below.
+            // Pending-restart deferrals share the channel but are NOT warnings: the
+            // install succeeded and a reboot finalizes it — surface as Pending.
             if (loopSuppressedByName.TryGetValue(key, out var suppression))
             {
                 items.Add(new SessionPackageInfo
                 {
                     Name = mi.Name,
                     Version = version,
-                    Status = "Warning",
+                    Status = suppression.PendingRestart ? "Pending" : "Warning",
                     ItemType = itemType,
                     DisplayName = displayName,
                     InstalledVersion = suppression.InstalledVersion,
-                    WarningMessage = suppression.Reason,
+                    WarningMessage = suppression.PendingRestart ? null : suppression.Reason,
                     StatusReason = suppression.Reason,
-                    StatusReasonCode = Cimian.Core.Models.StatusReasonCode.LoopSuppressed,
+                    StatusReasonCode = suppression.PendingRestart
+                        ? Cimian.Core.Models.StatusReasonCode.PendingReboot
+                        : Cimian.Core.Models.StatusReasonCode.LoopSuppressed,
                     DetectionMethod = Cimian.Core.Models.DetectionMethod.None,
                     // Mark as touched this run so DataExporter stamps last_seen_in_session.
                     // Distinct from install/update/remove so consumers can filter on it.
-                    ActionPerformed = "loop_suppressed",
+                    ActionPerformed = suppression.PendingRestart ? "restart_deferred" : "loop_suppressed",
                     OutcomeTimestamp = DateTime.UtcNow
                 });
                 continue;
@@ -3226,6 +3290,39 @@ public class UpdateEngine : IDisposable
         reason = $"requires Cimian {item.MinimumCimianVersion} or newer, running {currentVersion}";
         reasonCode = StatusReasonCode.AgentVersionTooOld;
         return false;
+    }
+
+    /// <summary>
+    /// Re-runs the item's install status check immediately after a successful
+    /// install to prove the pkgsinfo is self-consistent. A correct pkgsinfo's
+    /// installcheck reports "no action needed" once the installer has run; one
+    /// that still reports "action needed" will reinstall every session — the
+    /// entire install-loop defect class, detected here on session 1 instead of
+    /// after 3+ sessions of churn.
+    /// Returns (warning, pendingRestart): warning carries the precise defect
+    /// message for a broken pkgsinfo; pendingRestart is true for the legitimate
+    /// case where the item's restart_action finalizes the install at reboot.
+    /// Verification must never fail a completed install — any error here is
+    /// swallowed and treated as converged.
+    /// </summary>
+    private (string? Warning, bool PendingRestart) VerifyConvergence(CatalogItem item)
+    {
+        try
+        {
+            var status = _statusService.CheckStatus(item, "install", _config.CachePath);
+            if (!status.NeedsAction)
+                return (null, false);
+
+            if (RequiresRestart(item) || RequiresLogout(item))
+                return (null, true);
+
+            var warning = $"installcheck did not converge: {item.Name} v{item.Version} still reports action needed ({status.Reason}) immediately after a successful install — fix the pkgsinfo installcheck/installs criteria (re-probes in {(_config.LoopReprobeHours > 0 ? _config.LoopReprobeHours : 24)}h; clears immediately on pkgsinfo change)";
+            return (warning, false);
+        }
+        catch
+        {
+            return (null, false);
+        }
     }
 
     /// <summary>

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -199,6 +199,8 @@ public class LoopGuard
                     pkgState.SessionCount = 0;
                     pkgState.VersionAttempts.Clear();
                     pkgState.RecentTimestamps.Clear();
+                    pkgState.PendingRestartSince = null;
+                    pkgState.ClearedAt = DateTime.UtcNow;
                     pkgState.LastVersion = version;
                     pkgState.CatalogFingerprint = catalogFingerprint;
                     SaveState();
@@ -313,6 +315,11 @@ public class LoopGuard
 
     /// <summary>
     /// Clears loop suppression for a specific package.
+    /// Stamps a ClearedAt watermark so the cleared history is not re-counted by the
+    /// next run's rebuild from events.jsonl — only installs that happen AFTER the
+    /// clear accumulate toward suppression again. A still-looping package therefore
+    /// re-suppresses after 3 fresh installs (as it should), but a clear is never
+    /// silently undone by history.
     /// </summary>
     public bool ClearLoop(string packageName)
     {
@@ -325,6 +332,9 @@ public class LoopGuard
             pkgState.SessionCount = 0;
             pkgState.VersionAttempts.Clear();
             pkgState.RecentTimestamps.Clear();
+            pkgState.ProcessedSessions.Clear();
+            pkgState.PendingRestartSince = null;
+            pkgState.ClearedAt = DateTime.UtcNow;
             SaveState();
             return true;
         }
@@ -333,13 +343,145 @@ public class LoopGuard
 
     /// <summary>
     /// Clears loop suppression for all packages.
+    /// Stamps the root ClearedAt watermark for the same reason as ClearLoop: the
+    /// old implementation reset state wholesale, which the next run promptly undid
+    /// by re-counting 7 days of events.jsonl and re-tripping "3 installs across 3
+    /// sessions" — making --clear-loop all (and any MDM-driven clear) a no-op.
     /// </summary>
     public int ClearAll()
     {
         var count = _state.Packages.Count(p => p.Value.SuppressedUntil.HasValue);
-        _state = new LoopGuardState();
+        _state = new LoopGuardState { ClearedAt = DateTime.UtcNow };
         SaveState();
         return count;
+    }
+
+    /// <summary>
+    /// System boot time (UTC), injectable for tests. Default derives it from uptime.
+    /// </summary>
+    internal Func<DateTime> BootTimeUtcProvider { get; set; } =
+        () => DateTime.UtcNow - TimeSpan.FromMilliseconds(Environment.TickCount64);
+
+    // Clock-skew fudge when comparing boot time against the pending-restart memo.
+    private static readonly TimeSpan BootTimeSkewTolerance = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Records that a successful install has not yet converged because the item's
+    /// restart_action finalizes it at the next reboot/logout. While the memo stands,
+    /// ShouldDeferForRestart tells the engine to skip the reinstall instead of
+    /// churning the installer every session until the machine restarts.
+    /// </summary>
+    public void RecordPendingRestart(string packageName, string version, string? catalogFingerprint = null)
+    {
+        if (_disabled || string.IsNullOrEmpty(packageName))
+            return;
+
+        var key = packageName.ToLowerInvariant();
+        if (!_state.Packages.TryGetValue(key, out var pkgState))
+        {
+            pkgState = new PackageLoopState { PackageName = packageName };
+            _state.Packages[key] = pkgState;
+        }
+
+        pkgState.PendingRestartSince = DateTime.UtcNow;
+        pkgState.LastVersion = version;
+        if (!string.IsNullOrEmpty(catalogFingerprint))
+            pkgState.CatalogFingerprint = catalogFingerprint;
+        SaveState();
+    }
+
+    /// <summary>
+    /// Whether an install for this package should be deferred because a prior
+    /// successful install is awaiting a reboot/logout to finalize. The memo clears
+    /// itself when: the system boot time advances past it (the reboot happened —
+    /// re-evaluate normally), the pkgsinfo fingerprint changes (admin shipped a
+    /// change), or it ages past the LoopMaxTime cap (defensive: a logout-finalized
+    /// item on a machine that never reboots, or drift such as a user uninstalling
+    /// the app, must not be deferred forever).
+    /// </summary>
+    public (bool Defer, string Reason) ShouldDeferForRestart(string packageName, string? catalogFingerprint = null)
+    {
+        if (_isBootstrap || _disabled || string.IsNullOrEmpty(packageName))
+            return (false, "");
+
+        var key = packageName.ToLowerInvariant();
+        if (!_state.Packages.TryGetValue(key, out var pkgState) || !pkgState.PendingRestartSince.HasValue)
+            return (false, "");
+
+        var since = pkgState.PendingRestartSince.Value;
+
+        // Pkgsinfo changed since the memo was stamped — defer no longer applies.
+        if (!string.IsNullOrEmpty(catalogFingerprint) && !string.IsNullOrEmpty(pkgState.CatalogFingerprint) &&
+            !string.Equals(catalogFingerprint, pkgState.CatalogFingerprint, StringComparison.OrdinalIgnoreCase))
+        {
+            pkgState.PendingRestartSince = null;
+            SaveState();
+            return (false, "");
+        }
+
+        // Reboot happened — clear the memo and let the normal installcheck decide.
+        DateTime bootTime;
+        try { bootTime = BootTimeUtcProvider(); }
+        catch { bootTime = DateTime.MinValue; }
+        if (bootTime - BootTimeSkewTolerance > since)
+        {
+            pkgState.PendingRestartSince = null;
+            SaveState();
+            return (false, "");
+        }
+
+        // Defensive age-out.
+        if (DateTime.UtcNow - since > TimeSpan.FromDays(_maxSuppressionDays))
+        {
+            pkgState.PendingRestartSince = null;
+            SaveState();
+            return (false, "");
+        }
+
+        return (true, $"PENDING RESTART: {packageName} v{pkgState.LastVersion} installed successfully but is finalized by a reboot — deferring reinstall until the machine restarts");
+    }
+
+    /// <summary>
+    /// Marks a package whose successful install provably did not converge: the
+    /// installcheck that scheduled the install still reports "action needed"
+    /// immediately afterwards, so the pkgsinfo's detection criteria never match
+    /// what the installer lays down. This is the root cause of the install-loop
+    /// class — recording it here on the FIRST install replaces churning through
+    /// 3+ sessions before the counting thresholds notice. Suppression re-probes
+    /// after <paramref name="reprobeHours"/> (capped by LoopMaxTime) and, as with
+    /// any suppression, auto-clears the moment the pkgsinfo fingerprint changes.
+    /// Returns the reason recorded, for surfacing on the session's outcome.
+    /// </summary>
+    public string MarkNonConverged(string packageName, string version, string? catalogFingerprint, int reprobeHours = 24)
+    {
+        var hours = reprobeHours > 0 ? reprobeHours : 24;
+        hours = Math.Min(hours, _maxSuppressionDays * 24);
+        var reason = $"installcheck did not converge: {packageName} v{version} still reports action needed immediately after a successful install — fix the pkgsinfo installcheck/installs criteria (re-probes in {hours}h; clears immediately on pkgsinfo change)";
+
+        if (_disabled || string.IsNullOrEmpty(packageName))
+            return reason;
+
+        var key = packageName.ToLowerInvariant();
+        if (!_state.Packages.TryGetValue(key, out var pkgState))
+        {
+            pkgState = new PackageLoopState { PackageName = packageName };
+            _state.Packages[key] = pkgState;
+        }
+
+        pkgState.SuppressedUntil = DateTime.UtcNow.AddHours(hours);
+        pkgState.SuppressionReason = reason;
+        pkgState.LastVersion = version;
+        if (!string.IsNullOrEmpty(catalogFingerprint))
+            pkgState.CatalogFingerprint = catalogFingerprint;
+        SaveState();
+        return reason;
+    }
+
+    private static DateTime? MaxNullable(DateTime? a, DateTime? b)
+    {
+        if (!a.HasValue) return b;
+        if (!b.HasValue) return a;
+        return a.Value > b.Value ? a : b;
     }
 
     /// <summary>
@@ -593,9 +735,22 @@ public class LoopGuard
                         _state.Packages[key] = pkgState;
                     }
 
+                    // Clear watermark: events older than the most recent clear
+                    // (--clear-loop, per-package or all) are history that was
+                    // deliberately discarded. Skip counting them — but still mark
+                    // the session processed so they are never revisited. Without
+                    // this gate, every clear was undone on the next run by this
+                    // very rebuild re-counting the last 7 days of events.
+                    var clearWatermark = MaxNullable(_state.ClearedAt, pkgState.ClearedAt);
+                    DateTime? eventTime = DateTime.TryParse(timestamp, out var ts2)
+                        ? ts2.ToUniversalTime()
+                        : null;
+                    var preClearHistory = clearWatermark.HasValue &&
+                        (!eventTime.HasValue || eventTime.Value < clearWatermark.Value);
+
                     // Only count if not already tracked in state (avoid double-counting
                     // from both state file and events)
-                    if (!pkgState.ProcessedSessions.Contains(sessionId))
+                    if (!pkgState.ProcessedSessions.Contains(sessionId) && !preClearHistory)
                     {
                         pkgState.AttemptCount++;
                         pkgState.LastSuccess = string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase)
@@ -608,11 +763,11 @@ public class LoopGuard
                             pkgState.VersionAttempts[version] = vc + 1;
                         }
 
-                        if (DateTime.TryParse(timestamp, out var ts2))
+                        if (eventTime.HasValue)
                         {
-                            pkgState.RecentTimestamps.Add(ts2.ToUniversalTime());
-                            if (pkgState.LastAttempt == null || ts2.ToUniversalTime() > pkgState.LastAttempt)
-                                pkgState.LastAttempt = ts2.ToUniversalTime();
+                            pkgState.RecentTimestamps.Add(eventTime.Value);
+                            if (pkgState.LastAttempt == null || eventTime.Value > pkgState.LastAttempt)
+                                pkgState.LastAttempt = eventTime.Value;
                         }
                     }
 
@@ -840,6 +995,15 @@ public class LoopGuardState
     [JsonPropertyName("last_updated")]
     public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Watermark stamped by ClearAll(). History rebuilds ignore install events older
+    /// than this, so a fleet-wide clear is not silently undone by the next run
+    /// re-counting the last 7 days of events.jsonl.
+    /// </summary>
+    [JsonPropertyName("cleared_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? ClearedAt { get; set; }
+
     [JsonPropertyName("packages")]
     public Dictionary<string, PackageLoopState> Packages { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 }
@@ -896,6 +1060,27 @@ public class PackageLoopState
     /// </summary>
     [JsonPropertyName("processed_sessions")]
     public HashSet<string> ProcessedSessions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Watermark stamped by ClearLoop(). Same contract as LoopGuardState.ClearedAt
+    /// but scoped to this package: install events older than this are never
+    /// re-counted, so a per-package clear survives history rebuilds.
+    /// </summary>
+    [JsonPropertyName("cleared_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? ClearedAt { get; set; }
+
+    /// <summary>
+    /// Set when a successful install did not converge (installcheck still reports
+    /// action needed) and the item's restart_action explains why — the install is
+    /// finalized by a reboot/logout. While set, reinstalls are deferred instead of
+    /// churning every session until the machine restarts. Cleared when the system
+    /// boot time advances past this timestamp, when the pkgsinfo changes, or when
+    /// the memo ages out (defensive cap — see ShouldDeferForRestart).
+    /// </summary>
+    [JsonPropertyName("pending_restart_since")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? PendingRestartSince { get; set; }
 }
 
 #endregion

--- a/tests/LoopGuardTests.cs
+++ b/tests/LoopGuardTests.cs
@@ -700,6 +700,157 @@ public class LoopGuardTests : IDisposable
 
     #endregion
 
+    #region Clears Survive History Rebuild
+
+    [Fact]
+    public void ClearAll_SurvivesHistoryRebuild()
+    {
+        // 3 sessions of installs → suppression trips
+        CreateEventsFile("ca_s1", "StuckPkg", "1.0.0", "completed", DateTime.UtcNow.AddHours(-3));
+        CreateEventsFile("ca_s2", "StuckPkg", "1.0.0", "completed", DateTime.UtcNow.AddHours(-2));
+        CreateEventsFile("ca_s3", "StuckPkg", "1.0.0", "completed", DateTime.UtcNow.AddMinutes(-90));
+
+        var guard = CreateGuard();
+        guard.ShouldSuppress("StuckPkg", "1.0.0").Suppress.Should().BeTrue();
+
+        guard.ClearAll().Should().BeGreaterThan(0);
+
+        // A fresh instance rebuilds history from the same events.jsonl files.
+        // Before the ClearedAt watermark existed, this rebuild re-counted the
+        // cleared installs and re-tripped suppression immediately — making
+        // --clear-loop all (and any MDM-driven clear) a self-undoing no-op.
+        var rebuilt = CreateGuard();
+        rebuilt.ShouldSuppress("StuckPkg", "1.0.0").Suppress.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ClearLoop_SurvivesHistoryRebuild()
+    {
+        CreateEventsFile("cl_s1", "OnePkg", "1.0.0", "completed", DateTime.UtcNow.AddHours(-3));
+        CreateEventsFile("cl_s2", "OnePkg", "1.0.0", "completed", DateTime.UtcNow.AddHours(-2));
+        CreateEventsFile("cl_s3", "OnePkg", "1.0.0", "completed", DateTime.UtcNow.AddMinutes(-90));
+
+        var guard = CreateGuard();
+        guard.ShouldSuppress("OnePkg", "1.0.0").Suppress.Should().BeTrue();
+        guard.ClearLoop("OnePkg").Should().BeTrue();
+
+        var rebuilt = CreateGuard();
+        rebuilt.ShouldSuppress("OnePkg", "1.0.0").Suppress.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ClearAll_FreshInstallsAfterClear_StillTripSuppression()
+    {
+        CreateEventsFile("cf_s1", "StillLooping", "1.0.0", "completed", DateTime.UtcNow.AddHours(-3));
+        CreateEventsFile("cf_s2", "StillLooping", "1.0.0", "completed", DateTime.UtcNow.AddHours(-2));
+        CreateEventsFile("cf_s3", "StillLooping", "1.0.0", "completed", DateTime.UtcNow.AddMinutes(-90));
+
+        var guard = CreateGuard();
+        guard.ShouldSuppress("StillLooping", "1.0.0").Suppress.Should().BeTrue();
+        guard.ClearAll();
+
+        // The loop is still live: 3 more installs land AFTER the clear.
+        // Clears must not whitelist a still-broken package.
+        CreateEventsFile("cf_s4", "StillLooping", "1.0.0", "completed", DateTime.UtcNow.AddMinutes(1));
+        CreateEventsFile("cf_s5", "StillLooping", "1.0.0", "completed", DateTime.UtcNow.AddMinutes(2));
+        CreateEventsFile("cf_s6", "StillLooping", "1.0.0", "completed", DateTime.UtcNow.AddMinutes(3));
+
+        var rebuilt = CreateGuard();
+        rebuilt.ShouldSuppress("StillLooping", "1.0.0").Suppress.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Convergence (MarkNonConverged)
+
+    [Fact]
+    public void MarkNonConverged_SuppressesWithPreciseReason()
+    {
+        var guard = CreateGuard();
+        var reason = guard.MarkNonConverged("BadCheck", "1.0.0", "fp1", reprobeHours: 24);
+        reason.Should().Contain("did not converge");
+
+        var (suppress, msg) = guard.ShouldSuppress("BadCheck", "1.0.0", "fp1");
+        suppress.Should().BeTrue();
+        msg.Should().Contain("did not converge");
+    }
+
+    [Fact]
+    public void MarkNonConverged_AutoClearsOnFingerprintChange()
+    {
+        var guard = CreateGuard();
+        guard.MarkNonConverged("BadCheck", "1.0.0", "fp1", reprobeHours: 24);
+        guard.ShouldSuppress("BadCheck", "1.0.0", "fp1").Suppress.Should().BeTrue();
+
+        // Admin fixes the pkgsinfo (any install-behavior field) — clears immediately
+        var (suppress, reason) = guard.ShouldSuppress("BadCheck", "1.0.0", "fp2-fixed");
+        suppress.Should().BeFalse();
+        reason.Should().Contain("Auto-cleared");
+    }
+
+    [Fact]
+    public void MarkNonConverged_SurvivesReload()
+    {
+        var guard = CreateGuard();
+        guard.MarkNonConverged("BadCheck", "1.0.0", "fp1", reprobeHours: 24);
+
+        var reloaded = CreateGuard();
+        reloaded.ShouldSuppress("BadCheck", "1.0.0", "fp1").Suppress.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Pending Restart Deferral
+
+    [Fact]
+    public void PendingRestart_DefersWhileNoRebootHasHappened()
+    {
+        var guard = CreateGuard();
+        // Machine booted an hour ago; install just happened
+        guard.BootTimeUtcProvider = () => DateTime.UtcNow.AddHours(-1);
+        guard.RecordPendingRestart("FirmwarePkg", "1.0.0", "fp1");
+
+        var (defer, reason) = guard.ShouldDeferForRestart("FirmwarePkg", "fp1");
+        defer.Should().BeTrue();
+        reason.Should().Contain("PENDING RESTART");
+    }
+
+    [Fact]
+    public void PendingRestart_ClearsAfterReboot()
+    {
+        var guard = CreateGuard();
+        guard.BootTimeUtcProvider = () => DateTime.UtcNow.AddHours(-1);
+        guard.RecordPendingRestart("FirmwarePkg", "1.0.0", "fp1");
+        guard.ShouldDeferForRestart("FirmwarePkg", "fp1").Defer.Should().BeTrue();
+
+        // Reboot: boot time is now AFTER the memo was stamped
+        guard.BootTimeUtcProvider = () => DateTime.UtcNow.AddMinutes(5);
+        guard.ShouldDeferForRestart("FirmwarePkg", "fp1").Defer.Should().BeFalse();
+
+        // Memo is gone — stays cleared even if boot time regresses (state, not luck)
+        guard.BootTimeUtcProvider = () => DateTime.UtcNow.AddHours(-1);
+        guard.ShouldDeferForRestart("FirmwarePkg", "fp1").Defer.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PendingRestart_ClearsOnFingerprintChange()
+    {
+        var guard = CreateGuard();
+        guard.BootTimeUtcProvider = () => DateTime.UtcNow.AddHours(-1);
+        guard.RecordPendingRestart("FirmwarePkg", "1.0.0", "fp1");
+
+        guard.ShouldDeferForRestart("FirmwarePkg", "fp2-changed").Defer.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PendingRestart_UnknownPackage_DoesNotDefer()
+    {
+        var guard = CreateGuard();
+        guard.ShouldDeferForRestart("NeverSeen", "fp1").Defer.Should().BeFalse();
+    }
+
+    #endregion
+
     #region Helpers
 
     /// <summary>


### PR DESCRIPTION
 — LoopGuard redesign so fixes break through and defects are named on day one.

## Problem

The fleet accumulated ~216 loop-suppression warnings on fully-updated clients even after the root-cause fixes shipped. Three structural defects:

1. **Client-side fixes never cleared suppression.** The auto-clear fingerprint hashes pkgsinfo fields only, so a fix shipped in the client binary (e.g. the packed-GUID MSI detection fix) left every suppression standing — an MDM-side clear script was the only way out.
2. **`--clear-loop all` undid itself.** `ClearAll()` discarded the processed-sessions ledger; the next run re-counted 7 days of events.jsonl and immediately re-tripped "3 installs across 3 sessions". Fleet signature confirmed: 85 records sitting at exactly 3 sessions after a fleet-wide clear.
3. **Detection was late and vague.** The client can prove an installcheck defect deterministically at the first install, but instead let machines churn 3+ sessions before gagging the package with a generic warning.

## Changes

- **Convergence verification** (`UpdateEngine.VerifyConvergence`): after a successful install, re-run the installcheck. Still reports action needed → precise warning naming the pkgsinfo defect on session 1, suppressed with a daily re-probe (`LoopReprobeHours`, default 24, capped by `LoopMaxTime`), auto-clears on any pkgsinfo change. `restart_action` items are the legitimate exception → recorded as pending-restart and **deferred as Pending** (not Warning) until the machine reboots, instead of reinstalling every session.
- **Clears that stick**: `ClearedAt` watermark (root for `ClearAll`, per-package for `ClearLoop` and fingerprint auto-clear) gates the history rebuild. Only installs after the clear count again — a still-looping package re-suppresses after 3 fresh installs, but a clear is never silently undone by old history.
- **Client version folded into the catalog fingerprint**: every agent update auto-clears standing suppressions fleet-wide on its first run.

## Tests

11 new tests (clears survive rebuild ×3, convergence ×3, pending-restart ×4, plus fresh-loops-still-trip). Full suite: 913 passed; the 2 ConfigurationServiceTests failures pre-exist on unmodified main (verified via stash).