### PR TITLE
Sync repo icons to clients and carry icon_name through catalogs

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -117,6 +117,14 @@ public class PkgsInfo
     [YamlMember(Alias = "developer")]
     public string? Developer { get; set; }
 
+    /// <summary>
+    /// Icon filename in the repo's icons directory. Carried through to the
+    /// generated catalogs so clients can resolve icons whose filename differs
+    /// from the package name (icon_name != "&lt;name&gt;.png").
+    /// </summary>
+    [YamlMember(Alias = "icon_name")]
+    public string? IconName { get; set; }
+
     [YamlMember(Alias = "requires")]
     public List<string>? Requires { get; set; }
 

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -402,6 +402,13 @@ public class CatalogItem
     [YamlMember(Alias = "developer")]
     public string? Developer { get; set; }
 
+    /// <summary>
+    /// Icon filename in the repo's icons directory (e.g. "AppName.png").
+    /// When unset, icon sync falls back to "&lt;name&gt;.png".
+    /// </summary>
+    [YamlMember(Alias = "icon_name")]
+    public string? IconName { get; set; }
+
     [YamlMember(Alias = "installer")]
     public InstallerInfo Installer { get; set; } = new();
 

--- a/cli/managedsoftwareupdate/Services/IconSyncService.cs
+++ b/cli/managedsoftwareupdate/Services/IconSyncService.cs
@@ -1,0 +1,156 @@
+using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.Core;
+using Cimian.Core.Services;
+using CatalogItem = Cimian.CLI.managedsoftwareupdate.Models.CatalogItem;
+
+namespace Cimian.CLI.managedsoftwareupdate.Services;
+
+/// <summary>
+/// Mirrors the repo's icons directory down to the local icons directory so the
+/// Managed Software Center GUI has real tiles instead of generated solid-color
+/// fallbacks. Icons resolve as icon_name from the catalog when set, otherwise
+/// "&lt;name&gt;.png". Uses conditional requests (If-Modified-Since) so steady-state
+/// runs cost one 304 per icon; a missing repo icon (404) is silently skipped and
+/// the GUI keeps its generated fallback.
+/// </summary>
+public class IconSyncService
+{
+    private const int MaxParallelDownloads = 4;
+
+    private readonly HttpClient _httpClient;
+    private readonly CimianConfig _config;
+
+    public IconSyncService(CimianConfig config, HttpClient? httpClient = null)
+    {
+        _config = config;
+        _httpClient = httpClient ?? CimianHttpClientFactory.CreateHttpClient(config, TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>
+    /// Syncs the icons for the given catalog items. Never throws — icon sync is
+    /// cosmetic and must not affect the run outcome.
+    /// </summary>
+    public async Task SyncAsync(IEnumerable<(string Name, CatalogItem? Catalog)> items, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            Directory.CreateDirectory(CimianPaths.IconsDir);
+
+            var iconFiles = items
+                .Select(i => ResolveIconFileName(i.Name, i.Catalog))
+                .Where(f => f != null)
+                .Select(f => f!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (iconFiles.Count == 0)
+                return;
+
+            int downloaded = 0, unchanged = 0, missing = 0, failed = 0;
+
+            await Parallel.ForEachAsync(
+                iconFiles,
+                new ParallelOptions { MaxDegreeOfParallelism = MaxParallelDownloads, CancellationToken = cancellationToken },
+                async (iconFile, ct) =>
+                {
+                    switch (await SyncOneAsync(iconFile, ct))
+                    {
+                        case SyncResult.Downloaded: Interlocked.Increment(ref downloaded); break;
+                        case SyncResult.Unchanged: Interlocked.Increment(ref unchanged); break;
+                        case SyncResult.Missing: Interlocked.Increment(ref missing); break;
+                        case SyncResult.Failed: Interlocked.Increment(ref failed); break;
+                    }
+                });
+
+            if (downloaded > 0 || failed > 0)
+                ConsoleLogger.Info($"Icon sync: {downloaded} downloaded, {unchanged} up-to-date, {missing} not in repo, {failed} failed");
+            else
+                ConsoleLogger.Detail($"    Icon sync: {unchanged} up-to-date, {missing} not in repo");
+        }
+        catch (OperationCanceledException)
+        {
+            // Run cancelled — partial icon sync is fine, the next run finishes it.
+        }
+        catch (Exception ex)
+        {
+            ConsoleLogger.Warn($"Icon sync failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Resolves the icon filename for an item: catalog icon_name when set,
+    /// otherwise "&lt;name&gt;.png". Rejects names that would escape the icons
+    /// directory.
+    /// </summary>
+    internal static string? ResolveIconFileName(string name, CatalogItem? catalog)
+    {
+        var fileName = !string.IsNullOrWhiteSpace(catalog?.IconName)
+            ? catalog!.IconName!.Trim()
+            : (string.IsNullOrWhiteSpace(name) ? null : name.Trim() + ".png");
+
+        if (string.IsNullOrWhiteSpace(fileName))
+            return null;
+
+        // Icons live flat in the icons directory — reject separators and traversal.
+        if (fileName.Contains('/') || fileName.Contains('\\') || fileName.Contains(".."))
+            return null;
+
+        return fileName;
+    }
+
+    private enum SyncResult { Downloaded, Unchanged, Missing, Failed }
+
+    private async Task<SyncResult> SyncOneAsync(string iconFile, CancellationToken cancellationToken)
+    {
+        var localPath = Path.Combine(CimianPaths.IconsDir, iconFile);
+        var url = $"{_config.SoftwareRepoURL.TrimEnd('/')}/icons/{Uri.EscapeDataString(iconFile)}";
+
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (File.Exists(localPath))
+            {
+                request.Headers.IfModifiedSince = File.GetLastWriteTimeUtc(localPath);
+            }
+
+            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotModified)
+                return SyncResult.Unchanged;
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                return SyncResult.Missing;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                ConsoleLogger.Detail($"    Icon fetch failed ({(int)response.StatusCode}): {iconFile}");
+                return SyncResult.Failed;
+            }
+
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            if (bytes.Length == 0)
+                return SyncResult.Missing;
+
+            await File.WriteAllBytesAsync(localPath, bytes, cancellationToken);
+
+            // Stamp the server's Last-Modified so the next If-Modified-Since matches.
+            var lastModified = response.Content.Headers.LastModified;
+            if (lastModified.HasValue)
+            {
+                File.SetLastWriteTimeUtc(localPath, lastModified.Value.UtcDateTime);
+            }
+
+            ConsoleLogger.Detail($"    Icon downloaded: {iconFile}");
+            return SyncResult.Downloaded;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ConsoleLogger.Detail($"    Icon fetch failed: {iconFile} ({ex.Message})");
+            return SyncResult.Failed;
+        }
+    }
+}

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -534,6 +534,20 @@ public class UpdateEngine : IDisposable
             // Print summary
             PrintActionSummary(manifestItems, toInstall, toUpdate, toUninstall);
 
+            // Mirror repo icons down for the MSC GUI so it renders real tiles
+            // instead of generated solid-color fallbacks. Cosmetic: conditional
+            // requests keep steady-state cost at one 304 per icon, and any
+            // failure is logged and swallowed without affecting the run.
+            await new IconSyncService(_config).SyncAsync(
+                manifestItems
+                    .Where(mi => !string.IsNullOrEmpty(mi.Name))
+                    .Select(mi =>
+                    {
+                        catalogMap.TryGetValue(mi.Name.ToLowerInvariant(), out var cat);
+                        return (mi.Name, cat);
+                    }),
+                cancellationToken);
+
             // Exit if check-only mode
             if (_checkOnly)
             {
@@ -3227,6 +3241,7 @@ public class UpdateEngine : IDisposable
             Description = cat?.Description,
             Category = cat?.Category,
             Developer = cat?.Developer,
+            Icon = cat?.IconName,
             InstallerItemSize = cat?.Installer?.Size ?? 0,
             Uninstallable = cat?.IsUninstallable() ?? false,
             RestartAction = cat?.RestartAction,

--- a/shared/core/CimianPaths.cs
+++ b/shared/core/CimianPaths.cs
@@ -28,6 +28,7 @@ public static class CimianPaths
     // ── Subdirectories under ManagedInstallsRoot ─────────────────────────────
     public static readonly string CacheDir       = Path.Combine(ManagedInstallsRoot, "Cache");
     public static readonly string CatalogsDir    = Path.Combine(ManagedInstallsRoot, "catalogs");
+    public static readonly string IconsDir       = Path.Combine(ManagedInstallsRoot, "icons");
     public static readonly string ManifestsDir   = Path.Combine(ManagedInstallsRoot, "manifests");
     public static readonly string LogsDir        = Path.Combine(ManagedInstallsRoot, "logs");
     public static readonly string ReportsDir     = Path.Combine(ManagedInstallsRoot, "reports");

--- a/shared/core/Models/CatalogItem.cs
+++ b/shared/core/Models/CatalogItem.cs
@@ -48,6 +48,13 @@ public class CatalogItem
     public string? Developer { get; set; }
 
     /// <summary>
+    /// Icon filename in the repo's icons directory (e.g. "AppName.png").
+    /// When unset, clients fall back to "&lt;name&gt;.png".
+    /// </summary>
+    [YamlMember(Alias = "icon_name")]
+    public string? IconName { get; set; }
+
+    /// <summary>
     /// Direct download URL for the package
     /// </summary>
     [YamlMember(Alias = "url")]


### PR DESCRIPTION
## Problem

Managed Software Center renders every app tile as a generated solid-color fallback. Three gaps compound:

1. **Catalogs drop `icon_name`** — the makecatalogs `PkgsInfo` model has no field for it, so YamlDotNet silently strips it from every generated catalog even though pkgsinfo files carry it.
2. **Nothing syncs icons to clients** — `cimiimport` extracts icons into the *repo's* `icons/` directory, and the GUI's `IconService` reads the *local* `ManagedInstalls\icons\` directory, but no client code ever downloads them. The directory is always empty, so `GenerateFallbackIcon` (a solid-color tile) is what every user sees.
3. **InstallInfo.yaml never carries `icon_name`** — `BuildInstallInfoItem` couldn't set it because the client's `CatalogItem` model didn't have the field.

## Fix

- `icon_name` added to the makecatalogs `PkgsInfo` model, the client `CatalogItem` model, and the shared core `CatalogItem` model, so the value survives pkgsinfo → catalog → client.
- New `IconSyncService` in managedsoftwareupdate: after the update check (both normal and `--checkonly` runs), mirrors the icons referenced by the manifest from `<SoftwareRepoURL>/icons/` into `ManagedInstalls\icons\`. Resolves `icon_name` when set, falls back to `<name>.png`. Conditional requests (`If-Modified-Since`, honoring the server's `Last-Modified`) make steady-state runs one 304 per icon; 404s are silently skipped (GUI keeps its fallback); all errors are non-fatal to the run. Downloads fan out 4-wide. Reuses `CimianHttpClientFactory`, so repo auth is identical to catalog/package downloads.
- `BuildInstallInfoItem` now writes `icon_name` into InstallInfo.yaml, and the GUI's existing `GetIconAsync(name, iconFileName)` path picks it up with no GUI changes needed.

## Notes

- Icon filenames are validated (no path separators / traversal) before being joined to the local icons directory.
- `makecatalogs` output stays clean for items without icons — the serializer omits nulls.
