### PR TITLE
Explain background managed runs on the Updates and History pages

### DIFF
--- a/gui/ManagedSoftwareCenter/Views/HistoryPage.xaml
+++ b/gui/ManagedSoftwareCenter/Views/HistoryPage.xaml
@@ -9,8 +9,12 @@
         <ScrollViewer Padding="24">
             <StackPanel Spacing="4">
                 <TextBlock Text="Installation History"
-                           Style="{StaticResource TitleTextBlockStyle}"
-                           Margin="0,0,0,16" />
+                           Style="{StaticResource TitleTextBlockStyle}" />
+                <TextBlock Text="Every software run on this computer, including automatic background maintenance. Managed software installs and updates on its own, so items here may never have appeared under Updates."
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           TextWrapping="Wrap"
+                           Margin="0,4,0,16" />
 
                 <ItemsRepeater ItemsSource="{Binding Sessions}">
                     <ItemsRepeater.Layout>

--- a/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
+++ b/gui/ManagedSoftwareCenter/Views/UpdatesPage.xaml
@@ -504,6 +504,13 @@
                        Style="{StaticResource BodyTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        HorizontalAlignment="Center"/>
+            <TextBlock Text="Managed software also installs and updates automatically in the background — the History page lists those runs."
+                       Style="{StaticResource CaptionTextBlockStyle}"
+                       Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                       TextWrapping="Wrap"
+                       TextAlignment="Center"
+                       MaxWidth="420"
+                       HorizontalAlignment="Center"/>
             <Button x:Name="CheckAgainButton"
                     Content="CHECK AGAIN"
                     Style="{StaticResource AccentButtonStyle}"


### PR DESCRIPTION
Testers reading the History page saw several applications being updated while the Updates tab listed only one item, and asked whether that was a bug. It isn't — managed software installs and updates automatically in the background, and the Updates tab intentionally shows only user-relevant pending work — but the app never says so.

Two small additions, no behavior change:

- **Installation History** gains a subtitle: sessions include automatic background maintenance, so items listed there may never have appeared under Updates.
- **Updates empty state** gains a caption pointing at the History page for the background runs.

XAML-only.