### PR TITLE
docs: correct self-service GUI framework in README (WPF → WinUI 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Cimian is an open-source software deployment solution designed for managing and 
 
 Cimian aims to allow Mac Admins that manage Windows with Munki to have the exact same experience on Windows and to provide Windows Admins with a powerful and flexible tool for software management or those looking to transition away from traditional imaging and towards modern management with Git and DevOps principles.
 
-Cimian is developed in C# using .NET 10. It leverages a YAML-based configuration system for easy management and customization, and includes native a WPF GUI application for end-user self-service software installation.
+Cimian is developed in C# using .NET 10. It leverages a YAML-based configuration system for easy management and customization, and includes a native WinUI 3 GUI application for end-user self-service software installation.
 
 Cimian is ideal for organizations of all sizes looking to streamline their Windows software deployment processes. It can be used in small environments with just a few machines, or scaled up to manage thousands of systems across multiple locations.
 


### PR DESCRIPTION
Carlos's fix from #65, cherry-picked onto current `main` with authorship intact. That PR could not be merged directly — its branch predates the history rewrite, so GitHub computed the merge base ~100 commits back and reported the whole intervening history as its diff (`+76,589/-20,110` across 388 files) with a `DIRTY` merge state. The actual change is the one line below.

`README.md:7` described Managed Software Center as "native a WPF GUI application". It is WinUI 3 (`gui/ManagedSoftwareCenter/*.csproj` sets `<UseWinUI>true</UseWinUI>`), and line 105 of the same file already said so — the intro was contradicting the feature list. The genuinely-WPF `CimianStatus` login/status window (`<UseWPF>true</UseWPF>`) is untouched.

Also fixes the word-order slip on the same line ("native a" → "a native").

Closes #65
