### PR TITLE
Take package identity and publisher metadata from configuration

### DIFF
--- a/gui/CimianStatus/Cimian.GUI.CimianStatus.csproj
+++ b/gui/CimianStatus/Cimian.GUI.CimianStatus.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>cimistatus</AssemblyName>
     <AssemblyTitle>Cimian Status</AssemblyTitle>
     <AssemblyDescription>Cimian Software Management Status Monitor</AssemblyDescription>
-    <AssemblyCompany>Emily Carr University</AssemblyCompany>
+    <AssemblyCompany Condition="'$(AssemblyCompany)' == ''">Windows Admins Open Source</AssemblyCompany>
     <AssemblyProduct>Cimian</AssemblyProduct>
     <AssemblyVersion>2025.12.0.0</AssemblyVersion>
     <FileVersion>2025.12.0.0</FileVersion>


### PR DESCRIPTION
The package identifier, `developer`, and `AssemblyCompany`/`Authors` described one particular publisher rather than the project itself.

- Identifiers use a `${PACKAGE_ID_PREFIX}` placeholder. cimipkg resolves `${NAME}` from `.env` first and then the process environment — the same mechanism `${ARCH}` already relies on — so a build produces whatever identity its operator configures. `.env.example` documents it.
- `.NET` metadata defaults to a neutral value with `Condition="'$(X)' == ''"`, so setting the MSBuild property or environment variable still overrides it.

**Package identity is unchanged for anyone who sets `PACKAGE_ID_PREFIX`.** Leaving it unset leaves the literal placeholder in the identifier rather than silently minting a different one — deliberately loud, because a changed identifier breaks upgrade detection for already-deployed packages.