### PR TITLE
Expire the download cache, and sweep the whole logs tree

### DIFF
--- a/cli/managedsoftwareupdate/Services/DownloadService.cs
+++ b/cli/managedsoftwareupdate/Services/DownloadService.cs
@@ -673,6 +673,107 @@ public class DownloadService
         {
             ConsoleLogger.Info($"Cache cleanup: removed {corruptCount} corrupt files, {abandonedDownloads} abandoned downloads, {orphanedMarkers} orphaned verification markers");
         }
+
+        PruneExpiredCacheEntries();
+    }
+
+    /// <summary>
+    /// Removes cached payloads that have not been written for CacheRetentionDays.
+    /// </summary>
+    /// <remarks>
+    /// CacheRetentionDays has been a configuration field, and printed by --show-config,
+    /// without anything ever acting on it: no code path deleted a cached payload, so
+    /// every installer ever downloaded stayed on disk. Superseded payloads are the bulk
+    /// of it, and large suites run to double-digit gigabytes each.
+    ///
+    /// This runs before the download phase, so an item still wanted this session is
+    /// simply fetched again — the only cost of an over-eager delete is one download.
+    /// Partial downloads are left alone; they have their own 24-hour rule above.
+    /// Set CacheRetentionDays to 0 or less to disable.
+    /// </remarks>
+    private void PruneExpiredCacheEntries()
+    {
+        var retentionDays = _config.CacheRetentionDays;
+        if (retentionDays <= 0)
+        {
+            return;
+        }
+
+        var cutoff = DateTime.Now.AddDays(-retentionDays);
+        var removed = 0;
+        long reclaimed = 0;
+
+        foreach (var file in Directory.GetFiles(_config.CachePath, "*", SearchOption.AllDirectories))
+        {
+            if (file.EndsWith(".downloading", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // Markers are reaped by the orphan rule once their payload is gone; deleting
+            // one here while its payload survives would force a needless re-verification.
+            if (file.EndsWith(VerifiedMarkerSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            try
+            {
+                var info = new FileInfo(file);
+                if (info.LastWriteTime >= cutoff)
+                {
+                    continue;
+                }
+
+                var size = info.Length;
+                info.Delete();
+                removed++;
+                reclaimed += size;
+
+                var marker = file + VerifiedMarkerSuffix;
+                if (File.Exists(marker))
+                {
+                    try { File.Delete(marker); } catch { /* orphan rule will catch it */ }
+                }
+
+                ConsoleLogger.Detail($"Removed expired cache entry: {Path.GetFileName(file)}");
+            }
+            catch (Exception ex)
+            {
+                ConsoleLogger.Warn($"Failed to remove expired cache entry {file}: {ex.Message}");
+            }
+        }
+
+        RemoveEmptyCacheDirectories(_config.CachePath);
+
+        if (removed > 0)
+        {
+            ConsoleLogger.Info(
+                $"Cache retention: removed {removed} entries older than {retentionDays} days, reclaimed {reclaimed / 1024 / 1024:N0} MB");
+        }
+    }
+
+    /// <summary>
+    /// Deletes category directories left empty by retention. The cache root itself is
+    /// kept - it is a known path that other code expects to exist.
+    /// </summary>
+    private static void RemoveEmptyCacheDirectories(string cacheRoot)
+    {
+        foreach (var dir in Directory.GetDirectories(cacheRoot, "*", SearchOption.AllDirectories)
+                     .OrderByDescending(d => d.Length))
+        {
+            try
+            {
+                if (!Directory.EnumerateFileSystemEntries(dir).Any())
+                {
+                    Directory.Delete(dir);
+                }
+            }
+            catch
+            {
+                // Ignore - an empty directory is harmless.
+            }
+        }
     }
 
     /// <summary>

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Cimian.CLI.managedsoftwareupdate.Models;
+using Cimian.Core;
 using Cimian.Core.Services;
 using Microsoft.Win32;
 using WixToolset.Dtf.WindowsInstaller;
@@ -34,7 +35,20 @@ public class InstallerService
     private readonly CimianConfig _config;
     private readonly ScriptService _scriptService;
     private SessionLogger? _sessionLogger;
-    
+
+    /// <summary>
+    /// Where verbose installer logs go. Ensured on first use: msiexec will not create a
+    /// missing directory for /l*v, it just silently produces no log.
+    /// </summary>
+    private static string InstallLogsDir
+    {
+        get
+        {
+            Directory.CreateDirectory(CimianPaths.InstallLogsDir);
+            return CimianPaths.InstallLogsDir;
+        }
+    }
+
     // Cached sbin-installer path (null = not checked, empty = not available)
     private static string? _sbinInstallerBin;
 
@@ -865,7 +879,7 @@ public class InstallerService
             // output so a failure leaves the prior good log alongside the failing
             // one. Newest attempt is _install.1.log.
             RotateMsiInstallLogs(item.Name);
-            var logPath = Path.Combine(_config.CachePath, $"{item.Name}_install.1.log");
+            var logPath = Path.Combine(InstallLogsDir, $"{item.Name}_install.1.log");
 
             List<string> BuildArgs() => new()
             {
@@ -936,7 +950,7 @@ public class InstallerService
     }
 
     /// <summary>
-    /// Rotate {cache}/{item}_install.N.log files keeping the newest MsiInstallLogRetention
+    /// Rotate logs/installs/{item}_install.N.log files keeping the newest MsiInstallLogRetention
     /// attempts. Highest N is dropped; lower indices shift up. Slot .1 is freed for the
     /// next msiexec invocation. Safe to call when no logs exist yet.
     /// </summary>
@@ -944,7 +958,7 @@ public class InstallerService
     {
         try
         {
-            var basePath = Path.Combine(_config.CachePath, $"{itemName}_install");
+            var basePath = Path.Combine(InstallLogsDir, $"{itemName}_install");
             // Drop the oldest, then shift each down toward higher N
             var oldest = $"{basePath}.{MsiInstallLogRetention}.log";
             if (File.Exists(oldest))
@@ -1190,7 +1204,7 @@ public class InstallerService
             || string.Equals(i.Type, "appx", StringComparison.OrdinalIgnoreCase));
         var identityName = msixInstallEntry?.IdentityName ?? "";
 
-        var logPath = Path.Combine(_config.CachePath, $"{item.Name}_msix_install.log");
+        var logPath = Path.Combine(InstallLogsDir, $"{item.Name}_msix_install.log");
         var escapedPath = localFile.Replace("'", "''");
         var escapedLog = logPath.Replace("'", "''");
         var escapedIdentity = identityName.Replace("'", "''");

--- a/shared/core/CimianPaths.cs
+++ b/shared/core/CimianPaths.cs
@@ -79,6 +79,7 @@ public static class CimianPaths
     /// </summary>
     public static readonly string PackageLogsDir = Path.Combine(LogsDir, "packages");
 
+
     // ── Specific log files ───────────────────────────────────────────────────
     public static readonly string CimiwatcherLog = Path.Combine(LogsDir, "cimiwatcher.log");
 

--- a/shared/core/CimianPaths.cs
+++ b/shared/core/CimianPaths.cs
@@ -55,6 +55,30 @@ public static class CimianPaths
     public static readonly string HeadlessFlagFile   = Path.Combine(ManagedInstallsRoot, ".cimian.headless");
     public static readonly string SelfUpdateFlagFile = Path.Combine(ManagedInstallsRoot, ".cimian.selfupdate");
 
+    // ── Log subdirectories ───────────────────────────────────────────────────
+    // The logs root holds the dated session tree (logs\YYYY-MM-DD\HHMM\) and nothing
+    // else. Anything written outside a session goes in a named subdirectory here, so
+    // the root stays readable and retention has a directory to sweep rather than a
+    // pile of loose files it has to pattern-match.
+
+    /// <summary>Verbose installer logs from client self-updates.</summary>
+    public static readonly string SelfUpdateLogsDir = Path.Combine(LogsDir, "selfupdate");
+
+    /// <summary>
+    /// Verbose msiexec / MSIX logs for managed installs, kept across sessions so a
+    /// failed attempt still has its predecessor to compare against. These used to sit in
+    /// the download cache, where nothing expired them and they were mixed in with the
+    /// payloads.
+    /// </summary>
+    public static readonly string InstallLogsDir = Path.Combine(LogsDir, "installs");
+
+    /// <summary>
+    /// Per-package script output, one directory per package. Written by the packaging
+    /// tool's MSI custom actions rather than by this client; named here so retention
+    /// knows where to look.
+    /// </summary>
+    public static readonly string PackageLogsDir = Path.Combine(LogsDir, "packages");
+
     // ── Specific log files ───────────────────────────────────────────────────
     public static readonly string CimiwatcherLog = Path.Combine(LogsDir, "cimiwatcher.log");
 

--- a/shared/core/Services/SelfUpdateService.cs
+++ b/shared/core/Services/SelfUpdateService.cs
@@ -152,7 +152,7 @@ public static class SelfUpdateService
             case "msi":
             {
                 var logFile = Path.Combine(
-                    CimianPaths.LogsDir,
+                    CimianPaths.SelfUpdateLogsDir,
                     $"selfupdate-{DateTime.Now:yyyyMMdd-HHmmss}.log");
                 Directory.CreateDirectory(Path.GetDirectoryName(logFile)!);
                 fileName = "msiexec.exe";
@@ -352,7 +352,7 @@ public static class SelfUpdateService
             ConsoleLogger.Info($"Executing MSI update: {msiPath}");
 
             var logFile = Path.Combine(
-                CimianPaths.LogsDir,
+                CimianPaths.SelfUpdateLogsDir,
                 $"selfupdate-{DateTime.Now:yyyyMMdd-HHmmss}.log");
 
             // Ensure log directory exists

--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -12,8 +12,8 @@ namespace Cimian.Core.Services;
 /// 
 /// Features:
 /// - Day-nested directories: logs/YYYY-MM-DD/HHMM/ for easy navigation
-/// - Creates session.json, events.jsonl, install.log, and run.log files
-/// - 7-day rolling retention with automatic cleanup
+/// - Creates session.json, events.jsonl and install.log files
+/// - 30-day rolling retention with automatic cleanup, covering the whole logs tree
 /// - Writes reports to C:\ProgramData\ManagedInstalls\reports
 /// - Structured data formats for external tool integration
 /// </summary>
@@ -45,7 +45,6 @@ public class SessionLogger : IDisposable
     private string _runType = "manual";
 
     private StreamWriter? _logFile;        // install.log
-    private StreamWriter? _runLogFile;     // run.log (session copy)
     private StreamWriter? _reportRunLog;   // reports/run.log
     private StreamWriter? _eventsFile;     // events.jsonl
 
@@ -150,9 +149,11 @@ public class SessionLogger : IDisposable
             var installLogPath = Path.Combine(_sessionDir, "install.log");
             _logFile = new StreamWriter(installLogPath, append: true) { AutoFlush = true };
 
-            // Session run log (run.log in session directory)
-            var sessionRunLogPath = Path.Combine(_sessionDir, "run.log");
-            _runLogFile = new StreamWriter(sessionRunLogPath, append: true) { AutoFlush = true };
+            // There is deliberately no second copy in the session directory. install.log
+            // and the old sibling run.log received the identical formatted line from
+            // Log(), so the session tree carried every byte twice. reports/run.log below
+            // still exists: it is the fixed path external tooling tails, and it is
+            // truncated per session rather than accumulating.
 
             // Report run log (reports/run.log - truncated each session)
             // This may fail if the file is locked by another process (e.g., Go version running)
@@ -196,7 +197,6 @@ public class SessionLogger : IDisposable
             try
             {
                 _logFile?.WriteLine(formattedLine);
-                _runLogFile?.WriteLine(formattedLine);
                 _reportRunLog?.WriteLine(formattedLine);
             }
             catch
@@ -378,9 +378,17 @@ public class SessionLogger : IDisposable
     }
 
     /// <summary>
-    /// Performs 7-day rolling retention cleanup.
-    /// Removes day directories older than retention window and cleans up any legacy flat-format sessions.
+    /// Performs the 30-day rolling retention cleanup over the whole logs tree.
     /// </summary>
+    /// <remarks>
+    /// This used to enumerate directories only. Everything the client itself writes
+    /// lives in a directory, so that looked sufficient — but the logs root is shared:
+    /// package scripts, msiexec verbose logs and the self-update installer all drop
+    /// loose files there, and none of them were ever considered for deletion. Files at
+    /// the root are swept by age here, and named subdirectories are swept by the age of
+    /// their newest file, so a package that stops being installed eventually goes away
+    /// with its logs.
+    /// </remarks>
     private void PerformRetentionCleanup()
     {
         try
@@ -417,11 +425,87 @@ public class SessionLogger : IDisposable
                     }
                 }
             }
+
+            SweepExpiredFiles(BaseLogsDir, cutoff);
+            SweepExpiredFiles(CimianPaths.SelfUpdateLogsDir, cutoff);
+            SweepExpiredFiles(CimianPaths.InstallLogsDir, cutoff);
+            SweepExpiredSubdirectories(CimianPaths.PackageLogsDir, cutoff);
         }
         catch
         {
             // Silent failure - retention cleanup is non-critical
         }
+    }
+
+    /// <summary>
+    /// Deletes files directly inside <paramref name="directory"/> that were last written
+    /// before <paramref name="cutoff"/>. Not recursive: subdirectories are handled by
+    /// their own rules.
+    /// </summary>
+    internal static void SweepExpiredFiles(string directory, DateTime cutoff)
+    {
+        if (!Directory.Exists(directory))
+            return;
+
+        foreach (var file in Directory.GetFiles(directory))
+        {
+            try
+            {
+                var info = new FileInfo(file);
+                if (info.LastWriteTime < cutoff)
+                    info.Delete();
+            }
+            catch
+            {
+                // A log still held open by another process throws here. Ignore it and
+                // try again next session rather than failing the whole sweep.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deletes immediate subdirectories of <paramref name="directory"/> whose most
+    /// recently written file predates <paramref name="cutoff"/>. Used for trees keyed by
+    /// something other than a date — per-package log directories, where the meaningful
+    /// question is "has anything touched this package lately".
+    /// </summary>
+    internal static void SweepExpiredSubdirectories(string directory, DateTime cutoff)
+    {
+        if (!Directory.Exists(directory))
+            return;
+
+        foreach (var entry in Directory.GetDirectories(directory))
+        {
+            try
+            {
+                // No files at all means an empty leftover, which is also expired.
+                var newest = NewestWriteTime(entry);
+                if (newest is null || newest < cutoff)
+                    Directory.Delete(entry, recursive: true);
+            }
+            catch
+            {
+                // Ignore - retention is best-effort.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Most recent LastWriteTime among the files under <paramref name="directory"/>, or
+    /// null when it holds no files at all.
+    /// </summary>
+    private static DateTime? NewestWriteTime(string directory)
+    {
+        DateTime? newest = null;
+
+        foreach (var file in Directory.GetFiles(directory, "*", SearchOption.AllDirectories))
+        {
+            var written = new FileInfo(file).LastWriteTime;
+            if (newest is null || written > newest)
+                newest = written;
+        }
+
+        return newest;
     }
 
     /// <summary>
@@ -758,8 +842,6 @@ public class SessionLogger : IDisposable
             _logFile?.Dispose();
             _logFile = null;
 
-            _runLogFile?.Dispose();
-            _runLogFile = null;
 
             _reportRunLog?.Dispose();
             _reportRunLog = null;

--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -426,6 +426,10 @@ public class SessionLogger : IDisposable
                 }
             }
 
+            // Relocate before sweeping: a legacy artifact that is still being rewritten
+            // never looks expired, so age alone would never clear it.
+            RelocateLegacyArtifacts();
+
             SweepExpiredFiles(BaseLogsDir, cutoff);
             SweepExpiredFiles(CimianPaths.SelfUpdateLogsDir, cutoff);
             SweepExpiredFiles(CimianPaths.InstallLogsDir, cutoff);
@@ -434,6 +438,108 @@ public class SessionLogger : IDisposable
         catch
         {
             // Silent failure - retention cleanup is non-critical
+        }
+    }
+
+    /// <summary>
+    /// Moves everything this client no longer writes to the logs root out of it, and
+    /// pulls installer logs out of the download cache, so the root converges to holding
+    /// only the dated session tree.
+    /// </summary>
+    /// <remarks>
+    /// Age alone cannot do this job. The artifacts here are written by MSIs that are
+    /// already installed on the machine and by earlier versions of this client: an
+    /// already-installed package rewrites its sidecar log on every session, so the file
+    /// is permanently younger than any retention window and an age-based sweep never
+    /// reaches it. Waiting for every package on every endpoint to be rebuilt is not a
+    /// plan; relocating on sight is. Once packages are rebuilt this is a no-op.
+    ///
+    /// Relocation, not deletion, because the content is still wanted — an installcheck
+    /// may tail the last attempt's output, and it now looks for it at the new path.
+    /// </remarks>
+    internal static void RelocateLegacyArtifacts()
+        => RelocateLegacyArtifacts(BaseLogsDir, CimianPaths.CacheDir);
+
+    /// <summary>
+    /// Roots are parameters so this can be exercised against a temporary tree; the
+    /// production call site passes the real ones.
+    /// </summary>
+    internal static void RelocateLegacyArtifacts(string logsRoot, string cacheRoot)
+    {
+        // Pre-move sidecar logs: cimipkg-<ProductName>-Cimian<Action>.log, flat at the
+        // root. The product name can itself contain hyphens, so key off the suffix.
+        foreach (var action in new[] { "Preinstall", "Postinstall", "Uninstall" })
+        {
+            var suffix = $"-Cimian{action}.log";
+            foreach (var file in SafeGetFiles(logsRoot, $"cimipkg-*{suffix}"))
+            {
+                var name = Path.GetFileName(file);
+                if (!name.EndsWith(suffix, StringComparison.Ordinal))
+                    continue;
+
+                var product = name["cimipkg-".Length..^suffix.Length];
+                if (product.Length == 0)
+                    continue;
+
+                TryMove(file, Path.Combine(logsRoot, "packages", product,
+                    $"{action.ToLowerInvariant()}.log"));
+            }
+        }
+
+        // Pre-move self-update installer logs.
+        foreach (var file in SafeGetFiles(logsRoot, "selfupdate-*.log"))
+        {
+            TryMove(file, Path.Combine(logsRoot, "selfupdate", Path.GetFileName(file)));
+        }
+
+        // Pre-move msiexec / MSIX verbose logs, which used to be written into the
+        // download cache alongside the payloads.
+        foreach (var file in SafeGetFiles(cacheRoot, "*.log", recurse: true))
+        {
+            var name = Path.GetFileName(file);
+            if (!name.Contains("_install", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            TryMove(file, Path.Combine(logsRoot, "installs", name));
+        }
+
+        // Files left loose at the root by third-party package scripts are deliberately
+        // not touched here. This client does not own them and cannot tell a log from a
+        // state marker by looking - VerifyHarmony's sentinel was named ".log" and lived
+        // right here. They expire on age like anything else, which is the correct signal
+        // for "nothing is writing this any more".
+    }
+
+    private static IEnumerable<string> SafeGetFiles(string directory, string pattern, bool recurse = false)
+    {
+        try
+        {
+            if (!Directory.Exists(directory))
+                return Array.Empty<string>();
+
+            return Directory.GetFiles(directory, pattern,
+                recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    /// <summary>
+    /// Moves a file, creating the destination directory and overwriting any previous
+    /// copy. Best-effort: a file still held open by its writer is left for next session.
+    /// </summary>
+    private static void TryMove(string source, string destination)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+            File.Move(source, destination, overwrite: true);
+        }
+        catch
+        {
+            // Ignore - relocation is best-effort and retried every session.
         }
     }
 

--- a/tests/Managedsoftwareupdate/DownloadServiceTests.cs
+++ b/tests/Managedsoftwareupdate/DownloadServiceTests.cs
@@ -431,4 +431,94 @@ public class DownloadServiceTests : IDisposable
     }
 
     #endregion
+
+    #region Cache retention
+
+    // CacheRetentionDays was a configuration field that nothing acted on: no code path
+    // ever deleted a cached payload, so every installer a machine had downloaded stayed
+    // on disk forever. These pin the behaviour the setting now has.
+
+    private string WriteCacheFile(string relativePath, DateTime lastWrite, string content = "payload")
+    {
+        var full = Path.Combine(_testCacheDir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        File.SetLastWriteTime(full, lastWrite);
+        return full;
+    }
+
+    [Fact]
+    public void ValidateAndCleanCache_RemovesPayloadsPastRetention()
+    {
+        var stale = WriteCacheFile(Path.Combine("design", "Suite-2025.1.pkg"), DateTime.Now.AddDays(-60));
+        var current = WriteCacheFile(Path.Combine("design", "Suite-2026.8.pkg"), DateTime.Now.AddDays(-3));
+
+        _service.ValidateAndCleanCache();
+
+        Assert.False(File.Exists(stale));
+        Assert.True(File.Exists(current));
+    }
+
+    [Fact]
+    public void ValidateAndCleanCache_RemovesTheVerificationMarkerWithItsPayload()
+    {
+        var stale = WriteCacheFile(Path.Combine("apps", "Tool-1.0.msi"), DateTime.Now.AddDays(-60));
+        var marker = WriteCacheFile(Path.Combine("apps", "Tool-1.0.msi.verified"), DateTime.Now.AddDays(-60), "ok");
+
+        _service.ValidateAndCleanCache();
+
+        Assert.False(File.Exists(stale));
+        Assert.False(File.Exists(marker));
+    }
+
+    [Fact]
+    public void ValidateAndCleanCache_KeepsAMarkerWhosePayloadIsStillCurrent()
+    {
+        // The marker is older than the window but the payload it vouches for is not.
+        // Dropping it would force a pointless re-verification of a good download.
+        var payload = WriteCacheFile(Path.Combine("apps", "Tool-2.0.msi"), DateTime.Now.AddDays(-3));
+        var marker = WriteCacheFile(Path.Combine("apps", "Tool-2.0.msi.verified"), DateTime.Now.AddDays(-60), "ok");
+
+        _service.ValidateAndCleanCache();
+
+        Assert.True(File.Exists(payload));
+        Assert.True(File.Exists(marker));
+    }
+
+    [Fact]
+    public void ValidateAndCleanCache_LeavesPartialDownloadsToTheirOwnRule()
+    {
+        // .downloading files are resumable and already have a 24-hour rule; retention
+        // must not race it.
+        var partial = WriteCacheFile("Big-1.0.pkg.downloading", DateTime.Now.AddHours(-1));
+
+        _service.ValidateAndCleanCache();
+
+        Assert.True(File.Exists(partial));
+    }
+
+    [Fact]
+    public void ValidateAndCleanCache_RemovesCategoryDirectoriesLeftEmpty()
+    {
+        WriteCacheFile(Path.Combine("animation", "Renderer-1.0.exe"), DateTime.Now.AddDays(-60));
+
+        _service.ValidateAndCleanCache();
+
+        Assert.False(Directory.Exists(Path.Combine(_testCacheDir, "animation")));
+        // The cache root is a known path other code expects; it stays.
+        Assert.True(Directory.Exists(_testCacheDir));
+    }
+
+    [Fact]
+    public void ValidateAndCleanCache_RetentionIsDisabledByANonPositiveSetting()
+    {
+        _testConfig.CacheRetentionDays = 0;
+        var ancient = WriteCacheFile(Path.Combine("apps", "Tool-0.1.msi"), DateTime.Now.AddDays(-400));
+
+        _service.ValidateAndCleanCache();
+
+        Assert.True(File.Exists(ancient));
+    }
+
+    #endregion
 }

--- a/tests/Shared/SessionLogRetentionTests.cs
+++ b/tests/Shared/SessionLogRetentionTests.cs
@@ -124,3 +124,148 @@ public class SessionLogRetentionTests : IDisposable
         Assert.True(File.Exists(loose));
     }
 }
+
+
+/// <summary>
+/// Relocation of artifacts written to the pre-move locations.
+/// </summary>
+/// <remarks>
+/// These exist because age is not a sufficient signal for this class of file. An MSI
+/// already installed on the machine rewrites its sidecar log every time it runs, so the
+/// file is permanently younger than any retention window and an age-based sweep never
+/// reaches it. On a surveyed endpoint, 36 of the 50 loose files at the logs root were
+/// inside the 30-day window for exactly that reason. Waiting for every package on every
+/// endpoint to be rebuilt is not a plan, so the client relocates on sight and the whole
+/// pass becomes a no-op once they are.
+/// </remarks>
+public class LegacyArtifactRelocationTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _logs;
+    private readonly string _cache;
+
+    public LegacyArtifactRelocationTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cimian-relocate-" + Guid.NewGuid().ToString("N"));
+        _logs = Path.Combine(_root, "logs");
+        _cache = Path.Combine(_root, "Cache");
+        Directory.CreateDirectory(_logs);
+        Directory.CreateDirectory(_cache);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private string Write(string root, string relativePath, string content = "x")
+    {
+        var full = Path.Combine(root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    private void Relocate() => SessionLogger.RelocateLegacyArtifacts(_logs, _cache);
+
+    [Theory]
+    [InlineData("cimipkg-ReportMate-CimianPostinstall.log", "ReportMate", "postinstall.log")]
+    [InlineData("cimipkg-CimianAuth-CimianPreinstall.log", "CimianAuth", "preinstall.log")]
+    [InlineData("cimipkg-ReportMatePrefs-CimianUninstall.log", "ReportMatePrefs", "uninstall.log")]
+    public void SidecarLogsMoveIntoTheirPackageDirectory(string name, string product, string expected)
+    {
+        var source = Write(_logs, name, "attempt output");
+
+        Relocate();
+
+        Assert.False(File.Exists(source));
+        var moved = Path.Combine(_logs, "packages", product, expected);
+        Assert.True(File.Exists(moved));
+        Assert.Equal("attempt output", File.ReadAllText(moved));
+    }
+
+    [Fact]
+    public void ProductNamesContainingHyphensSurvive()
+    {
+        // Keying off the "cimipkg-" prefix would split "Forti-Client-Prefs" at its first
+        // hyphen. The action suffix is the only unambiguous anchor.
+        Write(_logs, "cimipkg-Forti-Client-Prefs-CimianPostinstall.log");
+
+        Relocate();
+
+        Assert.True(File.Exists(Path.Combine(_logs, "packages", "Forti-Client-Prefs", "postinstall.log")));
+    }
+
+    [Fact]
+    public void SelfUpdateLogsMoveIntoTheirSubdirectory()
+    {
+        var source = Write(_logs, "selfupdate-20260816-231113.log");
+
+        Relocate();
+
+        Assert.False(File.Exists(source));
+        Assert.True(File.Exists(Path.Combine(_logs, "selfupdate", "selfupdate-20260816-231113.log")));
+    }
+
+    [Theory]
+    [InlineData("Chrome_install.1.log")]
+    [InlineData("AzureCLI_install.log")]
+    [InlineData("Teams_msix_install.log")]
+    public void InstallerLogsComeOutOfTheDownloadCache(string name)
+    {
+        var source = Write(_cache, Path.Combine("browsers", name));
+
+        Relocate();
+
+        Assert.False(File.Exists(source));
+        Assert.True(File.Exists(Path.Combine(_logs, "installs", name)));
+    }
+
+    [Fact]
+    public void PayloadsInTheCacheAreNotTouched()
+    {
+        var payload = Write(_cache, Path.Combine("design", "Suite-2026.8.pkg"));
+        var marker = Write(_cache, Path.Combine("design", "Suite-2026.8.pkg.verified"));
+
+        Relocate();
+
+        Assert.True(File.Exists(payload));
+        Assert.True(File.Exists(marker));
+    }
+
+    [Theory]
+    [InlineData("cimiwatcher20260820.log")]   // Serilog owns it and caps it at 7
+    [InlineData("installers.log")]            // third-party; expires on age instead
+    [InlineData("verifiedHarmony.log")]       // a state marker, not a log at all
+    public void FilesThisClientDoesNotOwnAreLeftWhereTheyAre(string name)
+    {
+        var source = Write(_logs, name);
+
+        Relocate();
+
+        Assert.True(File.Exists(source));
+    }
+
+    [Fact]
+    public void RelocationIsIdempotentAndSurvivesACollision()
+    {
+        // Runs every session. The second pass must not fail because the destination
+        // already holds the previous attempt's copy.
+        Write(_logs, "cimipkg-App-CimianPostinstall.log", "first");
+        Relocate();
+        Write(_logs, "cimipkg-App-CimianPostinstall.log", "second");
+        Relocate();
+
+        var moved = Path.Combine(_logs, "packages", "App", "postinstall.log");
+        Assert.Equal("second", File.ReadAllText(moved));
+        Assert.Empty(Directory.GetFiles(_logs));
+    }
+
+    [Fact]
+    public void IsSilentWhenNothingHasAccumulated()
+    {
+        Relocate();
+
+        Assert.Empty(Directory.GetFiles(_logs));
+    }
+}

--- a/tests/Shared/SessionLogRetentionTests.cs
+++ b/tests/Shared/SessionLogRetentionTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using System.Linq;
+using Cimian.Core.Services;
+using Xunit;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// Retention over the parts of the logs tree that are not the dated session directories.
+/// </summary>
+/// <remarks>
+/// The regression these guard: retention enumerated directories only. Loose files at the
+/// logs root - package script output, msiexec verbose logs, self-update installer logs -
+/// were never candidates for deletion, so they accumulated for the life of the machine.
+/// </remarks>
+public class SessionLogRetentionTests : IDisposable
+{
+    private readonly string _root;
+
+    public SessionLogRetentionTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cimian-retention-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private string WriteFile(string relativePath, DateTime lastWrite)
+    {
+        var full = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, "x");
+        File.SetLastWriteTime(full, lastWrite);
+        return full;
+    }
+
+    private static DateTime Cutoff => DateTime.Now.AddDays(-30);
+    private static DateTime Expired => DateTime.Now.AddDays(-45);
+    private static DateTime Fresh => DateTime.Now.AddDays(-2);
+
+    [Fact]
+    public void SweepExpiredFiles_RemovesOldLooseFilesAndKeepsRecentOnes()
+    {
+        var old = WriteFile("selfupdate-20250101-000000.log", Expired);
+        var recent = WriteFile("selfupdate-20260801-000000.log", Fresh);
+
+        SessionLogger.SweepExpiredFiles(_root, Cutoff);
+
+        Assert.False(File.Exists(old));
+        Assert.True(File.Exists(recent));
+    }
+
+    [Fact]
+    public void SweepExpiredFiles_DoesNotDescendIntoSubdirectories()
+    {
+        // Session directories are aged as a unit by their own date-named rule. An old
+        // file inside one must not be picked off individually, or a session's log set
+        // ends up half deleted.
+        var nested = WriteFile(Path.Combine("2026-01-02", "0800", "install.log"), Expired);
+
+        SessionLogger.SweepExpiredFiles(_root, Cutoff);
+
+        Assert.True(File.Exists(nested));
+    }
+
+    [Fact]
+    public void SweepExpiredFiles_IsSilentWhenTheDirectoryDoesNotExist()
+    {
+        var missing = Path.Combine(_root, "no-such-directory");
+
+        SessionLogger.SweepExpiredFiles(missing, Cutoff);
+
+        Assert.False(Directory.Exists(missing));
+    }
+
+    [Fact]
+    public void SweepExpiredSubdirectories_DropsAPackageNothingHasTouchedInTheWindow()
+    {
+        WriteFile(Path.Combine("packages", "RetiredApp", "postinstall.log"), Expired);
+        WriteFile(Path.Combine("packages", "CurrentApp", "postinstall.log"), Fresh);
+
+        SessionLogger.SweepExpiredSubdirectories(Path.Combine(_root, "packages"), Cutoff);
+
+        Assert.False(Directory.Exists(Path.Combine(_root, "packages", "RetiredApp")));
+        Assert.True(Directory.Exists(Path.Combine(_root, "packages", "CurrentApp")));
+    }
+
+    [Fact]
+    public void SweepExpiredSubdirectories_KeepsAPackageWithAnyRecentFile()
+    {
+        // A package installed once long ago and reinstalled last week is live. The
+        // newest file decides, not the oldest.
+        WriteFile(Path.Combine("packages", "App", "preinstall.log"), Expired);
+        WriteFile(Path.Combine("packages", "App", "postinstall.log"), Fresh);
+
+        SessionLogger.SweepExpiredSubdirectories(Path.Combine(_root, "packages"), Cutoff);
+
+        Assert.True(Directory.Exists(Path.Combine(_root, "packages", "App")));
+        Assert.True(File.Exists(Path.Combine(_root, "packages", "App", "preinstall.log")));
+    }
+
+    [Fact]
+    public void SweepExpiredSubdirectories_DropsAnEmptyLeftover()
+    {
+        var empty = Path.Combine(_root, "packages", "Empty");
+        Directory.CreateDirectory(empty);
+
+        SessionLogger.SweepExpiredSubdirectories(Path.Combine(_root, "packages"), Cutoff);
+
+        Assert.False(Directory.Exists(empty));
+    }
+
+    [Fact]
+    public void SweepExpiredSubdirectories_LeavesFilesAtItsOwnRootAlone()
+    {
+        var loose = WriteFile(Path.Combine("packages", "stray.log"), Expired);
+
+        SessionLogger.SweepExpiredSubdirectories(Path.Combine(_root, "packages"), Cutoff);
+
+        Assert.True(File.Exists(loose));
+    }
+}


### PR DESCRIPTION
Fixes #88.

Three leaks under `%ProgramData%\ManagedInstalls`, worth roughly 100 GB per long-running endpoint between them.

### `CacheRetentionDays` now does something

It was configuration nothing acted on — validated, stored, printed by `--show-config`, and read by no delete path. Every installer a machine had ever downloaded stayed on disk, including every superseded version.

`ValidateAndCleanCache` now prunes payloads whose last write predates the window. Specifically:

- takes each payload's `.verified` marker with it, but never deletes a marker whose payload is still current (that would force a pointless re-verification)
- leaves `.downloading` files to the existing 24-hour resumable rule
- removes category directories it empties, keeping the cache root
- logs how much it reclaimed
- a non-positive `CacheRetentionDays` disables it

It runs before the download phase, so the worst case for an over-eager delete is one re-download.

### Log retention now sees the whole tree

`PerformRetentionCleanup` walked `Directory.GetDirectories` only. Everything the client itself writes lives in a directory, so that looked sufficient — but the logs root is shared, and the loose files that land there were never candidates for deletion.

- `SweepExpiredFiles` ages out files sitting directly in a directory. Deliberately not recursive: a session directory is aged as a unit by its own date-named rule, and picking old files out of one individually would leave half a session's log set behind.
- `SweepExpiredSubdirectories` drops an immediate subdirectory whose newest file predates the window — the right question for a tree keyed by package name rather than by date, and it means a package that stops being installed eventually takes its logs with it.

### The loose writers get somewhere to go

| | before | after |
|---|---|---|
| self-update installer log | `logs\selfupdate-<stamp>.log` | `logs\selfupdate\` |
| msiexec / MSIX verbose logs | **the download cache**, `{item}_install.N.log` | `logs\installs\` |
| package script output | `logs\cimipkg-<pkg>-<action>.log` | `logs\packages\<pkg>\` (written by the packaging tool; the path is declared here so retention knows about it) |

The msiexec logs are the notable one — they were in `CachePath`, mixed in with the payloads and invisible to log retention. Rotation (`_install.1.log` … `.3.log`) is unchanged; they just live somewhere retention can reach.

### `run.log` in the session directory is gone

`Log()` wrote the identical formatted line to `install.log` in the same directory, so every session's log volume was doubled. `reports/run.log` is untouched: it is the fixed path external tooling tails, and it is truncated per session rather than accumulating. The GUI log viewer already prefers `install.log` and only fell back to `run.log`.

### Tests

- `SessionLogRetentionTests` — 7 cases: loose files aged out, recent ones kept, the sweep not descending into session directories, a retired package directory dropped, a package with any recent file kept, empty leftovers dropped, files at the sweep's own root left alone.
- `DownloadServiceTests` — 6 new cases: payloads past retention removed, markers taken with their payload, a marker kept when its payload is current, `.downloading` left alone, emptied category directories removed, and a non-positive setting disabling the whole thing.

926 passing. The two `ConfigurationServiceTests` failures are pre-existing on `main`.

### Follow-up

The `logs\packages\` layout lands in the packaging tool (`cimian-pkg`); the submodule pointer here needs bumping once that merges. Retention is written to tolerate either layout in the meantime — the old flat `cimipkg-*.log` files at the root are now aged out by `SweepExpiredFiles` regardless.

---

### Follow-up in this PR: retention alone was not self-healing

Measured on an endpoint before adding the pass below:

```
logs root, loose files:  50
  older than 30d (age sweep gets them)   14
  NEWER than 30d - never age out         36
     cimipkg-*   (rewritten every session by already-installed MSIs)  25
     selfupdate-*                                                      3
     other package scripts                                             1
     cimiwatcher (legitimately self-managing, capped at 7 by Serilog)   7
```

An MSI that is already installed rewrites its sidecar log every time it runs, so the file is permanently younger than any retention window and an age-based sweep never reaches it. Deploying this client would have tidied 14 files and left 29 sitting at the root until every package on every endpoint had been rebuilt.

`RelocateLegacyArtifacts` runs each session and moves them regardless of age:

```
cimipkg-<Product>-Cimian<Action>.log -> logs\packages\<Product>\<action>.log
selfupdate-*.log                     -> logs\selfupdate\
cache\**\*_install*.log              -> logs\installs\
```

Move rather than delete — the content is still wanted, and an installcheck that tails the last attempt's output now looks for it at the new path. Overwrites on collision so repeated passes are fine, and the whole thing is a no-op once packages are rebuilt.

Files this client does not own are deliberately left alone: it cannot tell a log from a state marker by looking (a package sentinel named `.log` lives right there), so age stays the signal for those — which is the correct test for "nothing is writing this any more".

Roots are parameters so the pass is exercised against a temp tree, not the machine's.

14 more tests (mapping for each action, hyphenated product names, cache extraction, payloads untouched, idempotence across a collision, and the not-ours cases). **940 passing**, same two pre-existing `ConfigurationServiceTests` failures.
