### PR TITLE
Make MSI and script packages removable without extra metadata

### DIFF
--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -527,11 +527,21 @@ public class CatalogItem
         // is treated consistently across status, verify, and uninstall paths.
         || Installs.Any(i =>
             i.EffectiveType() == "msi" && !string.IsNullOrEmpty(i.ProductCode))
-        // Self-uninstallable MSI (legacy): pkginfos written before product_code moved
-        // out of the installer: block. Same msiexec /x path either way.
-        || (Installer is { } msi
-            && string.Equals(msi.Type, "msi", StringComparison.OrdinalIgnoreCase)
-            && !string.IsNullOrEmpty(msi.ProductCode))
+        // Any MSI is removable, declared product_code or not. An MSI registers
+        // itself with Windows Installer by definition, so the code is always
+        // discoverable at removal time: UninstallAsync falls back to the app's
+        // registry UninstallString, which for an MSI is literally
+        // `MsiExec.exe /X{ProductCode}`. Requiring the admin to restate a GUID
+        // the system can already read was the bug -- hand-written and
+        // Studio-authored pkginfos silently lost removal, while cimiimport ones
+        // worked, for no reason the author could see. This clause also subsumes
+        // the legacy `installer.product_code` shape.
+        || string.Equals(Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase)
+        // A script-removable package: uninstall_script is a real removal
+        // mechanism executed by UninstallAsync, so it must count here too --
+        // without it that branch is unreachable, which is the whole removal
+        // story for `type: ps1` packages that have no registry uninstall entry.
+        || !string.IsNullOrWhiteSpace(UninstallScript)
         // Self-uninstallable MSIX: installs-array entry of type msix/appx with a
         // usable identity_name. Without identity_name, UninstallAsync can't
         // synthesize an uninstaller — so in that case this clause must be false.

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -777,15 +777,22 @@ public class InstallerService
                     };
                     result = await UninstallMsixAsync(item, synthetic, cancellationToken);
                 }
-                // Last resort for exe/NSIS/Inno apps that carry no explicit
-                // uninstaller block, product_code, or msix identity: drive the app's
-                // own uninstaller via the standard Windows uninstall registry entry.
-                // This is what makes an installed optional app (e.g. an NSIS-packaged
-                // player) removable without per-package uninstall metadata. Note this
-                // is gated on the installer *type*, not unattended_uninstall — a
-                // user-initiated Remove must work even for packages that opt out of
-                // silent background removal.
-                else if (string.Equals(item.Installer?.Type, "exe", StringComparison.OrdinalIgnoreCase))
+                // Last resort for exe/NSIS/Inno apps and for MSIs whose pkginfo
+                // never declared a product_code: drive the app's own uninstaller via
+                // the standard Windows uninstall registry entry. This is what makes
+                // an installed optional app (e.g. an NSIS-packaged player) removable
+                // without per-package uninstall metadata. Note this is gated on the
+                // installer *type*, not unattended_uninstall — a user-initiated
+                // Remove must work even for packages that opt out of silent
+                // background removal.
+                //
+                // MSI is included because an MSI always registers an UninstallString
+                // of the form `MsiExec.exe /X{ProductCode}`, so the GUID the pkginfo
+                // omitted is recoverable from the registry. UninstallViaRegistryAsync
+                // already normalises those entries (/I -> /X, appends /qn /norestart),
+                // so no MSI-specific handling is needed here.
+                else if (string.Equals(item.Installer?.Type, "exe", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(item.Installer?.Type, "msi", StringComparison.OrdinalIgnoreCase))
                 {
                     result = await UninstallViaRegistryAsync(item, cancellationToken);
                 }

--- a/tests/Managedsoftwareupdate/InstallerServiceTests.cs
+++ b/tests/Managedsoftwareupdate/InstallerServiceTests.cs
@@ -270,6 +270,87 @@ public class InstallerServiceTests
     }
 
     [Fact]
+    public void IsUninstallable_MsiInstallerWithoutProductCode_ReturnsTrue()
+    {
+        // An MSI registers itself with Windows Installer by definition, so the
+        // ProductCode is recoverable from the registry UninstallString at removal
+        // time. Requiring the pkginfo to restate it meant hand-written and
+        // Studio-authored MSI packages silently lost their Remove action while
+        // cimiimport-generated ones worked. Reported in #cimian on Mac Admins.
+        var item = new CatalogItem
+        {
+            Name = "Mozilla Firefox",
+            Version = "153.1.0.0",
+            Uninstallable = true,
+            Uninstaller = [],
+            Installer = new InstallerInfo { Type = "msi", Location = "/mgmt/firefox.msi" },
+            // A file-type installs entry is a *detection* rule and contributes no
+            // removal mechanism — this is exactly the shape that regressed.
+            Installs = [
+                new InstallCheckItem { Type = "file", Path = @"C:\Program Files\Mozilla Firefox\firefox.exe" }
+            ]
+        };
+
+        Assert.True(item.IsUninstallable());
+    }
+
+    [Fact]
+    public void IsUninstallable_UninstallScriptOnly_ReturnsTrue()
+    {
+        // uninstall_script is executed by UninstallAsync, so it has to count as a
+        // removal mechanism here — otherwise that branch is unreachable and a
+        // script-installed package (type: ps1, no registry uninstall entry) can
+        // never be removed.
+        var item = new CatalogItem
+        {
+            Name = "PrinterQueue",
+            Version = "1.0",
+            Uninstallable = true,
+            Uninstaller = [],
+            Installer = new InstallerInfo { Type = "ps1", Location = "Scripts/install.ps1" },
+            UninstallScript = "Remove-Printer -Name \"LMZ VS\""
+        };
+
+        Assert.True(item.IsUninstallable());
+    }
+
+    [Fact]
+    public void IsUninstallable_UninstallableFalseOverridesMsiAndScript_ReturnsFalse()
+    {
+        // `uninstallable: false` is the explicit opt-out and must still win over
+        // every mechanism clause, including the two added above.
+        var item = new CatalogItem
+        {
+            Name = "PinnedApp",
+            Version = "1.0",
+            Uninstallable = false,
+            Uninstaller = [],
+            Installer = new InstallerInfo { Type = "msi", Location = "/mgmt/pinned.msi" },
+            UninstallScript = "exit 0"
+        };
+
+        Assert.False(item.IsUninstallable());
+    }
+
+    [Fact]
+    public void IsUninstallable_Ps1InstallerNoRemovalMechanism_ReturnsFalse()
+    {
+        // A script-installed package with no uninstall_script, no uninstaller block
+        // and no registry identity still has no way to be removed. Guards against
+        // the uninstall_script clause being widened into "any ps1 package".
+        var item = new CatalogItem
+        {
+            Name = "ScriptOnlyNoRemoval",
+            Version = "1.0",
+            Uninstallable = true,
+            Uninstaller = [],
+            Installer = new InstallerInfo { Type = "ps1", Location = "Scripts/install.ps1" }
+        };
+
+        Assert.False(item.IsUninstallable());
+    }
+
+    [Fact]
     public void IsUninstallable_NoUninstallerNoMsixInstalls_ReturnsFalse()
     {
         var item = new CatalogItem

--- a/tests/Managedsoftwareupdate/UpdateModelsTests.cs
+++ b/tests/Managedsoftwareupdate/UpdateModelsTests.cs
@@ -166,10 +166,15 @@ public class UpdateModelsTests
     }
 
     [Fact]
-    public void CatalogItem_IsUninstallable_MsiInstallerWithoutProductCode_ReturnsFalse()
+    public void CatalogItem_IsUninstallable_MsiInstallerWithoutProductCode_ReturnsTrue()
     {
-        // An MSI installer with no product_code can't be uninstalled — we have nothing
-        // to feed msiexec /x.
+        // Deliberate behaviour change: this previously asserted False on the premise
+        // that "we have nothing to feed msiexec /x". That premise was wrong — an MSI
+        // always registers an UninstallString of the form `MsiExec.exe /X{ProductCode}`,
+        // so UninstallAsync recovers the GUID from the registry when the pkginfo omits
+        // it. Requiring the admin to restate it meant hand-written and Studio-authored
+        // MSI packages silently lost their Remove action while cimiimport-generated
+        // ones worked.
         var item = new CatalogItem
         {
             Uninstallable = true,
@@ -177,7 +182,7 @@ public class UpdateModelsTests
             Installer = new InstallerInfo { Type = "msi" }
         };
 
-        Assert.False(item.IsUninstallable());
+        Assert.True(item.IsUninstallable());
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #90 and #96 — two independent reasons an item reported as not uninstallable. Both surfaced from the same #cimian report: **Remove never appears in Managed Software Center**, for two different packages, for two different reasons.

## `uninstall_script` was a dead branch (#90)

`UninstallAsync` executes `uninstall_script` as a removal mechanism, but `IsUninstallable()` did not list it. That predicate gates everything downstream:

- the removal queue — `UpdateEngine.cs:1211` (`managed_uninstalls`) and `:1256` (unused-software auto-removal)
- the `uninstallable` flag written into `InstallInfo.yaml` (`:3246`), which is what MSC's `ShowRemoveAction` reads

So the branch was unreachable. This is the entire removal story for `type: ps1` packages, which have no registry uninstall entry to fall back on.

## An MSI required a declared `product_code` (#96)

An MSI registers itself with Windows Installer *by definition*. Its `UninstallString` is literally `MsiExec.exe /X{ProductCode}`, so the GUID is recoverable at removal time and the admin should never have to restate it.

The machinery was already there and just gated off:

- `ResolveRegistryUninstall` matches on `DisplayName` — nothing in it is exe-specific
- `UninstallViaRegistryAsync` already normalises msiexec commands (`/I` → `/X`, appends `/qn /norestart`), with a comment anticipating products "not matched by product_code earlier"

Net effect before this change: `cimiimport`-generated pkginfos worked, hand-written and Studio-authored ones silently lost removal, and nothing distinguished them.

## Note for review

`installer.type == "msi"` subsumes the legacy `installer.product_code` clause, so that clause is removed. The `installs[]` clause stays — it covers pkginfos whose `installer` is not itself an MSI.

**One existing test changed meaning.** `CatalogItem_IsUninstallable_MsiInstallerWithoutProductCode_ReturnsFalse` asserted the old behaviour, commented "An MSI installer with no product_code can't be uninstalled — we have nothing to feed msiexec /x." That premise is what this PR corrects, so the test now asserts `True` and records why. Flagging explicitly since it is an asserted invariant being deliberately inverted.

## Testing

`dotnet test tests/Cimian.Tests.csproj` → **944 passed, 2 failed**. Both failures are `ConfigurationServiceTests` and reproduce on unmodified `main` (verified by stashing) — unrelated to this change.

Four new cases in `InstallerServiceTests.cs`:

- MSI installer with no product_code and a `type: file` installs entry → removable (the reported Firefox shape)
- `uninstall_script` only → removable (the reported printer shape)
- `uninstallable: false` with both an MSI installer and an uninstall_script → **not** removable, so the explicit opt-out still wins
- `type: ps1` with no removal mechanism at all → **not** removable, guarding against the uninstall_script clause widening into "any ps1 package"

## Not covered here

`uninstallcheck_script` (#95) is the remaining reason a package can look non-removable, and it needs a larger change — `StatusService.CheckStatus` takes an `action` parameter it never branches on, so there is no uninstall status path to attach it to. Left for its own PR.
