### PR TITLE
Emit the uninstaller shape the client actually reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,13 +593,14 @@ postinstall_script: |
     # Additional configuration here
   }
 
-# Uninstaller
+# Uninstaller. This is a list; only the first entry is used.
 uninstaller:
-  location: Microsoft/VisualStudio/vs_community_2022.exe
-  arguments:
-    - uninstall
-    - --quiet
-    - --wait
+  - type: exe
+    location: Microsoft/VisualStudio/vs_community_2022.exe
+    arguments:
+      - uninstall
+      - --quiet
+      - --wait
 
 supported_architectures:
   - x64
@@ -694,23 +695,14 @@ requires:
   - DotNetFramework48
   - VisualCPPRedistributable
 
-# Advanced uninstall handling
+# Advanced uninstall handling. This is a list; only the first entry is used.
 uninstaller:
-  type: exe
-  location: Microsoft/Office365/setup.exe
-  arguments:
-    - /configure
-    - /quiet
-    - /uninstall
-
-uninstalls:
-  - type: directory
-    path: "C:\Program Files\Microsoft Office"
-    recursive: true
-    force: true
-  - type: registry
-    path: "HKLM\SOFTWARE\Microsoft\Office"
-    recursive: true
+  - type: exe
+    location: Microsoft/Office365/setup.exe
+    arguments:
+      - /configure
+      - /quiet
+      - /uninstall
 
 # System requirements
 supported_architectures:

--- a/cli/makepkginfo/Cimian.CLI.makepkginfo.csproj
+++ b/cli/makepkginfo/Cimian.CLI.makepkginfo.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\..\shared\infrastructure\Cimian.Infrastructure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Cimian.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/cli/makepkginfo/Models/PkgsInfo.cs
+++ b/cli/makepkginfo/Models/PkgsInfo.cs
@@ -123,8 +123,13 @@ public class PkgsInfo
     [YamlMember(Alias = "postuninstall_script", Order = 20, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? PostuninstallScript { get; set; }
 
-    [YamlMember(Alias = "uninstaller_path", Order = 21, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
-    public string? UninstallerPath { get; set; }
+    // Emitted as a one-element sequence because that is the shape both
+    // makecatalogs and the client declare (List<Installer> / List<UninstallerInfo>),
+    // and the shape UninstallAsync executes. The previous `uninstaller_path` scalar
+    // was declared here and nowhere else, so it was stripped at catalog time and
+    // ignored by the client -- setting it did nothing at all.
+    [YamlMember(Alias = "uninstaller", Order = 21, DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public List<Installer>? Uninstaller { get; set; }
 
     [YamlMember(Alias = "OnDemand", Order = 22, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
     public bool OnDemand { get; set; }

--- a/cli/makepkginfo/Program.cs
+++ b/cli/makepkginfo/Program.cs
@@ -42,7 +42,7 @@ class Program
 
         var uninstallerOption = new Option<string?>(
             "--uninstaller",
-            "Path to uninstaller executable");
+            "Path to uninstaller executable; emitted as a one-element uninstaller: list");
 
         var catalogsOption = new Option<string>(
             "--catalogs",

--- a/cli/makepkginfo/Services/PkgInfoBuilder.cs
+++ b/cli/makepkginfo/Services/PkgInfoBuilder.cs
@@ -244,8 +244,19 @@ public class PkgInfoBuilder
         }
         if (!string.IsNullOrEmpty(options.UninstallerPath))
         {
-            // Store the uninstaller path - typically used for EXE installers
-            pkgsinfo.UninstallerPath = options.UninstallerPath;
+            // Emit the canonical one-element `uninstaller:` sequence. Only
+            // Uninstaller[0] is ever consumed (InstallerService.UninstallAsync), so a
+            // single entry is the complete shape. Type is inferred from the extension
+            // and drives the removal dispatch on the client; an unrecognised
+            // extension is left null, which UninstallAsync treats as msi.
+            pkgsinfo.Uninstaller =
+            [
+                new Installer
+                {
+                    Type = InferUninstallerType(options.UninstallerPath),
+                    Location = options.UninstallerPath
+                }
+            ];
         }
 
         // Process additional -f file paths
@@ -373,6 +384,24 @@ public class PkgInfoBuilder
     /// <summary>
     /// Reads a file or returns empty string
     /// </summary>
+
+    /// <summary>
+    /// Picks the uninstaller `type` from the file extension so the client dispatches
+    /// removal correctly (msi -> msiexec /x, exe -> process, ps1 -> script host).
+    /// Returns null for anything unrecognised rather than guessing, which leaves
+    /// UninstallAsync on its existing default path.
+    /// </summary>
+    internal static string? InferUninstallerType(string uninstallerPath)
+    {
+        var ext = System.IO.Path.GetExtension(uninstallerPath ?? string.Empty).ToLowerInvariant();
+        return ext switch
+        {
+            ".msi" => "msi",
+            ".exe" => "exe",
+            ".ps1" => "ps1",
+            _ => null
+        };
+    }
     private static string? ReadFileOrEmpty(string? path)
     {
         if (string.IsNullOrEmpty(path))
@@ -439,6 +468,7 @@ public class PkgsInfoOptions
     public string? PostinstallScriptPath { get; set; }
     public string? PreuninstallScriptPath { get; set; }
     public string? PostuninstallScriptPath { get; set; }
+    /// <summary>Path to the uninstaller; emitted as `uninstaller: [ ... ]`.</summary>
     public string? UninstallerPath { get; set; }
     public List<string>? AdditionalFiles { get; set; }
 }

--- a/tests/Makepkginfo/PkgInfoBuilderTests.cs
+++ b/tests/Makepkginfo/PkgInfoBuilderTests.cs
@@ -510,6 +510,65 @@ public class PkgsInfoOptionsTests
     }
 }
 
+public class UninstallerEmissionTests
+{
+    [Theory]
+    [InlineData("Vendor/App/uninstall.exe", "exe")]
+    [InlineData("Vendor/App/UNINSTALL.EXE", "exe")]
+    [InlineData("Vendor/App/remove.msi", "msi")]
+    [InlineData("Vendor/App/remove.ps1", "ps1")]
+    public void InferUninstallerType_FromExtension(string path, string expected)
+    {
+        Assert.Equal(expected, PkgInfoBuilder.InferUninstallerType(path));
+    }
+
+    [Theory]
+    [InlineData("Vendor/App/uninstall.bat")]
+    [InlineData("Vendor/App/uninstall")]
+    [InlineData("")]
+    public void InferUninstallerType_UnrecognisedExtension_ReturnsNull(string path)
+    {
+        // Deliberately null rather than a guess: UninstallAsync's switch treats an
+        // unknown type as msi, which is the pre-existing default, so guessing here
+        // would silently change dispatch for shapes we do not understand.
+        Assert.Null(PkgInfoBuilder.InferUninstallerType(path));
+    }
+
+    [Fact]
+    public void UninstallerPath_EmitsSingleElementUninstallerList()
+    {
+        // Regression guard for the write-only `uninstaller_path` scalar: makepkginfo
+        // declared it, nothing else did, so it was stripped at catalog time and
+        // ignored by the client. The emitted shape must be the List<Installer> that
+        // makecatalogs and the client both declare.
+        var yaml = Serialize(new PkgsInfo
+        {
+            Name = "TestApp",
+            Version = "1.0",
+            Uninstaller =
+            [
+                new Installer { Type = "exe", Location = "Vendor/App/uninstall.exe" }
+            ]
+        });
+
+        Assert.Contains("uninstaller:", yaml);
+        Assert.DoesNotContain("uninstaller_path", yaml);
+        // A sequence entry, not a mapping — "- type:" is what distinguishes them.
+        Assert.Matches(@"uninstaller:\s*?
+\s*-\s+type:\s*exe", yaml);
+    }
+
+    [Fact]
+    public void Uninstaller_OmittedWhenNotSet()
+    {
+        var yaml = Serialize(new PkgsInfo { Name = "TestApp", Version = "1.0" });
+        Assert.DoesNotContain("uninstaller", yaml);
+    }
+
+    private static string Serialize(PkgsInfo p) =>
+        Cimian.Core.Services.YamlUtils.Serializer.Serialize(p);
+}
+
 public class InstallerTypeDetectionTests
 {
     [Theory]


### PR DESCRIPTION
Fixes #93 and #91. Both are the same underlying thing: the `uninstaller` metadata that tooling and docs emit does not match what the client reads.

## `uninstaller_path` was write-only (#93)

`makepkginfo --uninstaller` wrote an `uninstaller_path:` scalar declared in exactly one model and read by none:

- `cli/makecatalogs/Models/PkgsInfo.cs` has no such member → stripped when generating catalogs
- `cli/managedsoftwareupdate/Models/UpdateModels.cs` has no such member → ignored even if it survived

So setting it did nothing, and since `IsUninstallable()` has no clause for it the package reported as not uninstallable with nothing explaining why. This is the same propagation break #84 fixed for `icon_name`.

The flag now emits the canonical one-element `uninstaller:` sequence — the shape both consumers declare and the shape `UninstallAsync` executes (`Uninstaller[0]`). Type is inferred from the extension (`.msi`/`.exe`/`.ps1`) so removal dispatches correctly; anything unrecognised stays `null` rather than guessing, which leaves `UninstallAsync` on its pre-existing default path.

## README documented a shape that cannot parse (#91)

`uninstaller:` was documented as a **mapping** at two places while every model declares `List<>`. Copying the documented example produces a hard YAML deserialization failure — which is exactly what a user hit, and it presented as the package silently vanishing from Cimian Studio. Both examples are corrected to the list form and note that only the first entry is used.

The same block documented an `uninstalls:` key for directory/registry cleanup. `grep -rn 'Alias = "uninstalls"'` returns nothing — it has never been implemented and was silently ignored. Removed rather than left as a promise the code doesn't keep.

## Note for review

Two small judgement calls worth confirming:

**`uninstalls:` removed rather than implemented.** If directory/registry cleanup is actually wanted, this should be an issue instead — say the word and I'll restore the docs and open one.

**A new test caught a serializer artifact.** `DefaultValuesHandling.OmitEmptyCollections` still emits a bare `uninstaller: ` key when the list is null, so the field uses `OmitNull`. `installs:` has the identical artifact on `main` today — I left it alone as pre-existing and out of scope, but it's a trivial follow-up if you want it.

`makepkginfo` gains `InternalsVisibleTo` for `Cimian.Tests`, matching what `managedsoftwareupdate` and `shared/core` already do, so the inference helper is testable directly instead of being widened to public.

## Testing

`dotnet test tests/Cimian.Tests.csproj` → **949 passed, 2 failed**. Both failures are `ConfigurationServiceTests` and reproduce on unmodified `main` — unrelated.

New `UninstallerEmissionTests`: extension→type inference including unrecognised-returns-null, emission as a sequence (asserted via `- type:`, which is what distinguishes a sequence entry from a mapping), `uninstaller_path` no longer appearing in output, and the key being omitted entirely when unset.

## Related

#90 and #96 (PR #97) fix the other reasons an item reports as not uninstallable. #95 remains — `uninstallcheck_script` is still accepted and ignored.
