### PR TITLE
Fail makecatalogs when a pkgsinfo cannot be parsed

### DIFF
--- a/cli/makecatalogs/Program.cs
+++ b/cli/makecatalogs/Program.cs
@@ -34,6 +34,10 @@ class Program
             aliases: ["--silent", "-q"],
             description: "Minimize output");
 
+        var tolerateParseErrorsOption = new Option<bool>(
+            aliases: ["--tolerate_parse_errors"],
+            description: "Write catalogs even if some pkgsinfo failed to parse (they are omitted)");
+
         var versionOption = new Option<bool>(
             aliases: ["-V"],
             description: "Print version and exit");
@@ -42,6 +46,7 @@ class Program
         rootCommand.AddOption(skipPayloadCheckOption);
         rootCommand.AddOption(hashCheckOption);
         rootCommand.AddOption(silentOption);
+        rootCommand.AddOption(tolerateParseErrorsOption);
         rootCommand.AddOption(versionOption);
 
         rootCommand.SetHandler((context) =>
@@ -50,11 +55,12 @@ class Program
             var skipPayloadCheck = context.ParseResult.GetValueForOption(skipPayloadCheckOption);
             var hashCheck = context.ParseResult.GetValueForOption(hashCheckOption);
             var silent = context.ParseResult.GetValueForOption(silentOption);
+            var tolerateParseErrors = context.ParseResult.GetValueForOption(tolerateParseErrorsOption);
             var showVersion = context.ParseResult.GetValueForOption(versionOption);
 
             try
             {
-                context.ExitCode = Run(repoPath, skipPayloadCheck, hashCheck, silent, showVersion);
+                context.ExitCode = Run(repoPath, skipPayloadCheck, hashCheck, silent, showVersion, tolerateParseErrors);
             }
             catch (Exception ex)
             {
@@ -66,7 +72,7 @@ class Program
         return await rootCommand.InvokeAsync(args);
     }
 
-    private static int Run(string? repoPath, bool skipPayloadCheck, bool hashCheck, bool silent, bool showVersion)
+    private static int Run(string? repoPath, bool skipPayloadCheck, bool hashCheck, bool silent, bool showVersion, bool tolerateParseErrors = false)
     {
         if (showVersion)
         {
@@ -92,7 +98,7 @@ class Program
             success: msg => Console.WriteLine(msg)
         );
 
-        return builder.Run(repoPath, skipPayloadCheck, hashCheck, silent);
+        return builder.Run(repoPath, skipPayloadCheck, hashCheck, silent, tolerateParseErrors);
     }
 
     private static string? LoadRepoPathFromConfig()

--- a/cli/makecatalogs/Services/CatalogBuilder.cs
+++ b/cli/makecatalogs/Services/CatalogBuilder.cs
@@ -13,6 +13,15 @@ public class CatalogBuilder
     private readonly Action<string> _warn;
     private readonly Action<string> _success;
 
+    // pkgsinfo files that failed to deserialize during the last ScanRepo. A parse
+    // failure means the package is absent from every catalog written afterwards,
+    // so this has to survive to the end of the run and affect the exit code --
+    // publishing a silently incomplete catalog is the failure mode this guards.
+    private readonly List<string> _parseErrors = new();
+
+    /// <summary>Files skipped by the last <see cref="ScanRepo"/> because they could not be parsed.</summary>
+    public IReadOnlyList<string> ParseErrors => _parseErrors;
+
     public CatalogBuilder(
         Action<string>? log = null,
         Action<string>? warn = null,
@@ -29,6 +38,7 @@ public class CatalogBuilder
     public List<PkgsInfo> ScanRepo(string repoPath)
     {
         var results = new List<PkgsInfo>();
+        _parseErrors.Clear();
         var pkgsInfoDir = Path.Combine(repoPath, "pkgsinfo");
 
         if (!Directory.Exists(pkgsInfoDir))
@@ -51,6 +61,7 @@ public class CatalogBuilder
             catch (Exception ex)
             {
                 _warn($"Error parsing {file}: {ex.Message}");
+                _parseErrors.Add($"{file}: {ex.Message}");
             }
         }
 
@@ -310,7 +321,7 @@ public class CatalogBuilder
     /// <summary>
     /// Runs the complete catalog building process
     /// </summary>
-    public int Run(string repoPath, bool skipPayloadCheck = false, bool hashCheck = false, bool silent = false)
+    public int Run(string repoPath, bool skipPayloadCheck = false, bool hashCheck = false, bool silent = false, bool tolerateParseErrors = false)
     {
         if (!silent)
         {
@@ -343,6 +354,28 @@ public class CatalogBuilder
             foreach (var warning in warnings)
             {
                 _warn(warning);
+            }
+
+            // A package that failed to parse is missing from the catalogs just
+            // written. Restate the failures here -- they scroll past mid-scan,
+            // long before this point -- and fail the run, so a pipeline cannot
+            // publish an incomplete catalog on a green exit code.
+            if (_parseErrors.Count > 0)
+            {
+                _warn($"{_parseErrors.Count} pkgsinfo skipped (parse errors); those packages are NOT in the catalogs:");
+                foreach (var err in _parseErrors)
+                {
+                    _warn($"  {err}");
+                }
+
+                if (!tolerateParseErrors)
+                {
+                    _warn("makecatalogs failed: fix the files above, or pass --tolerate_parse_errors to publish without them.");
+                    return 1;
+                }
+
+                _success($"makecatalogs completed with {_parseErrors.Count} skipped pkgsinfo (--tolerate_parse_errors).");
+                return 0;
             }
 
             _success("makecatalogs completed successfully.");

--- a/tests/Makecatalogs/CatalogBuilderTests.cs
+++ b/tests/Makecatalogs/CatalogBuilderTests.cs
@@ -125,6 +125,88 @@ catalogs: []
     }
 
     [Fact]
+    public void ScanRepo_RecordsParseErrors()
+    {
+        CreatePkgInfo("invalid.yaml", "{ this is not valid yaml: [");
+
+        _builder.ScanRepo(_tempDir);
+
+        Assert.Single(_builder.ParseErrors);
+        Assert.Contains("invalid.yaml", _builder.ParseErrors[0]);
+    }
+
+    [Fact]
+    public void ScanRepo_ClearsParseErrorsBetweenRuns()
+    {
+        CreatePkgInfo("invalid.yaml", "{ this is not valid yaml: [");
+        _builder.ScanRepo(_tempDir);
+        Assert.Single(_builder.ParseErrors);
+
+        File.Delete(Path.Combine(_tempDir, "pkgsinfo", "invalid.yaml"));
+        _builder.ScanRepo(_tempDir);
+
+        Assert.Empty(_builder.ParseErrors);
+    }
+
+    [Fact]
+    public void Run_FailsAndDoesNotReportSuccess_WhenPkgsinfoCannotBeParsed()
+    {
+        // The regression: a package that fails to parse is absent from the catalogs
+        // that get written, but the run previously printed "completed successfully"
+        // and returned 0, so a pipeline would publish an incomplete catalog with no
+        // signal. Exit code and success message are both part of the contract here.
+        CreatePkgInfo("good.yaml", @"name: GoodApp
+version: 1.0
+catalogs:
+  - Testing
+");
+        CreatePkgInfo("broken.yaml", "{ this is not valid yaml: [");
+
+        var exitCode = _builder.Run(_tempDir, skipPayloadCheck: true);
+
+        Assert.Equal(1, exitCode);
+        Assert.DoesNotContain(_successes, m => m.Contains("completed successfully"));
+        Assert.Contains(_warnings, m => m.Contains("1 pkgsinfo skipped"));
+        Assert.Contains(_warnings, m => m.Contains("broken.yaml"));
+    }
+
+    [Fact]
+    public void Run_TolerateParseErrors_SucceedsButStillReportsSkipped()
+    {
+        // The escape hatch keeps the old exit code for pipelines that need it, but
+        // must never restate the unqualified "completed successfully" -- the whole
+        // point is that the outcome stays visible.
+        CreatePkgInfo("good.yaml", @"name: GoodApp
+version: 1.0
+catalogs:
+  - Testing
+");
+        CreatePkgInfo("broken.yaml", "{ this is not valid yaml: [");
+
+        var exitCode = _builder.Run(_tempDir, skipPayloadCheck: true, tolerateParseErrors: true);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains(_warnings, m => m.Contains("1 pkgsinfo skipped"));
+        Assert.Contains(_successes, m => m.Contains("1 skipped pkgsinfo"));
+        Assert.DoesNotContain(_successes, m => m.Contains("completed successfully"));
+    }
+
+    [Fact]
+    public void Run_ReportsSuccess_WhenAllPkgsinfoParse()
+    {
+        CreatePkgInfo("good.yaml", @"name: GoodApp
+version: 1.0
+catalogs:
+  - Testing
+");
+
+        var exitCode = _builder.Run(_tempDir, skipPayloadCheck: true);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains(_successes, m => m.Contains("completed successfully"));
+    }
+
+    [Fact]
     public void VerifyPayloads_ReturnsEmptyForExistingPayloads()
     {
         // Arrange


### PR DESCRIPTION
Fixes #92.

A pkgsinfo that failed to deserialize was caught per-file, warned about mid-scan, and dropped. The run then printed `makecatalogs completed successfully.` and returned `0` — so the catalogs got published missing that package, with no signal any pipeline could act on.

That is not a no-op. Depending on manifest configuration, an item vanishing from the catalog means silent non-delivery of updates, or the item being treated as unmanaged. And the failure mode is worst for the case that triggers it most — a hand-edited pkgsinfo with a schema mistake (#91) — where the operator gets a green run and a quietly smaller catalog.

## Change

Parse failures are now collected on the builder (exposed as `ParseErrors`, cleared per scan), restated in the end-of-run summary where they are actually visible rather than scrolled past mid-scan, and the run exits `1`.

The payload-verification warnings already worked this way — collected into a list and reported at the end. Parse failures were the outlier.

`ScanRepo` keeps its signature, so callers and existing tests are unaffected.

## ⚠️ This changes exit-code behaviour — please sanity-check against the pipelines

**Any pipeline running `makecatalogs` over a repo that currently contains an unparseable pkgsinfo will start failing.** That is the intent — better than publishing an incomplete catalog — but it is a behaviour change on a tool in the fleet publish path, so it deserves a look before merge rather than after.

`--tolerate_parse_errors` is the escape hatch: it keeps the old exit code, still prints the skipped list, and still does not claim "completed successfully" — it reports how many were skipped instead, so the outcome stays visible either way.

If you would rather this defaulted the other way (warn loudly, exit 0, with a `--strict` opt-in), that is a one-line flip of the default — say so and I'll switch it.

## Testing

`dotnet test tests/Cimian.Tests.csproj` → **945 passed, 2 failed**. Both failures are `ConfigurationServiceTests` and reproduce on unmodified `main` — unrelated.

Five new cases: parse errors recorded, cleared between scans, the run failing without claiming success, the tolerate flag succeeding while still reporting skipped, and a clean repo still reporting success. The failure case asserts on both the exit code and the absence of the success message, since both were part of the regression.
