### PR TITLE
Treat an MSI with no File table as a wrapper

### DIFF
--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -1983,6 +1983,26 @@ exit 0
                     if (!msiFound)
                     {
                         var reason = $"MSI not registered in Windows Installer (ProductCode={install.ProductCode}, UpgradeCode={install.UpgradeCode})";
+
+                        // Second net for wrapper MSIs that were not classified as such at
+                        // import time, so the installs entry carries no display_name and the
+                        // fallback above could not run. Deliberately advisory, not a pass:
+                        // an ARP name match is weaker evidence than the declared codes, and
+                        // silently accepting it would mask a genuinely missing install. But
+                        // the bare message above is unactionable -- the admin sees the app
+                        // plainly installed and is told it is not. Naming the ARP entry we
+                        // can see turns that dead end into the exact fix.
+                        var probe = !string.IsNullOrWhiteSpace(item.DisplayName) ? item.DisplayName : item.Name;
+                        if (!string.IsNullOrWhiteSpace(probe) && string.IsNullOrEmpty(install.DisplayName))
+                        {
+                            var arpHit = FindArpVersionByDisplayName(probe);
+                            if (!string.IsNullOrEmpty(arpHit))
+                            {
+                                reason += $"; an ARP entry matching \"{probe}\" version {arpHit} is present"
+                                    + $" -- add `display_name: {probe}` to the installs entry to verify against it";
+                            }
+                        }
+
                         ConsoleLogger.Warn($"Verification failed for {item.Name}: {reason}");
                         return (false, reason);
                     }

--- a/shared/import/Services/MsiBomReader.cs
+++ b/shared/import/Services/MsiBomReader.cs
@@ -71,13 +71,33 @@ public static class MsiBomReader
     }
 
     /// <summary>
-    /// True when the MSI's File table has at least one row. Wrapper MSIs
-    /// (payload embedded in the Binary table, installed by a custom action)
-    /// have an empty File table. Fails soft to true on read errors so an
-    /// unreadable MSI is never misclassified as a wrapper.
+    /// True when the MSI installs files of its own. Wrapper MSIs (payload
+    /// embedded in the Binary table, installed by a custom action) either have
+    /// an empty File table or no File table at all.
     /// </summary>
+    /// <remarks>
+    /// A <em>missing</em> File table is checked before the query rather than
+    /// being left to the catch below. Selecting from a table that does not
+    /// exist throws, and the catch fails soft to true -- so the purest wrapper
+    /// shape, the one with no File table whatsoever, was reported as installing
+    /// files and never classified as a wrapper. That suppressed the
+    /// ArpDisplayName hint in MetadataExtractor, which in turn suppressed the
+    /// runtime's ARP DisplayName fallback, surfacing as "MSI not registered in
+    /// Windows Installer" for a product that had installed correctly.
+    ///
+    /// Failing soft to true is still right for a genuine read error: an
+    /// unreadable MSI must not be misclassified as a wrapper, because a fuzzy
+    /// ARP match could mask an install that really is missing. A well-formed
+    /// MSI with no File table is not an error condition -- it is the signal.
+    /// </remarks>
     public static bool HasInstalledFiles(Database db)
     {
+        // Not an error: no File table means the MSI lays down no payload itself.
+        if (!db.Tables.Contains("File"))
+        {
+            return false;
+        }
+
         try
         {
             using var view = db.OpenView("SELECT `File` FROM `File`");

--- a/tests/CLI/Cimiimport/MsiBomReaderTests.cs
+++ b/tests/CLI/Cimiimport/MsiBomReaderTests.cs
@@ -1,5 +1,6 @@
 using Xunit;
 using Cimian.CLI.Cimiimport.Services;
+using WixToolset.Dtf.WindowsInstaller;
 
 namespace Cimian.Tests.CLI.Cimiimport;
 
@@ -93,5 +94,63 @@ public class MsiBomReaderTests
         var result = MsiBomReader.PickPrimaryBinary(files, "");
 
         Assert.Equal(@"C:\Program Files\Vendor\big.exe", result);
+    }
+}
+
+/// <summary>
+/// HasInstalledFiles decides whether an MSI is a "wrapper" (no payload of its
+/// own). That single boolean gates the ArpDisplayName hint, which gates the
+/// runtime's ARP DisplayName fallback -- so getting it wrong surfaces as
+/// "MSI not registered in Windows Installer" for a product that installed fine.
+/// These build real MSI databases because the distinction under test is
+/// table-missing vs table-empty, which cannot be expressed without one.
+/// </summary>
+public class MsiBomReaderHasInstalledFilesTests : IDisposable
+{
+    private readonly List<string> _temp = new();
+
+    private Database NewMsi()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"bomtest_{Guid.NewGuid():N}.msi");
+        _temp.Add(path);
+        return new Database(path, DatabaseOpenMode.CreateDirect);
+    }
+
+    public void Dispose()
+    {
+        foreach (var p in _temp)
+        {
+            try { if (File.Exists(p)) File.Delete(p); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NoFileTable_IsWrapper()
+    {
+        // The regression: SELECT from a nonexistent table throws, and the catch
+        // failed soft to true, so the purest wrapper shape -- no File table at
+        // all -- was reported as installing files.
+        using var db = NewMsi();
+
+        Assert.False(MsiBomReader.HasInstalledFiles(db));
+    }
+
+    [Fact]
+    public void EmptyFileTable_IsWrapper()
+    {
+        using var db = NewMsi();
+        db.Execute("CREATE TABLE `File` (`File` CHAR(72) NOT NULL PRIMARY KEY `File`)");
+
+        Assert.False(MsiBomReader.HasInstalledFiles(db));
+    }
+
+    [Fact]
+    public void PopulatedFileTable_IsNotWrapper()
+    {
+        using var db = NewMsi();
+        db.Execute("CREATE TABLE `File` (`File` CHAR(72) NOT NULL PRIMARY KEY `File`)");
+        db.Execute("INSERT INTO `File` (`File`) VALUES ('payload.exe')");
+
+        Assert.True(MsiBomReader.HasInstalledFiles(db));
     }
 }


### PR DESCRIPTION
Fixes #102.

A user reported Firefox installing correctly and then failing verification:

```
Verification failed for Firefox: MSI not registered in Windows Installer
(ProductCode={1294A4C5-...}, UpgradeCode={3118AB4C-...})
```

The escape hatch for exactly this already existed — its comments name Mozilla Firefox as the motivating case — but could never fire.

## The chain

The runtime ARP DisplayName fallback needs `display_name` on the installs entry → cimiimport emits it only when `MetadataExtractor` sets `ArpDisplayName` → which happens only when `HasInstalledFiles` is false. And that selected from the `File` table inside a try/catch failing soft to `true`:

```csharp
try { using var view = db.OpenView("SELECT `File` FROM `File`"); ... }
catch { return true; }      // a missing File table lands here
```

So an MSI with **no File table at all** — payload embedded in the Binary table, run by a custom action — threw, was reported as installing files, and was never classified as a wrapper:

- File table present but empty → wrapper detected → fallback works
- File table absent entirely → exception → treated as having files → fallback can never fire

The stricter the wrapper, the more certainly it was misclassified. The comment said "gate strictly on the File table being empty"; the code treated *missing* as *non-empty*.

The missing-table case is now checked before the query, matching what `MsiPropertyReader` already does (`db.Tables.Contains("Property")`). Failing soft to `true` is kept for genuine read errors — an unreadable MSI must not be misclassified as a wrapper, since a fuzzy ARP match could mask an install that really is missing. A well-formed MSI with no File table is not an error condition; it is the signal.

## Second net

Verification failure now also handles wrapper MSIs that were not classified at import time and so carry no `display_name` at all. When the codes miss but an ARP entry matching the item's own display name is present, the message names it:

```
MSI not registered in Windows Installer (ProductCode=..., UpgradeCode=...);
an ARP entry matching "Mozilla Firefox" version 153.1.0 is present
-- add `display_name: Mozilla Firefox` to the installs entry to verify against it
```

**It stays a failure.** An ARP name match is weaker evidence than the declared codes, and accepting it silently would mask a missing install — the concern the existing comments raise. But the bare message was unactionable: the admin sees the app plainly installed and is told it is not, and the rational response is to abandon MSI detection entirely, which is what the reporter did.

## Testing

`dotnet test tests/Cimian.Tests.csproj` → **961 passed, 2 failed**. Both failures are `ConfigurationServiceTests` and reproduce on unmodified `main` — unrelated.

Three new cases covering no File table / empty File table / populated File table. These build real MSI databases via DTF `CreateDirect`, because the distinction under test is table-missing vs table-empty and cannot be expressed without one — the existing `MsiBomReaderTests` deliberately avoid `Database`, so this is a new harness rather than a change to those.

**I verified the coverage is real** by reverting the fix and confirming `NoFileTable_IsWrapper` fails, then restoring it.

## Note

I have not confirmed the File table state of the specific Firefox ESR MSI involved, so I cannot prove this is the exact path the reporter hit. The defect stands on its own reading of the code either way — but if you have that MSI to hand, checking it would settle whether this is the whole story or only part of it.

## Why this is upstream of the others

A package that cannot verify goes pending, so the rational workaround is to abandon the MSI codes and hand-author `type: file` detection. That then costs removal too, since a `type: file` entry contributes no removal mechanism (#90, #96). One root cause explains both of this user's reports.
