### PR TITLE
Fold package script output into the session log

### DIFF
--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -642,6 +642,11 @@ public class InstallerService
             _ => await InstallExeAsync(item, localFile, cancellationToken) // Default to EXE
         };
 
+        // The installer has returned, so any script it ran as an MSI custom action has
+        // finished writing. Fold that output into this session's log before branching on
+        // the result - a failed install is exactly when the script's output matters.
+        EmitPackageScriptOutput();
+
         if (!result.Success)
         {
             _sessionLogger?.LogInstall(item.Name, item.Version, "install", "failed", result.Output);
@@ -815,10 +820,48 @@ public class InstallerService
             }
         }
 
+        EmitPackageScriptOutput();
+
         // Remove from ManagedInstalls registry
         UnregisterInstallation(item);
 
         return result;
+    }
+
+    /// <summary>
+    /// Moves package script output out of the sidecar files the packaging tool's custom
+    /// actions leave behind and into this session's log.
+    /// </summary>
+    /// <remarks>
+    /// A pre/postinstall script packaged into an MSI runs as a custom action inside
+    /// msiexec, not as a child of this process, so there is no stdout for us to read.
+    /// The custom action redirects it to a file instead; this is the other half of that
+    /// handoff. Without it an install's story is split between the session log and a
+    /// parallel tree that nothing ingests - the packaging side already had to grow a
+    /// workaround where an installcheck tails the sidecar just to get its own output
+    /// into the run log.
+    /// </remarks>
+    /// <summary>
+    /// Same drain, exposed for the once-per-session sweep at startup.
+    /// </summary>
+    public void EmitPendingPackageScriptOutput() => EmitPackageScriptOutput();
+
+    private void EmitPackageScriptOutput()
+    {
+        foreach (var output in SessionLogger.CollectPackageScriptLogs())
+        {
+            foreach (var line in output.Lines)
+            {
+                ConsoleLogger.Detail($"[{output.Package}] {output.Phase} | {line}");
+            }
+
+            if (output.Truncated)
+            {
+                ConsoleLogger.Detail(
+                    $"[{output.Package}] {output.Phase} | ... output truncated at " +
+                    $"{SessionLogger.MaxPackageScriptLogLines} lines");
+            }
+        }
     }
 
     private string GetInstallerType(CatalogItem item, string localFile)

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -295,6 +295,11 @@ public class UpdateEngine : IDisposable
         _sessionLogger.Log("INFO", $"Session started: {sessionId}");
         _sessionLogger.Log("INFO", $"Run type: {runType}");
 
+        // Anything a package's install scripts wrote out-of-band since the last run -
+        // an install performed outside this client, or a session that died before it
+        // could collect them - belongs in this log rather than in a file nothing reads.
+        _installerService.EmitPendingPackageScriptOutput();
+
         // Now that verbosity is set and the SessionLogger is attached, surface the
         // LoopGuard kill-switch so it reaches both the console and run.log.
         if (loopGuardDisabled)

--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Cimian.Core.Models;
@@ -508,6 +509,159 @@ public class SessionLogger : IDisposable
         // state marker by looking - VerifyHarmony's sentinel was named ".log" and lived
         // right here. They expire on age like anything else, which is the correct signal
         // for "nothing is writing this any more".
+    }
+
+    /// <summary>
+    /// One package script's output, recovered from the sidecar file its MSI custom
+    /// action wrote.
+    /// </summary>
+    public sealed record PackageScriptOutput(
+        string Package, string Phase, IReadOnlyList<string> Lines, bool Truncated);
+
+    /// <summary>
+    /// A script that prints more than this has a problem of its own; the session log
+    /// should not become unreadable because of it.
+    /// </summary>
+    public const int MaxPackageScriptLogLines = 500;
+
+    private static readonly string[] ScriptPhases = { "preinstall", "postinstall", "uninstall" };
+
+    /// <summary>
+    /// Takes the output a package's install scripts produced and hands it back so the
+    /// caller can put it in this session's log. The sidecar files are removed as they
+    /// are read.
+    /// </summary>
+    /// <remarks>
+    /// A cimipkg pre/postinstall script runs as an MSI custom action inside msiexec,
+    /// not as a child of this process, so its stdout cannot be captured directly. The
+    /// custom action redirects it to a file, and this drains that file: it is a handoff
+    /// between two processes, not a log, and nothing should be left behind once its
+    /// contents are in the session log where ReportMate will pick them up.
+    ///
+    /// Draining here rather than changing what the custom action writes means every
+    /// package already deployed is covered without waiting for a rebuild — the same
+    /// reason <see cref="RelocateLegacyArtifacts(string, string)"/> exists.
+    /// </remarks>
+    public static IReadOnlyList<PackageScriptOutput> CollectPackageScriptLogs()
+        => CollectPackageScriptLogs(BaseLogsDir);
+
+    /// <summary>
+    /// Root is a parameter so this can be exercised against a temporary tree; the
+    /// production call site passes the real one.
+    /// </summary>
+    internal static IReadOnlyList<PackageScriptOutput> CollectPackageScriptLogs(string logsRoot)
+    {
+        var collected = new List<PackageScriptOutput>();
+
+        // Current layout: logs\packages\<Package>\<phase>.log
+        var packagesRoot = Path.Combine(logsRoot, "packages");
+        foreach (var dir in SafeGetDirectories(packagesRoot))
+        {
+            var package = Path.GetFileName(dir);
+            foreach (var file in SafeGetFiles(dir, "*.log"))
+            {
+                if (TryDrainScriptLog(file, package, Path.GetFileNameWithoutExtension(file), out var drained))
+                    collected.Add(drained);
+            }
+
+            TryRemoveEmptyDirectory(dir);
+        }
+
+        // Hand-rolled sidecars: <Package>-<phase>.log, flat at the logs root, written by
+        // package scripts that opened a file themselves instead of printing to stdout.
+        // Matched by suffix, never by "any .log here" — a file at this root can just as
+        // easily be a state marker owned by something else, and deleting one of those
+        // makes its package reinstall forever.
+        foreach (var phase in ScriptPhases)
+        {
+            var suffix = $"-{phase}.log";
+            foreach (var file in SafeGetFiles(logsRoot, $"*{suffix}"))
+            {
+                var name = Path.GetFileName(file);
+                if (name.Length <= suffix.Length)
+                    continue;
+
+                if (TryDrainScriptLog(file, name[..^suffix.Length], phase, out var drained))
+                    collected.Add(drained);
+            }
+        }
+
+        return collected;
+    }
+
+    /// <summary>
+    /// Reads a sidecar and removes it. Returns false when there was nothing worth
+    /// logging, or when the file could not be read — in which case it is left for the
+    /// next session rather than silently dropped.
+    /// </summary>
+    private static bool TryDrainScriptLog(
+        string file, string package, string phase, out PackageScriptOutput output)
+    {
+        output = null!;
+
+        string[] lines;
+        try
+        {
+            lines = File.ReadAllLines(file);
+        }
+        catch
+        {
+            // Still held open by its writer. Leave it; this runs every session.
+            return false;
+        }
+
+        var truncated = lines.Length > MaxPackageScriptLogLines;
+        var kept = truncated ? lines[..MaxPackageScriptLogLines] : lines;
+
+        // Delete only after a successful read. Losing the file without having recorded
+        // what was in it is worse than draining the same content twice.
+        try
+        {
+            File.Delete(file);
+        }
+        catch
+        {
+            return false;
+        }
+
+        // An empty sidecar means the script ran and printed nothing. The file is gone
+        // either way; there is just nothing to say about it.
+        var meaningful = kept.Where(line => !string.IsNullOrWhiteSpace(line)).ToArray();
+        if (meaningful.Length == 0)
+            return false;
+
+        output = new PackageScriptOutput(package, phase, meaningful, truncated);
+        return true;
+    }
+
+    private static IEnumerable<string> SafeGetDirectories(string directory)
+    {
+        try
+        {
+            return Directory.Exists(directory)
+                ? Directory.GetDirectories(directory)
+                : Array.Empty<string>();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    private static void TryRemoveEmptyDirectory(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory) &&
+                Directory.GetFileSystemEntries(directory).Length == 0)
+            {
+                Directory.Delete(directory);
+            }
+        }
+        catch
+        {
+            // Best-effort tidying; an empty directory harms nothing.
+        }
     }
 
     private static IEnumerable<string> SafeGetFiles(string directory, string pattern, bool recurse = false)

--- a/tests/Shared/PackageScriptLogDrainTests.cs
+++ b/tests/Shared/PackageScriptLogDrainTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Linq;
+using Cimian.Core.Services;
+using Xunit;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// Collection of the script output that MSI custom actions leave in sidecar files.
+/// </summary>
+/// <remarks>
+/// The behaviour these pin down: a package's install scripts run inside msiexec, so
+/// their output reaches this client only through a file. That file is a handoff, not a
+/// log — once its contents are in the session log (which is what ReportMate ingests)
+/// nothing should be left behind. Anything still sitting under the logs root afterwards
+/// is either not ours or is state, and both must survive untouched.
+/// </remarks>
+public class PackageScriptLogDrainTests : IDisposable
+{
+    private readonly string _logs;
+
+    public PackageScriptLogDrainTests()
+    {
+        _logs = Path.Combine(Path.GetTempPath(), "cimian-drain-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_logs);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_logs, recursive: true); } catch { }
+    }
+
+    private string Write(string relativePath, params string[] lines)
+    {
+        var full = Path.Combine(_logs, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllLines(full, lines);
+        return full;
+    }
+
+    private SessionLogger.PackageScriptOutput[] Drain()
+        => SessionLogger.CollectPackageScriptLogs(_logs).ToArray();
+
+    [Fact]
+    public void PerPackageSidecarIsReturnedAndRemoved()
+    {
+        var file = Write(Path.Combine("packages", "ExampleAgent", "postinstall.log"),
+            "Registry key exists", "Configuration applied");
+
+        var drained = Drain();
+
+        Assert.False(File.Exists(file));
+        var one = Assert.Single(drained);
+        Assert.Equal("ExampleAgent", one.Package);
+        Assert.Equal("postinstall", one.Phase);
+        Assert.Equal(new[] { "Registry key exists", "Configuration applied" }, one.Lines);
+        Assert.False(one.Truncated);
+    }
+
+    [Theory]
+    [InlineData("preinstall")]
+    [InlineData("postinstall")]
+    [InlineData("uninstall")]
+    public void EveryPhaseIsCollected(string phase)
+    {
+        Write(Path.Combine("packages", "App", $"{phase}.log"), "output");
+
+        var one = Assert.Single(Drain());
+
+        Assert.Equal(phase, one.Phase);
+    }
+
+    [Fact]
+    public void HandRolledSidecarAtTheLogsRootIsCollectedToo()
+    {
+        // Scripts that opened a file themselves instead of printing to stdout. This is
+        // what is actually sitting on already-deployed endpoints, so the drain has to
+        // cover it without waiting for every package to be rebuilt.
+        var file = Write("LocalAccountSetup-postinstall.log", "All verification checks passed.");
+
+        var drained = Drain();
+
+        Assert.False(File.Exists(file));
+        var one = Assert.Single(drained);
+        Assert.Equal("LocalAccountSetup", one.Package);
+        Assert.Equal("postinstall", one.Phase);
+    }
+
+    [Theory]
+    [InlineData("vendor-state-marker.log")]          // a state marker: deleting it reinstalls forever
+    [InlineData("installers.log")]               // third-party, not ours to consume
+    [InlineData("cimiwatcher20260824.log")]      // Serilog owns it
+    [InlineData("ManagedSoftwareUpdate.log")]
+    [InlineData("postinstall.log")]              // no package name in front of it
+    public void FilesAtTheRootThatAreNotOursAreLeftAlone(string name)
+    {
+        var file = Write(name, "content");
+
+        var drained = Drain();
+
+        Assert.Empty(drained);
+        Assert.True(File.Exists(file));
+    }
+
+    [Fact]
+    public void SessionDirectoriesAreNeverTouched()
+    {
+        var nested = Write(Path.Combine("2026-08-24", "1408", "install.log"), "the session log itself");
+
+        Assert.Empty(Drain());
+        Assert.True(File.Exists(nested));
+    }
+
+    [Fact]
+    public void BlankOutputIsRemovedButNotReported()
+    {
+        // The script ran and printed nothing. There is nothing to say, and leaving an
+        // empty file behind would defeat the point.
+        var file = Write(Path.Combine("packages", "Quiet", "preinstall.log"), "", "   ");
+
+        Assert.Empty(Drain());
+        Assert.False(File.Exists(file));
+    }
+
+    [Fact]
+    public void RunawayOutputIsCappedAndSaysSo()
+    {
+        var lines = Enumerable.Range(1, SessionLogger.MaxPackageScriptLogLines + 50)
+            .Select(i => $"line {i}").ToArray();
+        Write(Path.Combine("packages", "Chatty", "postinstall.log"), lines);
+
+        var one = Assert.Single(Drain());
+
+        Assert.True(one.Truncated);
+        Assert.Equal(SessionLogger.MaxPackageScriptLogLines, one.Lines.Count);
+        Assert.Equal("line 1", one.Lines[0]);
+    }
+
+    [Fact]
+    public void EmptiedPackageDirectoryIsCleanedUp()
+    {
+        Write(Path.Combine("packages", "Gone", "postinstall.log"), "done");
+
+        Drain();
+
+        Assert.False(Directory.Exists(Path.Combine(_logs, "packages", "Gone")));
+    }
+
+    [Fact]
+    public void DrainingTwiceIsSafeAndTheSecondPassFindsNothing()
+    {
+        Write(Path.Combine("packages", "App", "postinstall.log"), "first run");
+
+        Assert.Single(Drain());
+        Assert.Empty(Drain());
+    }
+
+    [Fact]
+    public void IsSilentWhenNothingHasBeenWritten()
+    {
+        Assert.Empty(Drain());
+    }
+}


### PR DESCRIPTION
## What

A pre/postinstall script packaged into an MSI runs as a custom action inside `msiexec`, not as a child of this client, so there is no stdout for us to capture. The custom action redirects it to a sidecar file instead.

Nothing ever collected those files. An install's story ended up split in two — the client's own account of it in the session log, and the script's actual output in a parallel tree that no reporting path reads.

This collects the sidecars and logs their contents through the normal path, which already writes both `install.log` and `reports/run.log`. The files are removed as they are read: they are a handoff between two processes, not a log.

## Why drain client-side rather than change what the custom action writes

Endpoints are carrying packages built long before any change here would land. Draining in the client covers those immediately instead of waiting for every package to be rebuilt.

It also retires a workaround that had grown on the packaging side, where an `installcheck_script` tailed the sidecar itself purely to get its own output into the run log. That is a symptom of the split this fixes.

## Where it runs

- after an install
- after an uninstall

Both run *before* the result is branched on — a failed install is exactly when the script's output matters.

- once at session start, for anything left behind by an install performed outside the client, or by a session that died before it could collect.

## Safety

Matching at the logs root is by `<package>-<phase>.log` suffix, never by "any `.log` here". A file at that root can just as easily be a state marker owned by something else, and consuming one of those would make its package reinstall forever. There is a test for each of those cases.

Output is capped per script, and the cap is reported in the log rather than silently applied.

## Tests

16 new cases covering both layouts, all three phases, the files that must be left alone, session directories, empty output, the cap, idempotency, and cleanup of emptied directories.

`Failed: 0, Passed: 956` overall. The 2 remaining failures are the pre-existing `ConfigurationServiceTests` ones on `main`, untouched by this change.