### PR TITLE
Skip convergence verification for OnDemand items

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -3327,6 +3327,16 @@ public class UpdateEngine : IDisposable
     /// </summary>
     private (string? Warning, bool PendingRestart) VerifyConvergence(CatalogItem item)
     {
+        // OnDemand items never converge by design: CheckStatus reports them as
+        // needing action on every call, before any installcheck runs, because
+        // they are (re)installed each time they are requested and never recorded
+        // as installed. Probing one here always produces the "did not converge"
+        // warning and a 24h suppression, so every bootstrap and provisioning
+        // helper lights up as a broken pkgsinfo the moment it runs. There is
+        // nothing to verify for them.
+        if (item.OnDemand)
+            return (null, false);
+
         try
         {
             var status = _statusService.CheckStatus(item, "install", _config.CachePath);


### PR DESCRIPTION
The post-install convergence probe added with the LoopGuard redesign runs `CheckStatus` after a successful install and warns when the item still reports action needed. `CheckStatus` returns *needs action* for every `OnDemand` item unconditionally (priority 0, before any installcheck), so the probe can never pass for them: every OnDemand helper in a bootstrap manifest gets the `installcheck did not converge` warning and a 24h suppression the first time it runs, and shows up in reporting as a broken pkgsinfo.

Skip the probe for `OnDemand` items. There is no convergence to prove for something that is reinstalled by design each time it is requested.