### PR TITLE
Honour installer_timeout per item and let policy set CacheRetentionDays

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -207,6 +207,10 @@ public class PkgsInfo
     [YamlMember(Alias = "restart_action")]
     public string? RestartAction { get; set; }
 
+    /// <summary>Per-item override of the fleet InstallerTimeout, in seconds, for payloads that legitimately run long.</summary>
+    [YamlMember(Alias = "installer_timeout")]
+    public int? InstallerTimeout { get; set; }
+
     [YamlMember(Alias = "force_install_after_date")]
     public DateTime? ForceInstallAfterDate { get; set; }
 

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -486,6 +486,10 @@ public class CatalogItem
     [YamlMember(Alias = "restart_action")]
     public string? RestartAction { get; set; }
 
+    /// <summary>Per-item override of the fleet InstallerTimeout, in seconds, for payloads that legitimately run long.</summary>
+    [YamlMember(Alias = "installer_timeout")]
+    public int? InstallerTimeout { get; set; }
+
     [YamlMember(Alias = "version_script")]
     public string? VersionScript { get; set; }
 

--- a/cli/managedsoftwareupdate/Services/ConfigurationService.cs
+++ b/cli/managedsoftwareupdate/Services/ConfigurationService.cs
@@ -77,6 +77,20 @@ public class ConfigurationService
             {
                 config.InstallerTimeout = timeout;
             }
+
+            // Cache retention is the only lever against superseded multi-gigabyte
+            // payloads filling small system drives; let policy set it fleet-wide.
+            var retentionRaw = key.GetValue("CacheRetentionDays");
+            var retention = retentionRaw switch
+            {
+                int i => i,
+                string s when int.TryParse(s, out var parsed) => parsed,
+                _ => int.MinValue
+            };
+            if (retention != int.MinValue && retention >= 0)
+            {
+                config.CacheRetentionDays = retention;
+            }
         }
         catch (Exception ex)
         {

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -274,8 +274,9 @@ public class InstallerService
         var args = argsBuilder.ToString();
 
         // Use configured timeout or default to 30 minutes
-        var timeoutMinutes = _config.InstallerTimeout > 0 
-            ? _config.InstallerTimeout / 60 
+        var effectiveTimeout = item.InstallerTimeout is > 0 ? item.InstallerTimeout.Value : _config.InstallerTimeout;
+        var timeoutMinutes = effectiveTimeout > 0
+            ? effectiveTimeout / 60
             : 30;
 
         ConsoleLogger.Debug($"sbin-installer command: {sbinPath} {args}");
@@ -955,7 +956,7 @@ public class InstallerService
                     CreateNoWindow = true
                 };
 
-                var (ok, output) = await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken);
+                var (ok, output) = await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken, item.InstallerTimeout);
                 if (ok) return (true, output);
 
                 // 1618 = ERROR_INSTALL_ALREADY_RUNNING. Retry with backoff.
@@ -1154,7 +1155,7 @@ public class InstallerService
             CreateNoWindow = true
         };
 
-        return await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken);
+        return await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken, item.InstallerTimeout);
     }
 
     private async Task<(bool Success, string Output)> InstallChocolateyAsync(
@@ -1200,7 +1201,7 @@ public class InstallerService
             CreateNoWindow = true
         };
 
-        return await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken);
+        return await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken, item.InstallerTimeout);
     }
 
     /// <summary>
@@ -1858,10 +1859,16 @@ exit 0
     private async Task<(bool Success, string Output)> RunProcessWithTimeoutAsync(
         ProcessStartInfo startInfo,
         string itemName,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int? itemTimeoutSeconds = null)
     {
         var output = new StringBuilder();
-        var timeout = TimeSpan.FromSeconds(_config.InstallerTimeout);
+        // A pkgsinfo may declare installer_timeout for payloads that legitimately
+        // take longer than the fleet default (multi-gigabyte packages). Until now
+        // the field was parsed and ignored, so those installs were killed at the
+        // global limit, counted as failed installs, and looped.
+        var timeoutSeconds = itemTimeoutSeconds is > 0 ? itemTimeoutSeconds.Value : _config.InstallerTimeout;
+        var timeout = TimeSpan.FromSeconds(timeoutSeconds);
 
         ConsoleLogger.Detail($"Launching process: {startInfo.FileName}");
         if (!string.IsNullOrEmpty(startInfo.Arguments))


### PR DESCRIPTION
`installer_timeout` was parsed into the shared `CatalogItem` but the installer only ever read the fleet `InstallerTimeout`, so packages that legitimately run longer than the global limit (multi-gigabyte payloads) were killed at that limit every session, counted as failed installs, and ended up as LoopGuard rapid-fire loops. This carries the field into the managedsoftwareupdate and makecatalogs models and applies it, when set, to the sbin-installer and generic process timeouts.

`CacheRetentionDays` is the only lever against superseded multi-gigabyte payloads filling small system drives, but it could only be set per device in Config.yaml. It is now accepted from the same policy registry key as the other overrides so it can be set fleet-wide.

Both affected projects build; no behaviour change for pkgsinfo that do not set `installer_timeout`.