### PR TITLE
Let a pkgsinfo declare extra success exit codes for its installer

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -25,6 +25,9 @@ public class Installer
 
     [YamlMember(Alias = "flags")]
     public List<string>? Flags { get; set; }
+    /// <summary>Additional process exit codes to treat as a successful install, beyond 0 and 3010 (e.g. an installer that returns 2 for "installed, reboot recommended").</summary>
+    [YamlMember(Alias = "success_codes")]
+    public List<int>? SuccessCodes { get; set; }
 
     [YamlMember(Alias = "subcommand")]
     public string? Subcommand { get; set; }

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -741,6 +741,9 @@ public class InstallerInfo
     /// </summary>
     [YamlMember(Alias = "flags")]
     public List<string> Flags { get; set; } = new();
+    /// <summary>Additional process exit codes to treat as a successful install, beyond 0 and 3010 (e.g. an installer that returns 2 for "installed, reboot recommended").</summary>
+    [YamlMember(Alias = "success_codes")]
+    public List<int>? SuccessCodes { get; set; }
 
     /// <summary>
     /// Subcommand placed before flags/switches (e.g., "install")

--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Runtime.InteropServices;
@@ -956,7 +957,7 @@ public class InstallerService
                     CreateNoWindow = true
                 };
 
-                var (ok, output) = await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken, item.InstallerTimeout);
+                var (ok, output) = await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken, item.InstallerTimeout, item.Installer?.SuccessCodes);
                 if (ok) return (true, output);
 
                 // 1618 = ERROR_INSTALL_ALREADY_RUNNING. Retry with backoff.
@@ -1155,7 +1156,7 @@ public class InstallerService
             CreateNoWindow = true
         };
 
-        return await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken, item.InstallerTimeout);
+        return await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken, item.InstallerTimeout, item.Installer?.SuccessCodes);
     }
 
     private async Task<(bool Success, string Output)> InstallChocolateyAsync(
@@ -1201,7 +1202,7 @@ public class InstallerService
             CreateNoWindow = true
         };
 
-        return await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken, item.InstallerTimeout);
+        return await RunProcessWithTimeoutAsync(startInfo, item.Name, cancellationToken, item.InstallerTimeout, item.Installer?.SuccessCodes);
     }
 
     /// <summary>
@@ -1860,7 +1861,8 @@ exit 0
         ProcessStartInfo startInfo,
         string itemName,
         CancellationToken cancellationToken,
-        int? itemTimeoutSeconds = null)
+        int? itemTimeoutSeconds = null,
+        IEnumerable<int>? extraSuccessCodes = null)
     {
         var output = new StringBuilder();
         // A pkgsinfo may declare installer_timeout for payloads that legitimately
@@ -1924,8 +1926,14 @@ exit 0
             var exitCode = process.ExitCode;
             ConsoleLogger.Detail($"Process exited with code {exitCode}");
             
-            // Common success exit codes
-            if (exitCode == 0 || exitCode == 3010) // 3010 = reboot required
+            // Common success exit codes, plus any the pkgsinfo declares under
+            // installer.success_codes for installers with their own convention.
+            var declaredSuccess = extraSuccessCodes != null && extraSuccessCodes.Contains(exitCode);
+            if (declaredSuccess)
+            {
+                output.AppendLine($"Note: exit code {exitCode} is declared a success code for this installer");
+            }
+            if (exitCode == 0 || exitCode == 3010 || declaredSuccess) // 3010 = reboot required
             {
                 if (exitCode == 3010)
                 {


### PR DESCRIPTION
The process runner accepted only exit 0 and 3010. Some installers have their own convention (e.g. return 2 for a completed install that recommends a reboot), so every fresh install was recorded as failed although the payload was on disk and verified a minute later.

`installer.success_codes` (list of ints) is carried through makecatalogs and the client model, and the runner treats those codes as success (logged as such in the output). Absent, behaviour is unchanged. Both affected projects build.