### PR TITLE
Drain the shared installers.log instead of stepping around it

### DIFF
--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -527,6 +527,22 @@ public class SessionLogger : IDisposable
     private static readonly string[] ScriptPhases = { "preinstall", "postinstall", "uninstall" };
 
     /// <summary>
+    /// Shared files that package scripts used to append to instead of printing to
+    /// stdout. Matched by exact name, never by pattern: a file at the logs root can be
+    /// a state marker owned by something else.
+    /// </summary>
+    /// <remarks>
+    /// Every script that wrote these has since been changed to print to stdout, but the
+    /// deployed payloads still carry the old version, so the file is recreated on every
+    /// install until each package happens to be rebuilt. Draining it retires the file on
+    /// every machine now, and puts the contents somewhere ReportMate actually reads.
+    ///
+    /// These are aggregates -- many packages appended to one file -- so the lines cannot
+    /// be attributed to a single package the way a sidecar can.
+    /// </remarks>
+    private static readonly string[] LegacyAggregateLogs = { "installers.log" };
+
+    /// <summary>
     /// Takes the output a package's install scripts produced and hands it back so the
     /// caller can put it in this session's log. The sidecar files are removed as they
     /// are read.
@@ -584,6 +600,17 @@ public class SessionLogger : IDisposable
                 if (TryDrainScriptLog(file, name[..^suffix.Length], phase, out var drained))
                     collected.Add(drained);
             }
+        }
+
+        // Shared aggregate files, matched by exact name.
+        foreach (var name in LegacyAggregateLogs)
+        {
+            var file = Path.Combine(logsRoot, name);
+            if (!File.Exists(file))
+                continue;
+
+            if (TryDrainScriptLog(file, name, "legacy", out var drained))
+                collected.Add(drained);
         }
 
         return collected;

--- a/tests/Shared/PackageScriptLogDrainTests.cs
+++ b/tests/Shared/PackageScriptLogDrainTests.cs
@@ -88,8 +88,12 @@ public class PackageScriptLogDrainTests : IDisposable
     }
 
     [Theory]
+    /// <remarks>
+    /// "installers.log" used to be listed here as third-party. It is not: every line in
+    /// it comes from one of our own package scripts, each of which has since been
+    /// changed to print to stdout instead. It is drained above.
+    /// </remarks>
     [InlineData("vendor-state-marker.log")]          // a state marker: deleting it reinstalls forever
-    [InlineData("installers.log")]               // third-party, not ours to consume
     [InlineData("cimiwatcher20260824.log")]      // Serilog owns it
     [InlineData("ManagedSoftwareUpdate.log")]
     [InlineData("postinstall.log")]              // no package name in front of it
@@ -160,5 +164,50 @@ public class PackageScriptLogDrainTests : IDisposable
     public void IsSilentWhenNothingHasBeenWritten()
     {
         Assert.Empty(Drain());
+    }
+
+    [Fact]
+    public void SharedInstallersLogIsDrainedAndRemoved()
+    {
+        // Several packages appended to this one file instead of printing to stdout, so
+        // its contents never reached the session log and nothing ever expired it.
+        var file = Write("installers.log",
+            "Example app installed on 2026-01-01 00:00:00.",
+            "Another app installed on 2026-01-01 00:01:00.");
+
+        var drained = Drain();
+
+        Assert.False(File.Exists(file));
+        var one = Assert.Single(drained);
+        Assert.Equal("installers.log", one.Package);
+        Assert.Equal("legacy", one.Phase);
+        Assert.Equal(2, one.Lines.Count);
+    }
+
+    [Fact]
+    public void SharedInstallersLogIsCappedLikeAnySidecar()
+    {
+        Write("installers.log",
+            Enumerable.Range(0, SessionLogger.MaxPackageScriptLogLines + 50)
+                .Select(i => $"line {i}").ToArray());
+
+        var one = Assert.Single(Drain());
+
+        Assert.True(one.Truncated);
+        Assert.Equal(SessionLogger.MaxPackageScriptLogLines, one.Lines.Count);
+    }
+
+    [Fact]
+    public void UnrelatedLogsAtTheRootAreLeftAlone()
+    {
+        // A file at this root can be a state marker whose existence means "already
+        // done". Draining one would make its package reinstall forever.
+        var sentinel = Write("verifiedHarmony.log", "done");
+        var watcher = Write("cimiwatcher20260101.log", "service started");
+
+        Drain();
+
+        Assert.True(File.Exists(sentinel));
+        Assert.True(File.Exists(watcher));
     }
 }


### PR DESCRIPTION
Closes #112.

Several package scripts used to append to a single shared `installers.log` at the logs root instead of printing to stdout. All of them print to stdout now, but that only reaches a machine when the package is rebuilt — deployed payloads still carry the old script, so the file reappears on the next install of any contributing package.

The drain stepped around it, and a `[Theory]` case pinned it as third-party. That was wrong: every line in the file comes from one of our own package scripts. The effect of leaving it:

- the lines never reach the session log, because they were never on stdout for the packaging tool to capture;
- nothing ever expires it — it sits outside the dated session tree, and it is rewritten often enough to stay permanently younger than any retention window, so an age-based sweep can never reach it.

Draining by exact name retires the file on every machine at the next session, without waiting for each package to be rebuilt — the same reasoning that put the sidecar drain in rather than changing what the custom action writes.

Matching stays by exact name, never a pattern. A file at that root can be a state marker whose existence means "already done", and consuming one would make its package reinstall forever. The theory covering that is unchanged apart from dropping this one name, with a note recording why the classification changed.

### Tests
18 in the drain suite pass. Three new: the file is drained and removed, it is capped like any other sidecar, and unrelated files at the root — a state marker and the watcher's own Serilog file — are still left untouched.

Two `ConfigurationServiceTests` failures in the full suite are pre-existing and fail identically on clean `main`; they read the local machine's config.