### PR TITLE
Point --clean-cache at the cache that actually exists

### DIFF
--- a/cli/managedsoftwareupdate/Program.cs
+++ b/cli/managedsoftwareupdate/Program.cs
@@ -475,10 +475,20 @@ public class Program
         Console.WriteLine("Cleaning Cimian Cache");
         Console.WriteLine("════════════════════════════");
 
-        var cacheDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "Cimian", "Cache");
+        // %ProgramData%\ManagedInstalls\Cache. This used to build its own
+        // %ProgramData%\Cimian\Cache, which is not where the cache has ever been, so
+        // the command found no directory, reported nothing to clean and exited 0 while
+        // the real cache kept growing.
+        return CleanCacheDirectory(CimianPaths.CacheDir);
+    }
 
+    /// <summary>
+    /// Deletes everything under <paramref name="cacheDir"/> and removes the directories
+    /// left empty behind it. Takes the directory as a parameter so the behaviour can be
+    /// exercised against a temporary tree.
+    /// </summary>
+    internal static int CleanCacheDirectory(string cacheDir)
+    {
         if (!Directory.Exists(cacheDir))
         {
             Console.WriteLine("Cache directory does not exist. Nothing to clean.");

--- a/tests/Managedsoftwareupdate/CleanCacheTests.cs
+++ b/tests/Managedsoftwareupdate/CleanCacheTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using Cimian.CLI.managedsoftwareupdate;
+using Cimian.Core;
+using Xunit;
+
+namespace Cimian.Tests.Managedsoftwareupdate;
+
+/// <summary>
+/// The --clean-cache command.
+/// </summary>
+/// <remarks>
+/// The regression these pin down: the command resolved its own
+/// %ProgramData%\Cimian\Cache rather than the cache root everything else uses. That
+/// directory has never existed, so the command reported "nothing to clean" and exited
+/// successfully no matter how large the real cache had grown.
+/// </remarks>
+public class CleanCacheTests : IDisposable
+{
+    private readonly string _root;
+
+    public CleanCacheTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cimian-clean-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void TargetsTheCacheDirectoryTheRestOfTheClientUses()
+    {
+        Assert.Equal(
+            Path.Combine(CimianPaths.ManagedInstallsRoot, "Cache"),
+            CimianPaths.CacheDir);
+    }
+
+    [Fact]
+    public void RemovesCachedPayloadsIncludingNestedOnes()
+    {
+        var top = Path.Combine(_root, "payload.msi");
+        var nested = Path.Combine(_root, "SomePackage", "payload.pkg");
+        Directory.CreateDirectory(Path.GetDirectoryName(nested)!);
+        File.WriteAllText(top, "x");
+        File.WriteAllText(nested, "x");
+
+        var exit = Program.CleanCacheDirectory(_root);
+
+        Assert.Equal(0, exit);
+        Assert.False(File.Exists(top));
+        Assert.False(File.Exists(nested));
+    }
+
+    [Fact]
+    public void RemovesTheDirectoriesLeftEmptyBehindIt()
+    {
+        var nested = Path.Combine(_root, "SomePackage", "payload.pkg");
+        Directory.CreateDirectory(Path.GetDirectoryName(nested)!);
+        File.WriteAllText(nested, "x");
+
+        Program.CleanCacheDirectory(_root);
+
+        Assert.False(Directory.Exists(Path.Combine(_root, "SomePackage")));
+    }
+
+    [Fact]
+    public void SucceedsQuietlyWhenThereIsNoCacheDirectory()
+    {
+        var exit = Program.CleanCacheDirectory(Path.Combine(_root, "not-there"));
+
+        Assert.Equal(0, exit);
+    }
+}


### PR DESCRIPTION
Closes #114.

`--clean-cache` ("Perform comprehensive cache cleanup and exit") built its own `%ProgramData%\Cimian\Cache`. The cache root is `%ProgramData%\ManagedInstalls\Cache` — `CimianPaths.CacheDir`, which the download service and loop guard already use — and nothing creates the directory it was looking for.

The result: it took the "no such directory" branch, printed `Cache directory does not exist. Nothing to clean.` and returned **0**. Success, doing nothing, on machines whose real cache is tens of gigabytes. The zero exit and the reassuring message are what kept it invisible — this is the command you reach for when a disk is filling.

`CimianPaths` exists so the layout is defined exactly once; this call site bypassed it. It now resolves `CimianPaths.CacheDir`.

The cleanup body moves to an internal `CleanCacheDirectory(string)` so it can be exercised against a temporary tree rather than the live cache.

I grepped for other hardcoded `CommonApplicationData` roots while here: the only two others rebuild `ManagedInstalls` by hand but land on the right directory, so they are a consistency nit and are left alone.

### Tests
4 new: the cache constant resolves under `ManagedInstalls`, nested payloads are removed, directories left empty are removed, and a missing directory still exits 0. 978 pass.

The two `ConfigurationServiceTests` failures are pre-existing and fail identically on clean `main` — they read the local machine's config.