### PR TITLE
Make a catalog change the fleet-wide loop clear

### DIFF
--- a/cli/makecatalogs/Models/PkgsInfo.cs
+++ b/cli/makecatalogs/Models/PkgsInfo.cs
@@ -238,6 +238,21 @@ public class PkgsInfo
     public bool Recurring { get; set; }
 
     /// <summary>
+    /// Content fingerprint of this catalog item, stamped by makecatalogs (see
+    /// CatalogBuilder.StampLoopFingerprints). Hashes the whole serialized item, so ANY
+    /// pkgsinfo edit that reaches the catalog changes it.
+    /// <para>
+    /// The client's LoopGuard clears a package's loop suppression when this value
+    /// changes: publishing a fix is what gets a suppressed package installing again
+    /// fleet-wide, with no per-machine <c>--clear-loop</c>. Excluded from its own hash
+    /// (it is nulled before hashing), and ignored by older clients, which tolerate
+    /// unknown catalog keys.
+    /// </para>
+    /// </summary>
+    [YamlMember(Alias = "loop_fingerprint")]
+    public string? LoopFingerprint { get; set; }
+
+    /// <summary>
     /// Source file path (not serialized)
     /// </summary>
     [YamlIgnore]

--- a/cli/makecatalogs/Services/CatalogBuilder.cs
+++ b/cli/makecatalogs/Services/CatalogBuilder.cs
@@ -173,6 +173,44 @@ public class CatalogBuilder
     }
 
     /// <summary>
+    /// Stamps every item with <c>loop_fingerprint</c> — a hash of the item's own catalog
+    /// content, and the fleet-wide lever for releasing LoopGuard suppression.
+    /// <para>
+    /// The client stores the fingerprint of the item it last installed and clears the
+    /// package's loop history the moment it sees a different one, so publishing a fixed
+    /// pkgsinfo is what gets a suppressed package installing again everywhere — nobody
+    /// has to run <c>--clear-loop</c> on individual machines.
+    /// </para>
+    /// <para>
+    /// Hashing the whole serialized item rather than a hand-picked field list is
+    /// deliberate: the previous client-side fingerprint covered version, scripts,
+    /// installer hash/location/type, installs[] and check, and therefore did NOT notice
+    /// fixes to product_code/upgrade_code, installer switches/arguments/success_codes,
+    /// blocking_applications, installer_timeout or requires — the exact fields our real
+    /// loop fixes touch. Anything makecatalogs carries into the catalog is covered here,
+    /// and stays covered as fields are added. The cost is that a description-only edit
+    /// also clears suppression; that errs toward retrying an install, which is the side
+    /// to err on.
+    /// </para>
+    /// <para>
+    /// Line endings are normalized first so the hash does not depend on whether the
+    /// pkgsinfo was last written on Windows or Linux.
+    /// </para>
+    /// </summary>
+    public void StampLoopFingerprints(List<PkgsInfo> items)
+    {
+        foreach (var pkg in items)
+        {
+            NormalizeLineEndings(pkg);
+
+            // Null it before hashing: the field is part of the serialized item, so
+            // including a previous value would make the hash depend on itself.
+            pkg.LoopFingerprint = null;
+            pkg.LoopFingerprint = LoopGuard.ComputeFingerprint(YamlUtils.SerializePkgInfo(pkg));
+        }
+    }
+
+    /// <summary>
     /// Builds catalog dictionaries from package info items
     /// Always includes "All" catalog containing all items
     /// </summary>
@@ -343,6 +381,11 @@ public class CatalogBuilder
             {
                 warnings = VerifyPayloads(repoPath, items, hashCheck);
             }
+
+            // Stamp per-item loop fingerprints before the items are fanned out into
+            // catalogs (the same instance appears in "All" and in each named catalog,
+            // so this has to happen once, up front).
+            StampLoopFingerprints(items);
 
             // Build catalogs
             var catalogs = BuildCatalogs(items, silent);

--- a/cli/managedsoftwareupdate/Models/UpdateModels.cs
+++ b/cli/managedsoftwareupdate/Models/UpdateModels.cs
@@ -515,6 +515,17 @@ public class CatalogItem
     [YamlMember(Alias = "installs")]
     public List<InstallCheckItem> Installs { get; set; } = new();
 
+    /// <summary>
+    /// Content fingerprint of this catalog item, stamped by makecatalogs. Changes
+    /// whenever ANY field of the pkgsinfo that reaches the catalog changes, and is what
+    /// LoopGuard compares to decide that a looping package has been fixed upstream and
+    /// its suppression should be cleared. Absent on catalogs written by an older
+    /// makecatalogs — UpdateEngine.ComputeCatalogFingerprint then falls back to hashing
+    /// the install-behavior fields locally.
+    /// </summary>
+    [YamlMember(Alias = "loop_fingerprint")]
+    public string? LoopFingerprint { get; set; }
+
     public bool IsUninstallable() => Uninstallable && (
         Uninstaller.Count > 0
         || Check.Registry.Name != null

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -70,16 +70,31 @@ public class UpdateEngine : IDisposable
     }
 
     /// <summary>
-    /// Computes a LoopGuard catalog fingerprint from a CatalogItem's install-behavior fields.
-    /// If ANY of these fields change in the pkgsinfo, the fingerprint changes and LoopGuard
-    /// auto-clears suppression — the admin may have fixed the root cause of the loop.
+    /// Computes the LoopGuard catalog fingerprint for an item. If it changes, LoopGuard
+    /// clears the package's loop suppression — the admin may have fixed the root cause.
     ///
-    /// Fields included: version, installcheck_script, installs array, check info,
-    /// installer hash/url/type, install_script, postinstall_script, preinstall_script.
+    /// <para>
+    /// The authoritative value is <c>loop_fingerprint</c>, stamped per item by
+    /// makecatalogs over the item's whole catalog content, so any pkgsinfo edit that
+    /// reaches the fleet clears the loop. Only when the catalog predates that field
+    /// (older, version-pinned makecatalogs) do we fall back to hashing the
+    /// install-behavior fields here — a hand-picked list that misses fixes to
+    /// product_code/upgrade_code, installer switches, blocking_applications and the
+    /// like, which is exactly why the server-side stamp exists.
+    /// </para>
     /// </summary>
     private static string ComputeCatalogFingerprint(CatalogItem item)
     {
         var sb = new System.Text.StringBuilder(512);
+
+        if (!string.IsNullOrWhiteSpace(item.LoopFingerprint))
+        {
+            sb.Append(item.LoopFingerprint);
+            sb.Append('|');
+            sb.Append(VersionService.GetRunningAgentVersion());
+            return LoopGuard.ComputeFingerprint(sb.ToString());
+        }
+
         sb.Append(item.Version);
         sb.Append('|');
         sb.Append(item.InstallcheckScript ?? "");

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -18,10 +18,13 @@ namespace Cimian.Core.Services;
 /// items.json with loop warnings for dashboards/monitoring. LoopGuard is the ACTIVE layer
 /// that integrates into UpdateEngine.IdentifyActions() to actually suppress looping packages.
 ///
-/// Auto-clear: when ANY install-behavior field in the pkgsinfo changes (version,
-/// installcheck_script, installs array, hash, scripts, etc.), suppression is automatically
-/// cleared — the root cause may have been fixed. Change detection uses a SHA256 fingerprint
-/// of all install-behavior fields, computed by the caller and passed as catalogFingerprint.
+/// Auto-clear: when the pkgsinfo behind a package changes, its loop history is cleared —
+/// the root cause may have been fixed. This is the CENTRAL lever: makecatalogs stamps a
+/// loop_fingerprint over each catalog item's whole content, the caller passes it as
+/// catalogFingerprint, and publishing a fix therefore gets a suppressed package installing
+/// again across the whole fleet without touching a single machine. It is evaluated whether
+/// or not suppression is currently active, and performs exactly the same reset as an
+/// explicit --clear-loop, so a fix is never judged on pre-fix history.
 ///
 /// Backoff strategy (finite — never a permanent blacklist, so a transient failure
 /// like a download outage self-heals on retry instead of needing a manual clear):
@@ -30,11 +33,15 @@ namespace Cimian.Core.Services;
 ///   8+ installs → suppress 7 days (the cap), then retry automatically
 ///   3 installs within 2 hours (rapid-fire) → suppress 12 hours
 ///
-/// A genuinely-broken package therefore retries at most once a week and re-suppresses;
-/// one whose root cause was fixed (pkgsinfo change auto-clears immediately, or the
-/// underlying failure simply went away) installs cleanly on its next window. Legacy
-/// permanently-suppressed entries (DateTime.MaxValue, written before this cap) are
-/// migrated to a finite window (LoopMaxTime) anchored on their last attempt when first seen.
+/// When a window expires the accumulated counters are retired with it, so the package is
+/// genuinely retried instead of instantly re-tripping the same thresholds on the same
+/// history; a persistent SuppressionCycles count floors the next window (1 prior cycle →
+/// 24h, 2+ → the 7-day cap), so a genuinely-broken package converges on a few installs a
+/// week and then goes quiet. One whose root cause was fixed (pkgsinfo change auto-clears
+/// immediately and resets the cycles, or the underlying failure simply went away)
+/// installs cleanly on its next window. Legacy permanently-suppressed entries
+/// (DateTime.MaxValue, written before this cap) are migrated to a finite window
+/// (LoopMaxTime) anchored on their last attempt when first seen.
 ///
 /// State persisted to: %ProgramData%\ManagedInstalls\reports\state.json
 /// Clear with: managedsoftwareupdate --clear-loop (name or all)
@@ -111,15 +118,14 @@ public class LoopGuard
     }
 
     /// <summary>
-    /// Computes a SHA256 fingerprint from the install-behavior fields of a catalog item.
-    /// The caller builds the input string by concatenating all fields that affect whether
-    /// an install succeeds or loops. If ANY field changes, the fingerprint changes and
-    /// LoopGuard auto-clears suppression.
+    /// Computes a short SHA256 fingerprint of arbitrary catalog content. If the input
+    /// changes, the fingerprint changes and LoopGuard clears the package's loop history.
     ///
-    /// Recommended fields to include (pipe-delimited):
-    ///   version | installcheck_script | installs (JSON) | check (JSON) |
-    ///   installer hash | installer url | installer type |
-    ///   install_script | postinstall_script | preinstall_script
+    /// Two callers share this so both sides agree on the algorithm: makecatalogs hashes
+    /// each serialized catalog item into its loop_fingerprint field (the authoritative
+    /// value), and UpdateEngine folds that — or, for catalogs written before the field
+    /// existed, a concatenation of the item's install-behavior fields — together with the
+    /// running agent version.
     /// </summary>
     public static string ComputeFingerprint(string fieldsConcat)
     {
@@ -164,49 +170,30 @@ public class LoopGuard
         // Check explicit suppression state first (from previous runs)
         if (_state.Packages.TryGetValue(key, out var pkgState))
         {
+            // Auto-clear: if the catalog fingerprint changed, the pkgsinfo was updated
+            // and the root cause may be fixed. This is deliberately evaluated BEFORE the
+            // suppression check and regardless of whether suppression is currently
+            // active: a package that has accumulated loop history but has not tripped
+            // yet must also start clean, otherwise the first install after the fix is
+            // judged on pre-fix evidence and trips immediately.
+            if (DetectCatalogChange(pkgState, version, catalogFingerprint, out var changeDetail))
+            {
+                ResetLoopHistory(pkgState, version, catalogFingerprint);
+                SaveState();
+                return (false, $"Auto-cleared: {changeDetail}");
+            }
+
+            // First sighting of a fingerprint for a package whose state predates it:
+            // record it (no clear — we have nothing to compare against) so the NEXT
+            // catalog change is detected instead of falling back to version-only.
+            if (!string.IsNullOrEmpty(catalogFingerprint) && string.IsNullOrEmpty(pkgState.CatalogFingerprint))
+            {
+                pkgState.CatalogFingerprint = catalogFingerprint;
+                SaveState();
+            }
+
             if (pkgState.SuppressedUntil.HasValue)
             {
-                // Auto-clear: if the catalog fingerprint changed, ANY install-behavior
-                // field in the pkgsinfo was updated — root cause may be fixed.
-                // Falls back to version-only comparison if no fingerprint is available.
-                bool catalogChanged = false;
-                string changeDetail = "";
-
-                if (!string.IsNullOrEmpty(catalogFingerprint) && !string.IsNullOrEmpty(pkgState.CatalogFingerprint))
-                {
-                    // Fingerprint comparison — covers version, scripts, hash, installs, etc.
-                    if (!string.Equals(catalogFingerprint, pkgState.CatalogFingerprint, StringComparison.OrdinalIgnoreCase))
-                    {
-                        catalogChanged = true;
-                        changeDetail = !string.Equals(version, pkgState.LastVersion, StringComparison.OrdinalIgnoreCase)
-                            ? $"catalog changed (version {pkgState.LastVersion} → {version})"
-                            : $"catalog changed (pkgsinfo fields updated, same version {version})";
-                    }
-                }
-                else if (!string.IsNullOrEmpty(version) && !string.IsNullOrEmpty(pkgState.LastVersion) &&
-                         !string.Equals(version, pkgState.LastVersion, StringComparison.OrdinalIgnoreCase))
-                {
-                    // Fallback: version-only comparison when fingerprint not available
-                    catalogChanged = true;
-                    changeDetail = $"catalog version changed from {pkgState.LastVersion} to {version}";
-                }
-
-                if (catalogChanged)
-                {
-                    pkgState.SuppressedUntil = null;
-                    pkgState.SuppressionReason = null;
-                    pkgState.AttemptCount = 0;
-                    pkgState.SessionCount = 0;
-                    pkgState.VersionAttempts.Clear();
-                    pkgState.RecentTimestamps.Clear();
-                    pkgState.PendingRestartSince = null;
-                    pkgState.ClearedAt = DateTime.UtcNow;
-                    pkgState.LastVersion = version;
-                    pkgState.CatalogFingerprint = catalogFingerprint;
-                    SaveState();
-                    return (false, $"Auto-cleared: {changeDetail}");
-                }
-
                 // Migrate any legacy permanent suppression (DateTime.MaxValue, written
                 // before the finite cap existed) to a concrete 7-day window anchored on
                 // the last real attempt. A package stranded permanently by a transient
@@ -225,15 +212,90 @@ public class LoopGuard
                     return (true, $"LOOP SUPPRESSED: {packageName} — suppressed for {FormatDuration(remaining)} ({pkgState.SuppressionReason}). Clear with: managedsoftwareupdate --clear-loop {packageName}");
                 }
 
-                // Suppression expired — clear it but keep history
-                pkgState.SuppressedUntil = null;
-                pkgState.SuppressionReason = null;
+                // Suppression expired. Retire the history that produced it as well as
+                // the window itself: the counters never decay, so leaving them intact
+                // meant the threshold pass below re-tripped on the same evidence and
+                // re-suppressed without the package ever being retried once — a permanent
+                // blacklist by the back door, and the opposite of the finite backoff
+                // documented above.
+                // SuppressionCycles survives the reset and floors the next window, so a
+                // genuinely-broken package still escalates to the 7-day cap.
+                pkgState.SuppressionCycles++;
+                var cycles = pkgState.SuppressionCycles;
+                ResetLoopHistory(pkgState, version, catalogFingerprint ?? pkgState.CatalogFingerprint);
+                pkgState.SuppressionCycles = cycles;
                 SaveState();
+                return (false, "");
             }
         }
 
         // Analyze current history for new loop conditions
         return AnalyzeForLoop(key, packageName, version);
+    }
+
+    /// <summary>
+    /// True when the catalog item backing this package has changed since the state was
+    /// written — the admin edited the pkgsinfo, so the root cause may be fixed.
+    /// Prefers the fingerprint (any install-behavior field) and falls back to a
+    /// version-only comparison when no fingerprint is available on either side.
+    /// </summary>
+    private static bool DetectCatalogChange(PackageLoopState pkgState, string version,
+                                            string? catalogFingerprint, out string changeDetail)
+    {
+        changeDetail = "";
+
+        if (!string.IsNullOrEmpty(catalogFingerprint) && !string.IsNullOrEmpty(pkgState.CatalogFingerprint))
+        {
+            if (string.Equals(catalogFingerprint, pkgState.CatalogFingerprint, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            changeDetail = !string.Equals(version, pkgState.LastVersion, StringComparison.OrdinalIgnoreCase)
+                ? $"catalog changed (version {pkgState.LastVersion} → {version})"
+                : $"catalog changed (pkgsinfo fields updated, same version {version})";
+            return true;
+        }
+
+        // Fallback: version-only comparison when no fingerprint is available
+        if (!string.IsNullOrEmpty(version) && !string.IsNullOrEmpty(pkgState.LastVersion) &&
+            !string.Equals(version, pkgState.LastVersion, StringComparison.OrdinalIgnoreCase))
+        {
+            changeDetail = $"catalog version changed from {pkgState.LastVersion} to {version}";
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Retires a package's accumulated loop history: drops the suppression window, zeroes
+    /// every counter the thresholds read, and stamps the ClearedAt watermark so the next
+    /// run's events.jsonl rebuild does not put it all back.
+    /// <para>
+    /// ProcessedSessions is cleared with the rest — without it SessionCount is recomputed
+    /// from "sessions ever seen" by the rebuild and snaps straight back to 3+, so the
+    /// session gate on every threshold was already satisfied and the package re-suppressed
+    /// on ~3 fresh installs rather than 3 fresh sessions. This is the same reset
+    /// <see cref="ClearLoop"/> performs: a catalog-driven clear must be exactly as strong
+    /// as the local one, since it is the central lever for getting a fixed package moving
+    /// again fleet-wide.
+    /// </para>
+    /// </summary>
+    private static void ResetLoopHistory(PackageLoopState pkgState, string version, string? catalogFingerprint)
+    {
+        pkgState.SuppressedUntil = null;
+        pkgState.SuppressionReason = null;
+        pkgState.AttemptCount = 0;
+        pkgState.SessionCount = 0;
+        pkgState.SuppressionCycles = 0;
+        pkgState.VersionAttempts.Clear();
+        pkgState.RecentTimestamps.Clear();
+        pkgState.ProcessedSessions.Clear();
+        pkgState.PendingRestartSince = null;
+        pkgState.ClearedAt = DateTime.UtcNow;
+        if (!string.IsNullOrEmpty(version))
+            pkgState.LastVersion = version;
+        if (!string.IsNullOrEmpty(catalogFingerprint))
+            pkgState.CatalogFingerprint = catalogFingerprint;
     }
 
     /// <summary>
@@ -351,15 +413,7 @@ public class LoopGuard
         var key = packageName.ToLowerInvariant();
         if (_state.Packages.TryGetValue(key, out var pkgState))
         {
-            pkgState.SuppressedUntil = null;
-            pkgState.SuppressionReason = null;
-            pkgState.AttemptCount = 0;
-            pkgState.SessionCount = 0;
-            pkgState.VersionAttempts.Clear();
-            pkgState.RecentTimestamps.Clear();
-            pkgState.ProcessedSessions.Clear();
-            pkgState.PendingRestartSince = null;
-            pkgState.ClearedAt = DateTime.UtcNow;
+            ResetLoopHistory(pkgState, version: "", catalogFingerprint: null);
             SaveState();
             return true;
         }
@@ -585,12 +639,8 @@ public class LoopGuard
         var recentCount = pkgState.RecentTimestamps.Count(t => t >= twoHoursAgo);
         if (recentCount >= 3)
         {
-            var suppressUntil = DateTime.UtcNow.AddHours(12);
-            pkgState.SuppressedUntil = suppressUntil;
-            var reason = $"Rapid-fire loop: {recentCount} installs within 2 hours";
-            pkgState.SuppressionReason = reason;
-            SaveState();
-            return (true, reason);
+            return Suppress(pkgState, TimeSpan.FromHours(12),
+                $"Rapid-fire loop: {recentCount} installs within 2 hours");
         }
 
         // Threshold 2: Same version reinstalled 3+ times across 3+ sessions
@@ -599,30 +649,27 @@ public class LoopGuard
             versionCount >= 3 && pkgState.SessionCount >= 3)
         {
             // Escalating backoff
-            DateTime suppressUntil;
+            TimeSpan window;
             string reason;
 
             if (versionCount >= 8)
             {
                 // Top tier — capped at 7 days (finite), then retries automatically
-                suppressUntil = DateTime.UtcNow.AddDays(_maxSuppressionDays);
+                window = TimeSpan.FromDays(_maxSuppressionDays);
                 reason = $"Persistent loop: version {version} installed {versionCount} times across {pkgState.SessionCount} sessions ({_maxSuppressionDays}-day suppression)";
             }
             else if (versionCount >= 5)
             {
-                suppressUntil = DateTime.UtcNow.AddHours(24);
+                window = TimeSpan.FromHours(24);
                 reason = $"Escalated loop: version {version} installed {versionCount} times across {pkgState.SessionCount} sessions (24h suppression)";
             }
             else
             {
-                suppressUntil = DateTime.UtcNow.AddHours(6);
+                window = TimeSpan.FromHours(6);
                 reason = $"Install loop: version {version} installed {versionCount} times across {pkgState.SessionCount} sessions (6h suppression)";
             }
 
-            pkgState.SuppressedUntil = suppressUntil;
-            pkgState.SuppressionReason = reason;
-            SaveState();
-            return (true, reason);
+            return Suppress(pkgState, window, reason);
         }
 
         // Threshold 3: High total attempt count across sessions (any version).
@@ -638,25 +685,50 @@ public class LoopGuard
         if (loopAttempts >= 8 && pkgState.SessionCount >= 5)
         {
             // Top tier — capped at 7 days (finite), then retries automatically
-            var suppressUntil = DateTime.UtcNow.AddDays(_maxSuppressionDays);
-            var reason = $"Persistent loop: {pkgState.AttemptCount} total installs across {pkgState.SessionCount} sessions ({_maxSuppressionDays}-day suppression)";
-            pkgState.SuppressedUntil = suppressUntil;
-            pkgState.SuppressionReason = reason;
-            SaveState();
-            return (true, reason);
+            return Suppress(pkgState, TimeSpan.FromDays(_maxSuppressionDays),
+                $"Persistent loop: {pkgState.AttemptCount} total installs across {pkgState.SessionCount} sessions ({_maxSuppressionDays}-day suppression)");
         }
 
         if (loopAttempts >= 5 && pkgState.SessionCount >= 4)
         {
-            var suppressUntil = DateTime.UtcNow.AddHours(24);
-            var reason = $"Escalated loop: {pkgState.AttemptCount} total installs across {pkgState.SessionCount} sessions (24h suppression)";
-            pkgState.SuppressedUntil = suppressUntil;
-            pkgState.SuppressionReason = reason;
-            SaveState();
-            return (true, reason);
+            return Suppress(pkgState, TimeSpan.FromHours(24),
+                $"Escalated loop: {pkgState.AttemptCount} total installs across {pkgState.SessionCount} sessions (24h suppression)");
         }
 
         return (false, "");
+    }
+
+    /// <summary>
+    /// Opens a suppression window, applying the escalation floor from
+    /// <see cref="PackageLoopState.SuppressionCycles"/>.
+    /// <para>
+    /// The raw counters are retired when a window expires so the package actually gets
+    /// retried; the cycle count is what remembers that it has been here before. One
+    /// served window floors the next at 24h, two or more at the 7-day cap — so a
+    /// genuinely-broken package converges on "3 installs a week, then quiet" instead of
+    /// looping every 6 hours forever, while a fixed one (catalog change or explicit
+    /// clear, both of which zero the cycles) starts from the bottom tier again.
+    /// </para>
+    /// </summary>
+    private (bool Suppress, string Reason) Suppress(PackageLoopState pkgState, TimeSpan window, string reason)
+    {
+        var floor = pkgState.SuppressionCycles switch
+        {
+            <= 0 => TimeSpan.Zero,
+            1 => TimeSpan.FromHours(24),
+            _ => TimeSpan.FromDays(_maxSuppressionDays)
+        };
+
+        if (floor > window)
+        {
+            window = floor;
+            reason += $" — escalated to {FormatDuration(window)} after {pkgState.SuppressionCycles} prior suppression window(s)";
+        }
+
+        pkgState.SuppressedUntil = DateTime.UtcNow + window;
+        pkgState.SuppressionReason = reason;
+        SaveState();
+        return (true, reason);
     }
 
     #endregion
@@ -961,6 +1033,7 @@ public class LoopGuard
             $"  Attempts: {pkgState.AttemptCount} across {pkgState.SessionCount} sessions",
             $"  Last version: {pkgState.LastVersion ?? "(unknown)"}",
             $"  Catalog fingerprint: {pkgState.CatalogFingerprint ?? "(none)"}",
+            $"  Suppression cycles served: {pkgState.SuppressionCycles}",
             $"  Last attempt: {pkgState.LastAttempt?.ToString("g") ?? "never"}",
             $"  Last success: {pkgState.LastSuccess}"
         };
@@ -1094,6 +1167,17 @@ public class PackageLoopState
     /// </summary>
     [JsonPropertyName("processed_sessions")]
     public HashSet<string> ProcessedSessions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Number of suppression windows this package has already served and exhausted.
+    /// Expiring a window resets the raw counters (so the package genuinely retries
+    /// instead of re-tripping instantly on the same history), and this survives that
+    /// reset to keep the backoff escalating: 1 prior cycle floors the next window at
+    /// 24h, 2+ floors it at the 7-day cap. A catalog change or an explicit clear
+    /// resets it to zero — that is a fix, and a fixed package starts clean.
+    /// </summary>
+    [JsonPropertyName("suppression_cycles")]
+    public int SuppressionCycles { get; set; }
 
     /// <summary>
     /// Watermark stamped by ClearLoop(). Same contract as LoopGuardState.ClearedAt

--- a/tests/LoopGuardTests.cs
+++ b/tests/LoopGuardTests.cs
@@ -584,6 +584,140 @@ public class LoopGuardTests : IDisposable
         reason.Should().Contain("Auto-cleared");
     }
 
+    [Fact]
+    public void FingerprintChange_ClearsHistory_EvenWhenNotYetSuppressed()
+    {
+        // A package can carry loop history without being suppressed yet. If the pkgsinfo
+        // is fixed at that point, the history must go too — otherwise the first install
+        // after the fix is judged on pre-fix evidence and trips immediately.
+        var guard = CreateGuard();
+        var before = LoopGuard.ComputeFingerprint("1.0.0|old");
+        var after = LoopGuard.ComputeFingerprint("1.0.0|fixed");
+
+        guard.RecordAttempt("NotYetPkg", "1.0.0", true, before);
+        guard.RecordAttempt("NotYetPkg", "1.0.0", true, before);
+        guard.ShouldSuppress("NotYetPkg", "1.0.0", before).Suppress.Should().BeFalse();
+        guard.GetPackageState("NotYetPkg")!.AttemptCount.Should().Be(2);
+
+        var (suppress, reason) = guard.ShouldSuppress("NotYetPkg", "1.0.0", after);
+
+        suppress.Should().BeFalse();
+        reason.Should().Contain("Auto-cleared");
+        var state = guard.GetPackageState("NotYetPkg")!;
+        state.AttemptCount.Should().Be(0);
+        state.VersionAttempts.Should().BeEmpty();
+        state.CatalogFingerprint.Should().Be(after);
+    }
+
+    [Fact]
+    public void FingerprintChange_ClearsProcessedSessions()
+    {
+        // SessionCount is recomputed from ProcessedSessions by the events rebuild, so
+        // leaving the set behind made the session gate on every threshold permanently
+        // satisfied and the package re-suppressed on ~3 installs instead of 3 sessions.
+        var guard = CreateGuard();
+        var before = LoopGuard.ComputeFingerprint("1.0.0|old");
+        var after = LoopGuard.ComputeFingerprint("1.0.0|fixed");
+
+        foreach (var session in new[] { "0900", "1000", "1100" })
+        {
+            guard.SetCurrentSession(Path.Combine(_logsDir, "2026-01-01", session));
+            guard.RecordAttempt("SessPkg", "1.0.0", true, before);
+        }
+
+        guard.GetPackageState("SessPkg")!.ProcessedSessions.Should().HaveCount(3);
+
+        guard.ShouldSuppress("SessPkg", "1.0.0", after);
+
+        var state = guard.GetPackageState("SessPkg")!;
+        state.ProcessedSessions.Should().BeEmpty();
+        state.SessionCount.Should().Be(0);
+        state.ClearedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void FingerprintChange_ResetsSuppressionCycles()
+    {
+        // A fix starts the backoff over: the escalation floor earned by earlier windows
+        // must not keep a fixed package on a 24h/7d leash.
+        var guard = CreateGuard();
+        var before = LoopGuard.ComputeFingerprint("1.0.0|old");
+        var after = LoopGuard.ComputeFingerprint("1.0.0|fixed");
+
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("CyclePkg", "1.0.0", true, before);
+
+        var state = guard.GetPackageState("CyclePkg")!;
+        state.SuppressedUntil = DateTime.UtcNow.AddMinutes(-1);
+        guard.ShouldSuppress("CyclePkg", "1.0.0", before).Suppress.Should().BeFalse();
+        guard.GetPackageState("CyclePkg")!.SuppressionCycles.Should().Be(1);
+
+        guard.ShouldSuppress("CyclePkg", "1.0.0", after);
+
+        guard.GetPackageState("CyclePkg")!.SuppressionCycles.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Suppression Expiry
+
+    [Fact]
+    public void ExpiredSuppression_RetriesInsteadOfReSuppressingOnTheSameHistory()
+    {
+        // The counters never decay, so an expired window used to fall straight back into
+        // the thresholds it was created by and re-suppress without a single retry — a
+        // permanent blacklist by the back door.
+        var guard = CreateGuard();
+
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("ExpirePkg", "1.0.0", true);
+
+        var state = guard.GetPackageState("ExpirePkg")!;
+        state.SuppressedUntil.Should().NotBeNull();
+        state.SuppressedUntil = DateTime.UtcNow.AddMinutes(-1);
+
+        guard.ShouldSuppress("ExpirePkg", "1.0.0").Suppress.Should().BeFalse();
+
+        // ...and still not suppressed on the next look: the history went with the window.
+        guard.ShouldSuppress("ExpirePkg", "1.0.0").Suppress.Should().BeFalse();
+        var cleared = guard.GetPackageState("ExpirePkg")!;
+        cleared.AttemptCount.Should().Be(0);
+        cleared.RecentTimestamps.Should().BeEmpty();
+        cleared.SuppressionCycles.Should().Be(1);
+    }
+
+    [Fact]
+    public void ExpiredSuppression_EscalatesTheNextWindow()
+    {
+        // Retrying after every window must not mean looping every 12 hours forever: a
+        // served cycle floors the next window at 24h, two or more at the 7-day cap.
+        var guard = CreateGuard();
+
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("EscalatePkg", "1.0.0", true);
+        guard.GetPackageState("EscalatePkg")!.SuppressedUntil = DateTime.UtcNow.AddMinutes(-1);
+        guard.ShouldSuppress("EscalatePkg", "1.0.0");
+
+        // Still broken — it loops again on the fresh history.
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("EscalatePkg", "1.0.0", true);
+
+        var state = guard.GetPackageState("EscalatePkg")!;
+        state.SuppressedUntil.Should().NotBeNull();
+        // Rapid-fire alone is 12h; the served cycle floors it at 24h.
+        state.SuppressedUntil!.Value.Should().BeAfter(DateTime.UtcNow.AddHours(23));
+        state.SuppressionReason.Should().Contain("escalated");
+
+        state.SuppressedUntil = DateTime.UtcNow.AddMinutes(-1);
+        guard.ShouldSuppress("EscalatePkg", "1.0.0");
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("EscalatePkg", "1.0.0", true);
+
+        // Second served cycle — floored at the 7-day cap.
+        guard.GetPackageState("EscalatePkg")!.SuppressedUntil!.Value
+            .Should().BeAfter(DateTime.UtcNow.AddDays(6));
+    }
+
     #endregion
 
     #region Cache Analysis

--- a/tests/Makecatalogs/CatalogBuilderTests.cs
+++ b/tests/Makecatalogs/CatalogBuilderTests.cs
@@ -426,6 +426,117 @@ installer:
 
         Assert.DoesNotContain(_warnings, w => w.Contains("missing installer"));
     }
+
+    #region Loop Fingerprint
+
+    private static PkgsInfo SamplePkg() => new()
+    {
+        Name = "LoopPkg",
+        Version = "1.0.0",
+        Catalogs = new List<string> { "Production" },
+        Installer = new Installer
+        {
+            Location = "apps/LoopPkg-1.0.0.msi",
+            Hash = "abc123",
+            Type = "msi",
+            ProductCode = "{11111111-1111-1111-1111-111111111111}",
+            Switches = new List<string> { "/qn" }
+        }
+    };
+
+    [Fact]
+    public void StampLoopFingerprints_IsDeterministic()
+    {
+        var a = SamplePkg();
+        var b = SamplePkg();
+
+        _builder.StampLoopFingerprints(new List<PkgsInfo> { a });
+        _builder.StampLoopFingerprints(new List<PkgsInfo> { b });
+
+        Assert.False(string.IsNullOrEmpty(a.LoopFingerprint));
+        Assert.Equal(a.LoopFingerprint, b.LoopFingerprint);
+    }
+
+    [Fact]
+    public void StampLoopFingerprints_IsStableAcrossRestamping()
+    {
+        // The field is part of the serialized item, so it has to be excluded from its own
+        // hash — otherwise every makecatalogs run produced a different value and cleared
+        // loop suppression fleet-wide for every package, every time.
+        var pkg = SamplePkg();
+
+        _builder.StampLoopFingerprints(new List<PkgsInfo> { pkg });
+        var first = pkg.LoopFingerprint;
+        _builder.StampLoopFingerprints(new List<PkgsInfo> { pkg });
+
+        Assert.Equal(first, pkg.LoopFingerprint);
+    }
+
+    [Theory]
+    // The fields our real loop fixes touch. A hand-picked field list missed every one of
+    // these; hashing the whole item is what makes "publish the fix" the central clear.
+    [InlineData("product_code")]
+    [InlineData("switches")]
+    [InlineData("blocking_applications")]
+    [InlineData("installer_timeout")]
+    [InlineData("requires")]
+    [InlineData("version")]
+    [InlineData("postinstall_script")]
+    [InlineData("installs")]
+    public void StampLoopFingerprints_ChangesWhenAnyInstallBehaviorFieldChanges(string field)
+    {
+        var baseline = SamplePkg();
+        _builder.StampLoopFingerprints(new List<PkgsInfo> { baseline });
+
+        var edited = SamplePkg();
+        switch (field)
+        {
+            case "product_code": edited.Installer!.ProductCode = "{22222222-2222-2222-2222-222222222222}"; break;
+            case "switches": edited.Installer!.Switches = new List<string> { "/qn", "/norestart" }; break;
+            case "blocking_applications": edited.BlockingApplications = new List<string> { "loop.exe" }; break;
+            case "installer_timeout": edited.InstallerTimeout = 3600; break;
+            case "requires": edited.Requires = new List<string> { "OtherPkg" }; break;
+            case "version": edited.Version = "1.0.1"; break;
+            case "postinstall_script": edited.PostinstallScript = "Write-Host fixed"; break;
+            case "installs": edited.Installs = new List<InstallItem> { new() { Type = "file", Path = "C:/app.exe" } }; break;
+        }
+
+        _builder.StampLoopFingerprints(new List<PkgsInfo> { edited });
+
+        Assert.NotEqual(baseline.LoopFingerprint, edited.LoopFingerprint);
+    }
+
+    [Fact]
+    public void StampLoopFingerprints_IgnoresLineEndingStyle()
+    {
+        var lf = SamplePkg();
+        lf.PostinstallScript = "line one\nline two\n";
+        var crlf = SamplePkg();
+        crlf.PostinstallScript = "line one\r\nline two\r\n";
+
+        _builder.StampLoopFingerprints(new List<PkgsInfo> { lf });
+        _builder.StampLoopFingerprints(new List<PkgsInfo> { crlf });
+
+        Assert.Equal(lf.LoopFingerprint, crlf.LoopFingerprint);
+    }
+
+    [Fact]
+    public void Run_WritesLoopFingerprintIntoCatalogs()
+    {
+        CreatePkgInfo("LoopPkg.yaml",
+            "name: LoopPkg\n" +
+            "version: 1.0.0\n" +
+            "catalogs:\n" +
+            "  - Production\n");
+
+        var exitCode = _builder.Run(_tempDir, skipPayloadCheck: true, silent: true);
+
+        Assert.Equal(0, exitCode);
+        var catalog = File.ReadAllText(Path.Combine(_tempDir, "catalogs", "Production.yaml"));
+        Assert.Contains("loop_fingerprint:", catalog);
+    }
+
+    #endregion
 }
 
 /// <summary>
@@ -452,4 +563,5 @@ public class PkgsInfoTests
         Assert.Null(installer.Type);
         Assert.Null(installer.Size);
     }
+
 }

--- a/wiki/install-loop-prevention.md
+++ b/wiki/install-loop-prevention.md
@@ -42,24 +42,49 @@ LoopGuard runs inside `UpdateEngine.IdentifyActions()` and actively blocks packa
 | 3+ installs within 2 hours (rapid-fire) | 12 hours |
 | 3+ installs of same version across 3+ sessions | 6 hours |
 | 5+ installs of same version across 5+ sessions | 24 hours |
-| 8+ installs of same version (any session count) | Indefinite — requires manual clear or version change |
+| 8+ installs of same version (any session count) | 7 days (the `LoopMaxTime` cap) |
 | 5+ total installs across 4+ sessions (any version) | 24 hours |
-| 8+ total installs across 5+ sessions (any version) | Indefinite — requires manual clear or version change |
+| 8+ total installs across 5+ sessions (any version) | 7 days (the `LoopMaxTime` cap) |
 
 #### Auto-Clear on Catalog Change
 
-When ANY install-behavior field changes in the pkgsinfo for a suppressed package, LoopGuard **automatically clears** the suppression and resets history. This covers:
+When the pkgsinfo behind a package changes, LoopGuard **clears that package's loop
+history** — the root cause may have been fixed. This is the central lever: publish the
+fix and the whole fleet starts installing again on its next run. Nobody has to reach
+individual machines with `--clear-loop`.
 
-- Version changes (e.g., `572.61` → `572.83`)
-- `installcheck_script` fixes (the most common loop fix)
-- `installs` array changes (different file paths, hashes, or version checks)
-- `check` info changes (registry path, file check)
-- Installer hash or URL changes (different binary)
-- Script changes (`install_script`, `postinstall_script`, `preinstall_script`)
+**How it works**: `makecatalogs` stamps each catalog item with a `loop_fingerprint` —
+a hash of that item's entire catalog content. The client stores the fingerprint of the
+item it last acted on and compares on every run. Because the hash covers the whole item,
+*any* field that reaches the catalog is covered: version, scripts, installer
+hash/location/type, `product_code`/`upgrade_code`, installer `switches`/`arguments`/
+`success_codes`, `installs`, `check`, `blocking_applications`, `installer_timeout`,
+`requires`, and anything added later. (A hand-picked field list used to miss most of
+those, so fixes to them left the package suppressed.) Editing only the description also
+clears — that errs toward retrying an install, which is the right side to err on.
 
-**How it works**: UpdateEngine computes a SHA256 fingerprint of all install-behavior fields in the catalog item. LoopGuard stores this fingerprint alongside the suppression state. On each run, if the fingerprint differs from the stored one, suppression is cleared — the pkgsinfo was modified and the root cause may be fixed.
+Two details worth knowing:
 
-This means you don't need to SSH into machines to run `--clear-loop` after fixing a pkgsinfo. Just update the catalog (change the version, fix the script, update the hash, etc.) and the next scheduled run will pick it up.
+- The check runs **whether or not the package is currently suppressed**, and performs
+  exactly the same reset as `--clear-loop` (counters, per-version counts, timestamps and
+  the processed-session set), so a fix is never judged on pre-fix history.
+- Catalogs written by a `makecatalogs` older than this feature carry no
+  `loop_fingerprint`. The client then falls back to hashing the install-behavior fields
+  it can see locally — narrower, but the old behavior, so nothing regresses while the
+  published `makecatalogs` is being rolled forward.
+
+The running Cimian agent version is folded into the comparison too: a client update can
+itself be the fix, so the first run after an update clears standing suppressions once.
+
+#### Expiry: retry, then escalate
+
+A suppression window is finite. When it expires, the counters that produced it are
+retired with it — otherwise the very next evaluation re-tripped the same thresholds on
+the same history and re-suppressed without the package ever being retried. A persistent
+`suppression_cycles` count survives that reset and floors the next window (one served
+cycle → at least 24 hours, two or more → the 7-day cap), so a genuinely-broken package
+converges on a few attempts a week and then goes quiet, while a fixed one starts from the
+bottom tier again (a catalog change or an explicit clear resets the cycles to zero).
 
 #### Bootstrap Exemption
 
@@ -111,7 +136,8 @@ The state file uses a nested structure (`CimianState`) to allow future extensibi
 This file tracks per-package:
 - Total attempt count and session count
 - Per-version attempt counts
-- Catalog fingerprint (SHA256 of install-behavior fields)
+- Catalog fingerprint (`loop_fingerprint` of the catalog item, folded with the agent version)
+- Suppression cycles served (the escalation floor for the next window)
 - Recent timestamps (for rapid-fire detection)
 - Suppression status and expiry time
 - Which event sessions have been processed (deduplication)
@@ -134,8 +160,8 @@ It builds a per-package history of install attempts, versions, and timestamps. T
 
 In `UpdateEngine.IdentifyActions()`, after `StatusService.CheckStatus()` determines a package needs action:
 
-1. LoopGuard checks if the package is currently suppressed
-2. If catalog fingerprint changed since suppression: **auto-clear** and allow install
+1. If the catalog fingerprint changed: **clear the loop history** and allow the install
+2. Otherwise, LoopGuard checks whether the package is currently suppressed
 3. If suppressed: logs a WARN, records `loop_suppressed` reason code, skips the package
 4. If not suppressed: package proceeds to install
 5. After install completes: `RecordAttempt()` logs the result + fingerprint for future detection
@@ -206,7 +232,8 @@ sudo .\managedsoftwareupdate.exe --clear-loop all
 In most cases, **you don't need to manually clear**. If you update the pkgsinfo (change the version, fix the installcheck_script, update the hash, modify the installs array, etc.), LoopGuard auto-clears when it sees the new catalog fingerprint.
 
 Manual clear is only needed when:
-- You fixed the issue without changing any fingerprinted field
+- The fix is outside the catalog entirely (machine state, an external dependency), so no
+  pkgsinfo field changed
 - You want to force a retry before the backoff expires
 
 Clearing without fixing the root cause will just trigger the loop again, and LoopGuard will re-suppress with the same or higher backoff.


### PR DESCRIPTION
Publishing a fixed pkgsinfo is supposed to be what gets a suppressed package installing again everywhere. Three gaps kept that from working.

### 1. The fingerprint missed the fields real fixes touch

`ComputeCatalogFingerprint` hashed a hand-picked list: version, the three scripts, installer hash/location/type, `installs[]` and `check`. Fixes to `product_code`/`upgrade_code`, installer `switches`/`arguments`/`success_codes`, `blocking_applications`, `installer_timeout` or `requires` therefore changed nothing, and the package stayed suppressed after being fixed.

`makecatalogs` now stamps every catalog item with `loop_fingerprint`, a hash of that item's entire catalog content (excluded from its own hash, line endings normalised first). The client prefers it, and falls back to the old locally-computed hash when the catalog predates the field — so nothing regresses before the published `makecatalogs` rolls forward. The running agent version is still folded in on both paths.

### 2. The central clear was weaker than the local one

The auto-clear zeroed the counters but left `ProcessedSessions`, so the next run's events rebuild recomputed `SessionCount` from every session ever seen. The session gate on every threshold was satisfied again immediately and the package re-suppressed after ~3 installs instead of 3 sessions. It now performs the same reset as `--clear-loop`, and is evaluated whether or not suppression is currently active — a package carrying loop history that has not tripped yet also starts clean, instead of tripping on pre-fix evidence at the first post-fix install.

### 3. An expired window re-suppressed without ever retrying

Counters never decay, so expiry nulled `SuppressedUntil` and fell straight into the thresholds that created it — re-suppressing on the same evidence, with no retry. The documented "retries at most once a week" never happened; a catalog change was the only exit.

Expiring a window now retires its history too. A persistent `suppression_cycles` count survives that reset and floors the next window (one served cycle → at least 24h, two or more → the 7-day cap), so a genuinely-broken package still converges on a few attempts a week and then goes quiet, while a fixed one (catalog change or explicit clear, both of which zero the cycles) starts from the bottom tier.

### Tests

13 new tests: fingerprint stability/exclusion-from-itself, a theory over the field classes that used to be invisible, `Run` writing the field into catalogs, clearing when not yet suppressed, `ProcessedSessions` clearing, retry-on-expiry and the escalation floor. Full suite: 997 passed, the same 5 pre-existing failures as `main` (`PredicateEngineTests`, `ConfigurationServiceTests` — unrelated).

### Rollout note

Catalogs only carry `loop_fingerprint` once the published `makecatalogs` is rebuilt and the pipeline version pins are bumped. Until then clients take the fallback path, which is current behaviour.
