### PR TITLE
Report why a suppressed package keeps wanting to install

### DIFF
--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -323,7 +323,8 @@ public class StatusService
                 result.Status = "pending";
                 result.NeedsAction = true;
                 result.IsUpdate = hasRegistryEntry;
-                result.Reason = $"installcheck_script returned 0 (install needed): {output}";
+                var scriptSaid = string.IsNullOrWhiteSpace(output) ? "no output" : output.Trim();
+                result.Reason = $"installcheck_script exited 0, which means install needed (script output: {scriptSaid})";
                 result.ReasonCode = StatusReasonCode.InstallcheckNeeded;
                 ConsoleLogger.Debug($"CheckStatus explicitly indicates update required item: {item.Name}");
             }
@@ -430,8 +431,16 @@ public class StatusService
         // Go parity: Read the ManagedInstalls registry version first
         var registryVersion = GetManagedInstallsVersion(item.Name);
 
+        var installIndex = -1;
         foreach (var installItem in item.Installs)
         {
+            // Every failure below names the exact entry that decided it. A pkgsinfo with
+            // six installs entries used to report "File not found: <path>" with no way to
+            // tell which entry (or which identity field) produced it without opening the
+            // catalog by hand — which is the whole diagnosis when the item is looping.
+            installIndex++;
+            var where = DescribeInstallsEntry(installIndex, installItem);
+
             switch (installItem.EffectiveType())
             {
                 case "file":
@@ -446,7 +455,7 @@ public class StatusService
                             result.Status = "pending";
                             result.NeedsAction = true;
                             result.IsUpdate = hasRegistryEntry; // If has registry entry, it was installed before
-                            result.Reason = $"File not found: {installItem.Path}";
+                            result.Reason = $"{where}: file not found";
                             result.ReasonCode = StatusReasonCode.FileMissing;
                             result.DetectionMethod = DetectionMethod.File;
                             return result;
@@ -465,7 +474,7 @@ public class StatusService
                                 result.Status = "pending";
                                 result.NeedsAction = true;
                                 result.IsUpdate = true; // File exists but hash mismatch = update
-                                result.Reason = $"Hash mismatch for {installItem.Path}: expected {installItem.Md5Checksum}, got {actualHash}";
+                                result.Reason = $"{where}: hash mismatch — expected {installItem.Md5Checksum}, found {actualHash}";
                                 result.ReasonCode = StatusReasonCode.HashMismatch;
                                 result.DetectionMethod = DetectionMethod.File;
                                 return result;
@@ -502,7 +511,7 @@ public class StatusService
                                         result.Status = "pending";
                                         result.NeedsAction = true;
                                         result.IsUpdate = true;
-                                        result.Reason = $"Version outdated: {fileVersion} -> {expectedVersion}";
+                                        result.Reason = $"{where}: file version {fileVersion} is older than the catalog's {expectedVersion}";
                                         result.ReasonCode = StatusReasonCode.VersionOutdated;
                                         result.DetectionMethod = DetectionMethod.File;
                                         return result;
@@ -521,7 +530,7 @@ public class StatusService
                                 result.Status = "pending";
                                 result.NeedsAction = true;
                                 result.IsUpdate = true;
-                                result.Reason = $"No file version metadata available for {installItem.Path}";
+                                result.Reason = $"{where}: file has no version metadata and the entry declares no md5checksum, so installation can never be confirmed";
                                 result.ReasonCode = StatusReasonCode.VersionOutdated;
                                 result.DetectionMethod = DetectionMethod.File;
                                 return result;
@@ -546,7 +555,7 @@ public class StatusService
                             result.Status = "pending";
                             result.NeedsAction = true;
                             result.IsUpdate = hasRegistryEntry;
-                            result.Reason = $"Directory not found: {installItem.Path}";
+                            result.Reason = $"{where}: directory not found";
                             result.ReasonCode = StatusReasonCode.DirectoryMissing;
                             result.DetectionMethod = DetectionMethod.Directory;
                             return result;
@@ -621,7 +630,7 @@ public class StatusService
                         result.Status = "pending";
                         result.NeedsAction = true;
                         result.IsUpdate = hasRegistryEntry;
-                        result.Reason = $"MSI product not installed";
+                        result.Reason = $"{where}: not registered in Windows Installer";
                         result.ReasonCode = StatusReasonCode.ProductCodeMissing;
                         result.DetectionMethod = DetectionMethod.Msi;
                         return result;
@@ -633,7 +642,7 @@ public class StatusService
                         result.NeedsAction = true;
                         result.IsUpdate = true;
                         result.InstalledVersion = msiInstalledVersion;
-                        result.Reason = $"MSI version outdated: {msiInstalledVersion} -> {catalogVersion}";
+                        result.Reason = $"{where}: registered version {msiInstalledVersion} is older than the catalog's {catalogVersion}";
                         result.ReasonCode = StatusReasonCode.VersionOutdated;
                         result.DetectionMethod = DetectionMethod.Msi;
                         return result;
@@ -656,7 +665,7 @@ public class StatusService
                                 result.Status = "pending";
                                 result.NeedsAction = true;
                                 result.IsUpdate = true;
-                                result.Reason = $"key_path file missing despite MSI registry hit: {installItem.KeyPath}";
+                                result.Reason = $"{where}: key_path {installItem.KeyPath} is missing although the MSI is registered";
                                 result.ReasonCode = StatusReasonCode.FileMissing;
                                 result.DetectionMethod = DetectionMethod.File;
                                 return result;
@@ -673,7 +682,7 @@ public class StatusService
                                     result.NeedsAction = true;
                                     result.IsUpdate = true;
                                     result.InstalledVersion = diskVersion;
-                                    result.Reason = $"key_path version mismatch: disk={diskVersion} catalog={catalogVersion} (ARP reported {msiInstalledVersion})";
+                                    result.Reason = $"{where}: key_path {installItem.KeyPath} is version {diskVersion}, catalog wants {catalogVersion} (ARP reports {msiInstalledVersion})";
                                     result.ReasonCode = StatusReasonCode.VersionOutdated;
                                     result.DetectionMethod = DetectionMethod.File;
                                     return result;
@@ -693,7 +702,7 @@ public class StatusService
                         ConsoleLogger.Warn($"MSIX install check missing identity_name item: {item.Name}");
                         result.Status = "error";
                         result.NeedsAction = true;
-                        result.Reason = $"MSIX install check missing identity_name";
+                        result.Reason = $"{where}: msix entry declares no identity_name, so it can never match";
                         result.ReasonCode = StatusReasonCode.CheckFailed;
                         result.DetectionMethod = DetectionMethod.Msix;
                         return result;
@@ -712,7 +721,7 @@ public class StatusService
                         result.Status = "pending";
                         result.NeedsAction = true;
                         result.IsUpdate = hasRegistryEntry;
-                        result.Reason = $"MSIX package not found for identity: {installItem.IdentityName}";
+                        result.Reason = $"{where}: no provisioned package with this identity";
                         // NotInstalled is the installer-type-neutral code for "package is absent".
                         // ProductCodeMissing is MSI-specific and would misclassify downstream.
                         result.ReasonCode = StatusReasonCode.NotInstalled;
@@ -730,7 +739,7 @@ public class StatusService
                             result.NeedsAction = true;
                             result.IsUpdate = true;
                             result.InstalledVersion = msixVersion;
-                            result.Reason = $"MSIX version outdated: {msixVersion} -> {msixCatalogVersion}";
+                            result.Reason = $"{where}: provisioned version {msixVersion} is older than the catalog's {msixCatalogVersion}";
                             result.ReasonCode = StatusReasonCode.VersionOutdated;
                             result.DetectionMethod = DetectionMethod.Msix;
                             return result;
@@ -748,7 +757,7 @@ public class StatusService
                     ConsoleLogger.Warn($"Installs entry for {item.Name} has no usable type or identity field — skipping (rawType: '{installItem.Type}')");
                     result.Status = "error";
                     result.NeedsAction = true;
-                    result.Reason = "Installs entry missing type and identity fields";
+                    result.Reason = $"{where}: entry declares neither a type nor any identity field (path/product_code/upgrade_code/identity_name)";
                     result.ReasonCode = StatusReasonCode.CheckFailed;
                     result.DetectionMethod = DetectionMethod.None;
                     return result;
@@ -1269,6 +1278,30 @@ if ($results.Count -gt 0) {{
         using var stream = File.OpenRead(filePath);
         var hash = md5.ComputeHash(stream);
         return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Names one installs entry the way an admin reads the pkgsinfo: its index, its
+    /// effective type, and the identity field the check actually used.
+    /// </summary>
+    private static string DescribeInstallsEntry(int index, InstallCheckItem entry)
+    {
+        var type = entry.EffectiveType();
+        var identity = type switch
+        {
+            "file" or "directory" => entry.Path,
+            "msi" => string.Join(" ", new[]
+            {
+                string.IsNullOrEmpty(entry.ProductCode) ? null : $"product_code={entry.ProductCode}",
+                string.IsNullOrEmpty(entry.UpgradeCode) ? null : $"upgrade_code={entry.UpgradeCode}",
+                string.IsNullOrEmpty(entry.DisplayName) ? null : $"display_name={entry.DisplayName}"
+            }.Where(part => part != null)),
+            "msix" or "appx" => entry.IdentityName,
+            _ => entry.Path
+        };
+
+        var head = $"installs[{index}] {(string.IsNullOrEmpty(type) ? "untyped" : type)}";
+        return string.IsNullOrWhiteSpace(identity) ? head : $"{head} {identity}";
     }
 
     private StatusCheckResult CheckRegistryStatus(CatalogItem item)

--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1083,6 +1083,12 @@ public class UpdateEngine : IDisposable
                     
                     if (status.NeedsAction)
                     {
+                        // Remember WHY this item needs to run. LoopGuard replays it in the
+                        // suppression warning, so a loop reports the failing criterion
+                        // (path, product code, script output) instead of only the counting
+                        // rule that tripped.
+                        RememberInstallTrigger(catalogItem.Name, status);
+
                         // --item targets specific packages by name; bypass LoopGuard for those
                         // (run-scoped only — persistent suppression state is left intact so
                         // future runs without --item still honor it).
@@ -1133,7 +1139,8 @@ public class UpdateEngine : IDisposable
                                 break; // Skip this item
                             }
 
-                            var (suppress, loopReason) = _loopGuard.ShouldSuppress(catalogItem.Name, catalogItem.Version, fingerprint);
+                            var (suppress, loopReason) = _loopGuard.ShouldSuppress(
+                                catalogItem.Name, catalogItem.Version, fingerprint, TriggerFrom(status));
                             if (suppress)
                             {
                                 ConsoleLogger.Warn(loopReason);
@@ -1972,9 +1979,10 @@ public class UpdateEngine : IDisposable
         // restart_action finalizes at reboot are the legitimate exception.
         string? convergenceWarning = null;
         var convergencePendingRestart = false;
+        Cimian.Core.Models.InstallTrigger? convergenceTrigger = null;
         if (success && warningMessage == null)
         {
-            (convergenceWarning, convergencePendingRestart) = VerifyConvergence(item);
+            (convergenceWarning, convergencePendingRestart, convergenceTrigger) = VerifyConvergence(item);
         }
 
         outcomes.Add(new ItemOutcome(item.Name, item.Version, "install", success, success ? null : output, DateTime.UtcNow, warningMessage ?? convergenceWarning));
@@ -2020,7 +2028,8 @@ public class UpdateEngine : IDisposable
                 item.Version,
                 success: true,
                 ComputeCatalogFingerprint(item),
-                selfReportedWarning: warningMessage != null);
+                selfReportedWarning: warningMessage != null,
+                trigger: TakeInstallTrigger(item.Name));
 
             // Act on the convergence verdict from above.
             if (convergencePendingRestart)
@@ -2032,7 +2041,7 @@ public class UpdateEngine : IDisposable
             {
                 ConsoleLogger.Warn(convergenceWarning);
                 _sessionLogger?.Log("WARN", convergenceWarning);
-                _loopGuard?.MarkNonConverged(item.Name, item.Version, ComputeCatalogFingerprint(item), _config.LoopReprobeHours);
+                _loopGuard?.MarkNonConverged(item.Name, item.Version, ComputeCatalogFingerprint(item), _config.LoopReprobeHours, convergenceTrigger);
             }
 
             // Add to installed items
@@ -2059,7 +2068,8 @@ public class UpdateEngine : IDisposable
                 output);
 
             // Record failed install for loop guard tracking
-            _loopGuard?.RecordAttempt(item.Name, item.Version, success: false, ComputeCatalogFingerprint(item));
+            _loopGuard?.RecordAttempt(item.Name, item.Version, success: false, ComputeCatalogFingerprint(item),
+                trigger: TakeInstallTrigger(item.Name));
             return false;
         }
 
@@ -3341,7 +3351,34 @@ public class UpdateEngine : IDisposable
     /// Verification must never fail a completed install — any error here is
     /// swallowed and treated as converged.
     /// </summary>
-    private (string? Warning, bool PendingRestart) VerifyConvergence(CatalogItem item)
+    /// <summary>
+    /// The check that decided an item needs to run, keyed by item name, from the moment
+    /// the decision is made until the install records it. LoopGuard needs the cause at
+    /// RecordAttempt time, but only IdentifyActions holds the status result that produced
+    /// it — without this hand-off the loop warning can report that a package installed
+    /// three times and still not say what kept asking for it.
+    /// </summary>
+    private readonly Dictionary<string, Cimian.Core.Models.InstallTrigger> _installTriggers = new(StringComparer.OrdinalIgnoreCase);
+
+    private static Cimian.Core.Models.InstallTrigger? TriggerFrom(StatusCheckResult status) =>
+        Cimian.Core.Models.InstallTrigger.From(status.ReasonCode, status.DetectionMethod, status.Reason, status.InstalledVersion);
+
+    private void RememberInstallTrigger(string name, StatusCheckResult status)
+    {
+        var trigger = TriggerFrom(status);
+        if (trigger != null)
+            _installTriggers[name] = trigger;
+    }
+
+    /// <summary>Consumes the remembered trigger for an item, so a later run cannot inherit a stale cause.</summary>
+    private Cimian.Core.Models.InstallTrigger? TakeInstallTrigger(string name)
+    {
+        if (!_installTriggers.Remove(name, out var trigger))
+            return null;
+        return trigger;
+    }
+
+    private (string? Warning, bool PendingRestart, Cimian.Core.Models.InstallTrigger? Trigger) VerifyConvergence(CatalogItem item)
     {
         // OnDemand items never converge by design: CheckStatus reports them as
         // needing action on every call, before any installcheck runs, because
@@ -3351,23 +3388,25 @@ public class UpdateEngine : IDisposable
         // helper lights up as a broken pkgsinfo the moment it runs. There is
         // nothing to verify for them.
         if (item.OnDemand)
-            return (null, false);
+            return (null, false, null);
 
         try
         {
             var status = _statusService.CheckStatus(item, "install", _config.CachePath);
             if (!status.NeedsAction)
-                return (null, false);
+                return (null, false, null);
+
+            var trigger = TriggerFrom(status);
 
             if (RequiresRestart(item) || RequiresLogout(item))
-                return (null, true);
+                return (null, true, trigger);
 
             var warning = $"installcheck did not converge: {item.Name} v{item.Version} still reports action needed ({status.Reason}) immediately after a successful install — fix the pkgsinfo installcheck/installs criteria (re-probes in {(_config.LoopReprobeHours > 0 ? _config.LoopReprobeHours : 24)}h; clears immediately on pkgsinfo change)";
-            return (warning, false);
+            return (warning, false, trigger);
         }
         catch
         {
-            return (null, false);
+            return (null, false, null);
         }
     }
 

--- a/shared/core/Models/InstallTrigger.cs
+++ b/shared/core/Models/InstallTrigger.cs
@@ -1,0 +1,89 @@
+// InstallTrigger.cs - The check that decided a package needed to run
+
+using System.Text.Json.Serialization;
+
+namespace Cimian.Core.Models;
+
+/// <summary>
+/// The concrete detection result that made Cimian decide a package needed to be
+/// (re)installed: which check ran, what it looked at, and what it found.
+/// <para>
+/// LoopGuard's warnings used to report only the counting rule that tripped
+/// ("Rapid-fire loop: 3 installs within 2 hours"), which says a loop exists but
+/// nothing about its cause — every diagnosis then started with an SSH session and
+/// a hand-read of the pkgsinfo. The trigger is captured at the moment the decision
+/// is made and replayed in the suppression message, so the warning itself names the
+/// installs entry, installcheck_script or product code that never converges.
+/// </para>
+/// </summary>
+public sealed class InstallTrigger
+{
+    /// <summary>Machine-readable code from <see cref="StatusReasonCode"/> (e.g. file_missing).</summary>
+    [JsonPropertyName("reason_code")]
+    public string ReasonCode { get; set; } = string.Empty;
+
+    /// <summary>Which check produced it, from <see cref="DetectionMethod"/> (e.g. installs_array).</summary>
+    [JsonPropertyName("detection_method")]
+    public string DetectionMethod { get; set; } = string.Empty;
+
+    /// <summary>Human-readable detail, including the path/GUID/script output that decided it.</summary>
+    [JsonPropertyName("detail")]
+    public string Detail { get; set; } = string.Empty;
+
+    /// <summary>Version found on disk at decision time, when the check determined one.</summary>
+    [JsonPropertyName("installed_version")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? InstalledVersion { get; set; }
+
+    /// <summary>Longest detail retained. Script output can run to hundreds of lines.</summary>
+    public const int MaxDetailLength = 300;
+
+    /// <summary>
+    /// Builds a trigger from a status check, or null when there is nothing worth
+    /// recording. Detail is flattened to a single line and truncated: it is carried
+    /// in a warning message and in state that is rewritten every session.
+    /// </summary>
+    public static InstallTrigger? From(string? reasonCode, string? detectionMethod, string? detail, string? installedVersion = null)
+    {
+        var flat = Flatten(detail);
+        if (string.IsNullOrEmpty(reasonCode) && string.IsNullOrEmpty(flat))
+            return null;
+
+        return new InstallTrigger
+        {
+            ReasonCode = reasonCode ?? string.Empty,
+            DetectionMethod = detectionMethod ?? Models.DetectionMethod.None,
+            Detail = flat,
+            InstalledVersion = string.IsNullOrWhiteSpace(installedVersion) ? null : installedVersion
+        };
+    }
+
+    /// <summary>Stable identity for counting how often the same trigger recurs.</summary>
+    [JsonIgnore]
+    public string Key => $"{ReasonCode}|{DetectionMethod}|{Detail}";
+
+    /// <summary>
+    /// One-line operator-facing form: the code, the check that produced it, and the
+    /// detail. Reads as "why does this keep wanting to install".
+    /// </summary>
+    public string Describe()
+    {
+        var head = string.IsNullOrEmpty(ReasonCode) ? "check" : ReasonCode;
+        var method = string.IsNullOrEmpty(DetectionMethod) || DetectionMethod == Models.DetectionMethod.None
+            ? null
+            : DetectionMethod;
+        var lead = method == null ? head : $"{head} via {method}";
+        return string.IsNullOrEmpty(Detail) ? lead : $"{lead} — {Detail}";
+    }
+
+    private static string Flatten(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return string.Empty;
+
+        var collapsed = string.Join(' ', text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+        return collapsed.Length > MaxDetailLength
+            ? collapsed[..MaxDetailLength] + "…"
+            : collapsed;
+    }
+}

--- a/shared/core/Models/Reporting.cs
+++ b/shared/core/Models/Reporting.cs
@@ -733,6 +733,18 @@ public class LoopSuppressedReportItem
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTime? SuppressedUntil { get; set; }
 
+    /// <summary>
+    /// The detection result that keeps deciding this package must run — the cause of the
+    /// loop, as opposed to the counting rule that suppressed it.
+    /// </summary>
+    [JsonPropertyName("trigger")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public InstallTrigger? Trigger { get; set; }
+
+    /// <summary>Human-readable form of the trigger, including how consistent it has been.</summary>
+    [JsonPropertyName("trigger_summary")]
+    public string TriggerSummary { get; set; } = string.Empty;
+
     /// <summary>Operator-actionable command string (matches LoopGuard's WARN log line).</summary>
     [JsonPropertyName("clear_command")]
     public string ClearCommand { get; set; } = string.Empty;

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -151,8 +151,13 @@ public class LoopGuard
     /// If provided and different from the stored fingerprint, suppression is auto-cleared
     /// because the pkgsinfo was changed (version, installcheck_script, hash, installs, etc.).
     /// Falls back to version-only comparison if no fingerprint is provided.
+    ///
+    /// trigger: the status check that decided the package needs to run right now.
+    /// Recorded against the package and replayed in the suppression message, so the
+    /// warning names the criterion that never converges instead of only the counting
+    /// rule that tripped.
     /// </summary>
-    public (bool Suppress, string Reason) ShouldSuppress(string packageName, string version, string? catalogFingerprint = null)
+    public (bool Suppress, string Reason) ShouldSuppress(string packageName, string version, string? catalogFingerprint = null, InstallTrigger? trigger = null)
     {
         // Never suppress during bootstrap — first-run provisioning must complete
         if (_isBootstrap)
@@ -170,6 +175,12 @@ public class LoopGuard
         // Check explicit suppression state first (from previous runs)
         if (_state.Packages.TryGetValue(key, out var pkgState))
         {
+            // Refresh the observed cause before anything else. A suppressed package is
+            // never installed, so its trigger would otherwise freeze at whatever was
+            // true when the window opened — and an operator reading the warning a day
+            // later needs to know what the item still wants now.
+            NoteTrigger(pkgState, trigger, countIt: false);
+
             // Auto-clear: if the catalog fingerprint changed, the pkgsinfo was updated
             // and the root cause may be fixed. This is deliberately evaluated BEFORE the
             // suppression check and regardless of whether suppression is currently
@@ -209,7 +220,7 @@ public class LoopGuard
                 if (DateTime.UtcNow < pkgState.SuppressedUntil.Value)
                 {
                     var remaining = pkgState.SuppressedUntil.Value - DateTime.UtcNow;
-                    return (true, $"LOOP SUPPRESSED: {packageName} — suppressed for {FormatDuration(remaining)} ({pkgState.SuppressionReason}). Clear with: managedsoftwareupdate --clear-loop {packageName}");
+                    return (true, BuildSuppressionMessage(packageName, version, pkgState, remaining));
                 }
 
                 // Suppression expired. Retire the history that produced it as well as
@@ -231,6 +242,83 @@ public class LoopGuard
 
         // Analyze current history for new loop conditions
         return AnalyzeForLoop(key, packageName, version);
+    }
+
+    /// <summary>
+    /// Records the check that decided this package needs to run. Called on every
+    /// evaluation (so the reported cause stays current while suppressed) and on every
+    /// real attempt with <paramref name="countIt"/> set, which is what builds the
+    /// "same reason every time" evidence the warning reports.
+    /// </summary>
+    private static void NoteTrigger(PackageLoopState pkgState, InstallTrigger? trigger, bool countIt)
+    {
+        if (trigger == null)
+            return;
+
+        pkgState.Trigger = trigger;
+        pkgState.TriggerLastSeen = DateTime.UtcNow;
+
+        if (!countIt)
+            return;
+
+        var key = trigger.Key;
+        pkgState.TriggerCounts.TryGetValue(key, out var count);
+        if (count == 0 && pkgState.TriggerCounts.Count >= MaxTrackedTriggers)
+            return;
+        pkgState.TriggerCounts[key] = count + 1;
+    }
+
+    /// <summary>
+    /// Distinct triggers retained per package. Past a handful the item is not "stuck on
+    /// one criterion", which is the distinction the summary needs to draw.
+    /// </summary>
+    private const int MaxTrackedTriggers = 5;
+
+    /// <summary>
+    /// The operator-facing suppression warning. Reports three things in order: how long
+    /// the package is gagged, the counting rule that gagged it, and — the part that was
+    /// missing — the detection result that keeps deciding the package must run. Without
+    /// the last one every diagnosis started by finding the machine and re-reading the
+    /// pkgsinfo by hand; the warning now carries the path, product code or script output
+    /// that never converges.
+    /// </summary>
+    private string BuildSuppressionMessage(string packageName, string version, PackageLoopState pkgState, TimeSpan remaining)
+    {
+        var shown = string.IsNullOrEmpty(version) ? pkgState.LastVersion : version;
+        var name = string.IsNullOrEmpty(shown) ? packageName : $"{packageName} v{shown}";
+
+        var sb = new StringBuilder();
+        sb.Append($"LOOP SUPPRESSED: {name} — suppressed for {FormatDuration(remaining)}.");
+        sb.Append($" Loop rule: {pkgState.SuppressionReason ?? "unknown"}.");
+        sb.Append($" Needs install because: {DescribeTrigger(pkgState)}.");
+        sb.Append($" Fix that criterion in the pkgsinfo — any catalog change clears this fleet-wide — or locally: managedsoftwareupdate --clear-loop {packageName}");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// One-line account of why the package keeps asking to install, with how consistent
+    /// that answer has been across attempts.
+    /// </summary>
+    private static string DescribeTrigger(PackageLoopState pkgState)
+    {
+        if (pkgState.Trigger == null)
+            return "not recorded — the loop history predates trigger capture; it is recorded on the next evaluation";
+
+        var described = pkgState.Trigger.Describe();
+        var total = pkgState.TriggerCounts.Values.Sum();
+
+        if (pkgState.TriggerCounts.Count == 1 && total >= 2)
+            return $"{described} (same on all {total} attempts — the detection criteria never match what the installer lays down)";
+
+        if (pkgState.TriggerCounts.Count > 1)
+        {
+            var codes = pkgState.TriggerCounts
+                .OrderByDescending(kv => kv.Value)
+                .Select(kv => $"{kv.Key.Split('|')[0]} x{kv.Value}");
+            return $"{described} (most recent of {total} attempts: {string.Join(", ", codes)})";
+        }
+
+        return described;
     }
 
     /// <summary>
@@ -290,6 +378,9 @@ public class LoopGuard
         pkgState.VersionAttempts.Clear();
         pkgState.RecentTimestamps.Clear();
         pkgState.ProcessedSessions.Clear();
+        pkgState.TriggerCounts.Clear();
+        pkgState.Trigger = null;
+        pkgState.TriggerLastSeen = null;
         pkgState.PendingRestartSince = null;
         pkgState.ClearedAt = DateTime.UtcNow;
         if (!string.IsNullOrEmpty(version))
@@ -333,7 +424,7 @@ public class LoopGuard
     /// marker) still accumulate and trip suppression as before.
     /// </para>
     /// </summary>
-    public void RecordAttempt(string packageName, string version, bool success, string? catalogFingerprint = null, bool selfReportedWarning = false)
+    public void RecordAttempt(string packageName, string version, bool success, string? catalogFingerprint = null, bool selfReportedWarning = false, InstallTrigger? trigger = null)
     {
         if (string.IsNullOrEmpty(packageName))
             return;
@@ -364,6 +455,7 @@ public class LoopGuard
 
         pkgState.AttemptCount++;
         pkgState.LastAttempt = DateTime.UtcNow;
+        NoteTrigger(pkgState, trigger, countIt: true);
         if (!string.IsNullOrEmpty(_currentSessionId) && !pkgState.ProcessedSessions.Contains(_currentSessionId))
         {
             pkgState.ProcessedSessions.Add(_currentSessionId);
@@ -531,11 +623,12 @@ public class LoopGuard
     /// any suppression, auto-clears the moment the pkgsinfo fingerprint changes.
     /// Returns the reason recorded, for surfacing on the session's outcome.
     /// </summary>
-    public string MarkNonConverged(string packageName, string version, string? catalogFingerprint, int reprobeHours = 24)
+    public string MarkNonConverged(string packageName, string version, string? catalogFingerprint, int reprobeHours = 24, InstallTrigger? trigger = null)
     {
         var hours = reprobeHours > 0 ? reprobeHours : 24;
         hours = Math.Min(hours, _maxSuppressionDays * 24);
-        var reason = $"installcheck did not converge: {packageName} v{version} still reports action needed immediately after a successful install — fix the pkgsinfo installcheck/installs criteria (re-probes in {hours}h; clears immediately on pkgsinfo change)";
+        var cause = trigger == null ? "" : $" [{trigger.Describe()}]";
+        var reason = $"installcheck did not converge: {packageName} v{version} still reports action needed immediately after a successful install{cause} — fix the pkgsinfo installcheck/installs criteria (re-probes in {hours}h; clears immediately on pkgsinfo change)";
 
         if (_disabled || string.IsNullOrEmpty(packageName))
             return reason;
@@ -550,6 +643,7 @@ public class LoopGuard
         pkgState.SuppressedUntil = DateTime.UtcNow.AddHours(hours);
         pkgState.SuppressionReason = reason;
         pkgState.LastVersion = version;
+        NoteTrigger(pkgState, trigger, countIt: false);
         if (!string.IsNullOrEmpty(catalogFingerprint))
             pkgState.CatalogFingerprint = catalogFingerprint;
         SaveState();
@@ -601,6 +695,8 @@ public class LoopGuard
                 Version         = pkgState.LastVersion ?? "",
                 Reason          = pkgState.SuppressionReason ?? "Unknown",
                 SuppressedUntil = until == DateTime.MaxValue ? null : until,
+                Trigger         = pkgState.Trigger,
+                TriggerSummary  = DescribeTrigger(pkgState),
                 ClearCommand    = $"managedsoftwareupdate --clear-loop {pkgState.PackageName}"
             });
         }
@@ -1043,6 +1139,10 @@ public class LoopGuard
             lines.Add($"  Versions attempted: {string.Join(", ", pkgState.VersionAttempts.Select(v => $"{v.Key} ({v.Value}x)"))}");
         }
 
+        lines.Add($"  Needs install because: {DescribeTrigger(pkgState)}");
+        if (pkgState.TriggerLastSeen.HasValue)
+            lines.Add($"  Trigger last seen: {pkgState.TriggerLastSeen.Value.ToString("g")}");
+
         var (hasCache, cachePath) = CheckCacheForPackage(packageName);
         if (hasCache)
         {
@@ -1199,6 +1299,33 @@ public class PackageLoopState
     [JsonPropertyName("pending_restart_since")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTime? PendingRestartSince { get; set; }
+
+    /// <summary>
+    /// The check that decided this package needed to run, as of the most recent
+    /// evaluation. This is the diagnosis: the counting rule says a loop exists, the
+    /// trigger says which installs entry, installcheck_script or product code never
+    /// converges. Refreshed on every attempt AND on every suppressed evaluation, so
+    /// the warning reports what the package still wants today rather than what it
+    /// wanted when the window opened.
+    /// </summary>
+    [JsonPropertyName("trigger")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public InstallTrigger? Trigger { get; set; }
+
+    /// <summary>When <see cref="Trigger"/> was last observed.</summary>
+    [JsonPropertyName("trigger_last_seen")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? TriggerLastSeen { get; set; }
+
+    /// <summary>
+    /// Distinct triggers seen across the attempts that built the current history,
+    /// keyed by <see cref="InstallTrigger.Key"/> and counted. One entry with a count
+    /// equal to the attempt count is a stuck detection criterion (the pkgsinfo is
+    /// wrong); several entries mean the machine keeps changing underneath the item.
+    /// Bounded — a package with more distinct triggers than this is already diagnosed.
+    /// </summary>
+    [JsonPropertyName("trigger_counts")]
+    public Dictionary<string, int> TriggerCounts { get; set; } = new(StringComparer.Ordinal);
 }
 
 #endregion

--- a/tests/LoopGuardTests.cs
+++ b/tests/LoopGuardTests.cs
@@ -1,6 +1,7 @@
 using Xunit;
 using FluentAssertions;
 using Cimian.Core.Services;
+using Cimian.Core.Models;
 using System.Text.Json;
 
 namespace Cimian.Tests.Core.Services;
@@ -1009,6 +1010,178 @@ public class LoopGuardTests : IDisposable
         var eventsPath = Path.Combine(sessionDir, "events.jsonl");
         // Append to allow multiple events in same session
         File.AppendAllText(eventsPath, JsonSerializer.Serialize(evt) + "\n");
+    }
+
+    #endregion
+
+    #region Trigger reporting — why the package keeps installing
+
+    private static InstallTrigger FileMissingTrigger(string path = "C:/Program Files/Thing/thing.exe") =>
+        InstallTrigger.From(StatusReasonCode.FileMissing, DetectionMethod.InstallsArray,
+            $"installs[0] file {path}: file not found")!;
+
+    [Fact]
+    public void SuppressionMessage_NamesTheCheckThatKeepsTriggeringTheInstall()
+    {
+        var guard = CreateGuard();
+        var trigger = FileMissingTrigger();
+
+        guard.RecordAttempt("LoopPkg", "1.0.0", true, trigger: trigger);
+        guard.RecordAttempt("LoopPkg", "1.0.0", true, trigger: trigger);
+        guard.RecordAttempt("LoopPkg", "1.0.0", true, trigger: trigger);
+
+        var (suppress, reason) = guard.ShouldSuppress("LoopPkg", "1.0.0", null, trigger);
+
+        suppress.Should().BeTrue();
+        reason.Should().Contain("Needs install because");
+        reason.Should().Contain(StatusReasonCode.FileMissing);
+        reason.Should().Contain("installs[0] file");
+        reason.Should().Contain("thing.exe");
+        reason.Should().Contain("same on all 3 attempts");
+        reason.Should().Contain("--clear-loop LoopPkg");
+    }
+
+    [Fact]
+    public void SuppressionMessage_StillReportsTheLoopRuleAndTheVersion()
+    {
+        var guard = CreateGuard();
+        var trigger = FileMissingTrigger();
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("LoopPkg", "2.5.0", true, trigger: trigger);
+
+        var (_, reason) = guard.ShouldSuppress("LoopPkg", "2.5.0", null, trigger);
+
+        reason.Should().Contain("LoopPkg v2.5.0");
+        reason.Should().Contain("Loop rule:");
+        reason.Should().MatchRegex("Rapid-fire|Install loop|Escalated|Persistent");
+    }
+
+    [Fact]
+    public void SuppressionMessage_SummarisesMultipleDistinctTriggers()
+    {
+        var guard = CreateGuard();
+        var missing = FileMissingTrigger();
+        var outdated = InstallTrigger.From(StatusReasonCode.VersionOutdated, DetectionMethod.Msi,
+            "installs[1] msi product_code={GUID}: registered version 1.0 is older than the catalog's 2.0")!;
+
+        guard.RecordAttempt("MixedPkg", "1.0.0", true, trigger: missing);
+        guard.RecordAttempt("MixedPkg", "1.0.0", true, trigger: outdated);
+        guard.RecordAttempt("MixedPkg", "1.0.0", true, trigger: outdated);
+
+        var (suppress, reason) = guard.ShouldSuppress("MixedPkg", "1.0.0", null, outdated);
+
+        suppress.Should().BeTrue();
+        reason.Should().Contain("most recent of 3 attempts");
+        reason.Should().Contain($"{StatusReasonCode.VersionOutdated} x2");
+        reason.Should().Contain($"{StatusReasonCode.FileMissing} x1");
+    }
+
+    [Fact]
+    public void SuppressionMessage_SaysSoWhenNoTriggerWasEverRecorded()
+    {
+        // State written by a client that predates trigger capture: the warning must
+        // admit it has no cause rather than silently reporting only the counting rule.
+        var guard = CreateGuard();
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("OldPkg", "1.0.0", true);
+
+        var (suppress, reason) = guard.ShouldSuppress("OldPkg", "1.0.0");
+
+        suppress.Should().BeTrue();
+        reason.Should().Contain("not recorded");
+    }
+
+    [Fact]
+    public void SuppressedEvaluation_RefreshesTheReportedCauseWithoutCountingAnAttempt()
+    {
+        var guard = CreateGuard();
+        var missing = FileMissingTrigger();
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("LoopPkg", "1.0.0", true, trigger: missing);
+
+        var nowOutdated = InstallTrigger.From(StatusReasonCode.VersionOutdated, DetectionMethod.File,
+            "installs[0] file C:/Program Files/Thing/thing.exe: file version 1.0 is older than the catalog's 2.0")!;
+        var (suppress, reason) = guard.ShouldSuppress("LoopPkg", "1.0.0", null, nowOutdated);
+
+        suppress.Should().BeTrue();
+        reason.Should().Contain(StatusReasonCode.VersionOutdated);
+
+        // The refresh must not inflate the attempt evidence — it was never installed.
+        var state = guard.GetPackageState("LoopPkg")!;
+        state.AttemptCount.Should().Be(3);
+        state.TriggerCounts.Values.Sum().Should().Be(3);
+    }
+
+    [Fact]
+    public void CatalogChange_ClearsTheRecordedTriggerEvidence()
+    {
+        var guard = CreateGuard();
+        var trigger = FileMissingTrigger();
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("LoopPkg", "1.0.0", true, "fingerprint-a", trigger: trigger);
+
+        guard.ShouldSuppress("LoopPkg", "1.0.0", "fingerprint-b").Suppress.Should().BeFalse();
+
+        var state = guard.GetPackageState("LoopPkg")!;
+        state.TriggerCounts.Should().BeEmpty();
+        state.Trigger.Should().BeNull();
+    }
+
+    [Fact]
+    public void MarkNonConverged_NamesTheCheckThatDidNotConverge()
+    {
+        var guard = CreateGuard();
+        var trigger = InstallTrigger.From(StatusReasonCode.InstallcheckNeeded, DetectionMethod.Script,
+            "installcheck_script exited 0, which means install needed (script output: legacy key still present)")!;
+
+        var reason = guard.MarkNonConverged("StuckPkg", "1.0.0", "fp", 24, trigger);
+
+        reason.Should().Contain("installcheck_script exited 0");
+        reason.Should().Contain("legacy key still present");
+
+        var (suppress, message) = guard.ShouldSuppress("StuckPkg", "1.0.0", "fp");
+        suppress.Should().BeTrue();
+        message.Should().Contain("legacy key still present");
+    }
+
+    [Fact]
+    public void Trigger_DetailIsFlattenedAndTruncated()
+    {
+        var noisy = "line one" + Environment.NewLine + new string('x', 500);
+        var trigger = InstallTrigger.From(StatusReasonCode.ScriptError, DetectionMethod.Script, noisy)!;
+
+        trigger.Detail.Should().NotContainAny(Environment.NewLine, "\r", "\n");
+        trigger.Detail.Length.Should().BeLessThanOrEqualTo(InstallTrigger.MaxDetailLength + 1);
+    }
+
+    [Fact]
+    public void Trigger_SurvivesAStateReload()
+    {
+        var trigger = FileMissingTrigger();
+        var guard = CreateGuard();
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("LoopPkg", "1.0.0", true, trigger: trigger);
+
+        var reloaded = CreateGuard();
+        var (suppress, reason) = reloaded.ShouldSuppress("LoopPkg", "1.0.0");
+
+        suppress.Should().BeTrue();
+        reason.Should().Contain("thing.exe");
+    }
+
+    [Fact]
+    public void SuppressedReport_CarriesTheTrigger()
+    {
+        var guard = CreateGuard();
+        var trigger = FileMissingTrigger();
+        for (var i = 0; i < 3; i++)
+            guard.RecordAttempt("LoopPkg", "1.0.0", true, trigger: trigger);
+        guard.ShouldSuppress("LoopPkg", "1.0.0");
+
+        var report = guard.GetSuppressedReport().Single(r => r.Name == "LoopPkg");
+        report.Trigger.Should().NotBeNull();
+        report.Trigger!.ReasonCode.Should().Be(StatusReasonCode.FileMissing);
+        report.TriggerSummary.Should().Contain("thing.exe");
     }
 
     #endregion

--- a/wiki/install-loop-prevention.md
+++ b/wiki/install-loop-prevention.md
@@ -46,6 +46,31 @@ LoopGuard runs inside `UpdateEngine.IdentifyActions()` and actively blocks packa
 | 5+ total installs across 4+ sessions (any version) | 24 hours |
 | 8+ total installs across 5+ sessions (any version) | 7 days (the `LoopMaxTime` cap) |
 
+#### What the suppression warning tells you
+
+Every suppression warning reports the cause, not just the count. The counting rule
+("3 installs within 2 hours") establishes that a loop exists; the trigger says which
+detection criterion keeps deciding the package must run, which is the thing an admin
+actually has to fix:
+
+```
+LOOP SUPPRESSED: FortiClient v7.4.3.4799 — suppressed for 15h 1m. Loop rule: Rapid-fire loop: 3 installs within 2 hours. Needs install because: version_outdated via installs_array — installs[0] file C:\Program Files\Fortinet\FortiClient\FortiClient.exe: file version 7.4.3.1790 is older than the catalog's 7.4.3.4799 (same on all 3 attempts — the detection criteria never match what the installer lays down). Fix that criterion in the pkgsinfo — any catalog change clears this fleet-wide — or locally: managedsoftwareupdate --clear-loop FortiClient
+```
+
+The trigger is the `StatusService` result that scheduled the install: its reason code,
+the check that produced it (`installs_array`, `script`, `msi`, `registry`, …) and the
+detail, which names the specific `installs` entry by index and identity field, the
+`installcheck_script` output, or the product code that missed. "Same on all N attempts"
+means the criterion is stuck — the pkgsinfo is describing something the installer does
+not produce. Several different triggers across attempts means the machine is changing
+underneath the item instead.
+
+It is refreshed on every run, including runs where the package stayed suppressed and was
+never installed, so the warning reports what the item wants **now** rather than what it
+wanted when the window opened. The same trigger is written to
+`reports/loop_suppressed.json` and printed by `--loop-status`. State written by a client
+older than this reports `not recorded` until the next evaluation.
+
 #### Auto-Clear on Catalog Change
 
 When the pkgsinfo behind a package changes, LoopGuard **clears that package's loop
@@ -182,6 +207,8 @@ NvidiaGeforce:
   Last attempt: 2/25/2026 4:00 AM
   Last success: True
   Versions attempted: 572.61 (8x)
+  Needs install because: hash_mismatch via installs_array — installs[0] file C:\Windows\System32\nvapi64.dll: hash mismatch — expected 4f2a…, found 9c81… (same on all 8 attempts — the detection criteria never match what the installer lays down)
+  Trigger last seen: 2/25/2026 4:00 AM
   Cache: HIT — C:\ProgramData\ManagedInstalls\Cache\NvidiaGeforce\dbInstaller.exe
   Diagnosis: Loop is install/status-check issue, not download (cached installer exists)
   Suppressed until: indefinite


### PR DESCRIPTION
Loop suppression warnings said a loop existed but never why. `LOOP SUPPRESSED: X — suppressed for 3h (Rapid-fire loop: 3 installs within 2 hours)` gives an operator nothing to fix, so every one of these turns into a manual hunt: find the machine, read the pkgsinfo, re-run the checks by hand.

The client already knows the answer — `StatusService` produced a precise reason when it decided the item needed to run — it was just thrown away before the warning was written.

## What changed

- **`InstallTrigger`** — the check that decided a package must run: reason code, detection method, detail, installed version. Detail is flattened to one line and truncated (script output can be hundreds of lines).
- **Captured at the decision, replayed at the warning.** `UpdateEngine` remembers the trigger when `NeedsAction` is established and hands it to `RecordAttempt`; `LoopGuard` also refreshes it on every evaluation, including runs where the package stayed suppressed and was never installed — so the warning reports what the item wants now, not what it wanted when the window opened.
- **Distinct triggers are counted.** One trigger repeated on every attempt is a stuck detection criterion (the pkgsinfo describes something the installer never produces); several different ones mean the machine is changing underneath the item. The message says which.
- **Surfaces:** the suppression warning (what ReportMate shows), `--loop-status`, `reports/loop_suppressed.json`, and the non-convergence reason.
- **Sharper details.** Installs-array failures name the entry by index, type and identity field instead of a bare path; `MSI product not installed` now says which product/upgrade code missed; an `installcheck_script` failure quotes what the script said.

Before:

```
LOOP SUPPRESSED: FortiClient — suppressed for 15h 1m (Rapid-fire loop: 3 installs within 2 hours). Clear with: managedsoftwareupdate --clear-loop FortiClient
```

After:

```
LOOP SUPPRESSED: FortiClient v7.4.3.4799 — suppressed for 15h 1m. Loop rule: Rapid-fire loop: 3 installs within 2 hours. Needs install because: version_outdated via installs_array — installs[0] file C:\Program Files\Fortinet\FortiClient\FortiClient.exe: file version 7.4.3.1790 is older than the catalog's 7.4.3.4799 (same on all 3 attempts — the detection criteria never match what the installer lays down). Fix that criterion in the pkgsinfo — any catalog change clears this fleet-wide — or locally: managedsoftwareupdate --clear-loop FortiClient
```

## Compatibility

New optional parameters throughout; state written by older clients reports the cause as `not recorded` until its next evaluation, then fills in. No catalog or pkgsinfo format change.

## Tests

10 new LoopGuard tests (message content, refresh-while-suppressed not inflating attempt counts, catalog-change clearing trigger evidence, state round-trip, truncation, report payload). Suite: 1007 passed, 5 pre-existing failures on main unchanged (2 ConfigurationService, 3 PredicateEngine fixtures).