### PR TITLE
Split the loop report into two short messages

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -444,7 +444,7 @@ public class UpdateEngine : IDisposable
             // and in a sibling reports/loop_suppressed.json for dashboards.
             var loopSuppressedByName = loopSuppressed.ToDictionary(
                 x => x.Item.Name.ToLowerInvariant(),
-                x => (x.Reason, x.InstalledVersion, x.WasUpdate, x.PendingRestart));
+                x => (x.Reason, x.Cause, x.InstalledVersion, x.WasUpdate, x.PendingRestart));
 
             // AutoRemove: queue uninstall for packages installed by Cimian but no longer in any manifest
             if (_config.AutoRemove)
@@ -975,7 +975,7 @@ public class UpdateEngine : IDisposable
     }
 
     private (List<CatalogItem> ToInstall, List<CatalogItem> ToUpdate, List<CatalogItem> ToUninstall,
-             List<(CatalogItem Item, string Reason, string? InstalledVersion, bool WasUpdate, bool PendingRestart)> LoopSuppressed)
+             List<(CatalogItem Item, string Reason, string? Cause, string? InstalledVersion, bool WasUpdate, bool PendingRestart)> LoopSuppressed)
         IdentifyActions(List<ManifestItem> manifestItems, Dictionary<string, CatalogItem> catalogMap,
                         ItemFilterService? itemFilterService = null)
     {
@@ -986,7 +986,7 @@ public class UpdateEngine : IDisposable
         // can stamp them as Warning instead of letting them fall through to "Installed".
         // PendingRestart entries are the benign flavor: a prior install just needs a
         // reboot to finalize — surfaced as Pending, not Warning.
-        var loopSuppressed = new List<(CatalogItem, string, string?, bool, bool)>();
+        var loopSuppressed = new List<(CatalogItem, string, string?, string?, bool, bool)>();
 
         var sysArch = StatusService.GetSystemArchitecture();
 
@@ -1135,7 +1135,7 @@ public class UpdateEngine : IDisposable
                                     Cimian.Core.Models.DetectionMethod.None,
                                     status.InstalledVersion,
                                     false);
-                                loopSuppressed.Add((catalogItem, deferReason, status.InstalledVersion, status.IsUpdate, true));
+                                loopSuppressed.Add((catalogItem, deferReason, null, status.InstalledVersion, status.IsUpdate, true));
                                 break; // Skip this item
                             }
 
@@ -1143,8 +1143,16 @@ public class UpdateEngine : IDisposable
                                 catalogItem.Name, catalogItem.Version, fingerprint, TriggerFrom(status));
                             if (suppress)
                             {
+                                // Two messages, not one paragraph: what the loop is, and
+                                // what the package's checks keep finding.
+                                var loopCause = _loopGuard.GetSuppressionCause(catalogItem.Name);
                                 ConsoleLogger.Warn(loopReason);
                                 _sessionLogger?.Log("WARN", loopReason);
+                                if (!string.IsNullOrEmpty(loopCause))
+                                {
+                                    ConsoleLogger.Warn(loopCause);
+                                    _sessionLogger?.Log("WARN", loopCause);
+                                }
                                 _sessionLogger?.LogStatusCheck(
                                     catalogItem.Name,
                                     catalogItem.Version,
@@ -1154,7 +1162,7 @@ public class UpdateEngine : IDisposable
                                     Cimian.Core.Models.DetectionMethod.None,
                                     status.InstalledVersion,
                                     false);
-                                loopSuppressed.Add((catalogItem, loopReason, status.InstalledVersion, status.IsUpdate, false));
+                                loopSuppressed.Add((catalogItem, loopReason, loopCause, status.InstalledVersion, status.IsUpdate, false));
                                 break; // Skip this item
                             }
                         }
@@ -1985,7 +1993,12 @@ public class UpdateEngine : IDisposable
             (convergenceWarning, convergencePendingRestart, convergenceTrigger) = VerifyConvergence(item);
         }
 
-        outcomes.Add(new ItemOutcome(item.Name, item.Version, "install", success, success ? null : output, DateTime.UtcNow, warningMessage ?? convergenceWarning));
+        var convergenceCause = convergenceWarning != null && convergenceTrigger != null
+            ? $"Needs install because {convergenceTrigger.Describe()}"
+            : null;
+        outcomes.Add(new ItemOutcome(item.Name, item.Version, "install", success, success ? null : output, DateTime.UtcNow,
+            warningMessage ?? convergenceWarning,
+            warningMessage != null ? null : convergenceCause));
 
         if (success)
         {
@@ -2041,6 +2054,11 @@ public class UpdateEngine : IDisposable
             {
                 ConsoleLogger.Warn(convergenceWarning);
                 _sessionLogger?.Log("WARN", convergenceWarning);
+                if (convergenceCause != null)
+                {
+                    ConsoleLogger.Warn(convergenceCause);
+                    _sessionLogger?.Log("WARN", convergenceCause);
+                }
                 _loopGuard?.MarkNonConverged(item.Name, item.Version, ComputeCatalogFingerprint(item), _config.LoopReprobeHours, convergenceTrigger);
             }
 
@@ -2887,7 +2905,7 @@ public class UpdateEngine : IDisposable
         List<CatalogItem> toUninstall,
         Dictionary<string, CatalogItem> catalogMap,
         IReadOnlyDictionary<string, ItemOutcome> outcomesByName,
-        IReadOnlyDictionary<string, (string Reason, string? InstalledVersion, bool WasUpdate, bool PendingRestart)> loopSuppressedByName)
+        IReadOnlyDictionary<string, (string Reason, string? Cause, string? InstalledVersion, bool WasUpdate, bool PendingRestart)> loopSuppressedByName)
     {
         if (_sessionLogger == null) return;
 
@@ -2942,8 +2960,9 @@ public class UpdateEngine : IDisposable
                     ItemType = itemType,
                     DisplayName = displayName,
                     InstalledVersion = suppression.InstalledVersion,
-                    WarningMessage = suppression.PendingRestart ? null : suppression.Reason,
-                    StatusReason = suppression.Reason,
+                    WarningMessage = suppression.PendingRestart ? null : JoinWarnings(suppression.Reason, suppression.Cause),
+                    WarningMessages = suppression.PendingRestart ? null : WarningList(suppression.Reason, suppression.Cause),
+                    StatusReason = JoinWarnings(suppression.Reason, suppression.Cause),
                     StatusReasonCode = suppression.PendingRestart
                         ? Cimian.Core.Models.StatusReasonCode.PendingReboot
                         : Cimian.Core.Models.StatusReasonCode.LoopSuppressed,
@@ -2982,7 +3001,8 @@ public class UpdateEngine : IDisposable
                 ItemType = itemType,
                 DisplayName = displayName,
                 ErrorMessage = hadOutcome && !outcome!.Success ? outcome.ErrorMessage : null,
-                WarningMessage = hasWarning ? outcome!.WarningMessage : null,
+                WarningMessage = hasWarning ? JoinWarnings(outcome!.WarningMessage!, outcome.WarningDetail) : null,
+                WarningMessages = hasWarning ? WarningList(outcome!.WarningMessage!, outcome.WarningDetail) : null,
                 ActionPerformed = hadOutcome ? outcome!.Action : null,
                 OutcomeTimestamp = hadOutcome ? outcome!.Timestamp : null
             });
@@ -3360,6 +3380,23 @@ public class UpdateEngine : IDisposable
     /// </summary>
     private readonly Dictionary<string, Cimian.Core.Models.InstallTrigger> _installTriggers = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// A warning that has a cause is two messages, not one paragraph. Consumers that read
+    /// a single string get them joined; consumers that can render a list get the parts.
+    /// </summary>
+    private static List<string>? WarningList(string message, string? detail)
+    {
+        if (string.IsNullOrEmpty(message))
+            return null;
+        var list = new List<string> { message };
+        if (!string.IsNullOrEmpty(detail))
+            list.Add(detail);
+        return list;
+    }
+
+    private static string JoinWarnings(string message, string? detail) =>
+        string.IsNullOrEmpty(detail) ? message : $"{message}{Environment.NewLine}{detail}";
+
     private static Cimian.Core.Models.InstallTrigger? TriggerFrom(StatusCheckResult status) =>
         Cimian.Core.Models.InstallTrigger.From(status.ReasonCode, status.DetectionMethod, status.Reason, status.InstalledVersion);
 
@@ -3401,7 +3438,8 @@ public class UpdateEngine : IDisposable
             if (RequiresRestart(item) || RequiresLogout(item))
                 return (null, true, trigger);
 
-            var warning = $"installcheck did not converge: {item.Name} v{item.Version} still reports action needed ({status.Reason}) immediately after a successful install — fix the pkgsinfo installcheck/installs criteria (re-probes in {(_config.LoopReprobeHours > 0 ? _config.LoopReprobeHours : 24)}h; clears immediately on pkgsinfo change)";
+            var hours = _config.LoopReprobeHours > 0 ? _config.LoopReprobeHours : 24;
+            var warning = $"Looping install detected: {item.Name} v{item.Version} — installcheck still reported action needed immediately after a successful install; paused for {hours}h";
             return (warning, false, trigger);
         }
         catch

--- a/shared/core/Models/InstallTrigger.cs
+++ b/shared/core/Models/InstallTrigger.cs
@@ -63,18 +63,14 @@ public sealed class InstallTrigger
     public string Key => $"{ReasonCode}|{DetectionMethod}|{Detail}";
 
     /// <summary>
-    /// One-line operator-facing form: the code, the check that produced it, and the
-    /// detail. Reads as "why does this keep wanting to install".
+    /// Operator-facing form: the detail in plain words, since it already names the check
+    /// that produced it. The reason code is machine-facing and is appended by the caller
+    /// rather than lodged in the middle of the sentence.
     /// </summary>
-    public string Describe()
-    {
-        var head = string.IsNullOrEmpty(ReasonCode) ? "check" : ReasonCode;
-        var method = string.IsNullOrEmpty(DetectionMethod) || DetectionMethod == Models.DetectionMethod.None
-            ? null
-            : DetectionMethod;
-        var lead = method == null ? head : $"{head} via {method}";
-        return string.IsNullOrEmpty(Detail) ? lead : $"{lead} — {Detail}";
-    }
+    public string Describe() =>
+        string.IsNullOrEmpty(Detail)
+            ? (string.IsNullOrEmpty(ReasonCode) ? "an unnamed check" : ReasonCode)
+            : Detail;
 
     private static string Flatten(string? text)
     {

--- a/shared/core/Models/Reporting.cs
+++ b/shared/core/Models/Reporting.cs
@@ -649,6 +649,16 @@ public class SessionPackageInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? WarningMessage { get; set; }
 
+    /// <summary>
+    /// The same warning split into its parts, so a consumer can render them as separate
+    /// messages instead of one paragraph. A looping install produces two: what the loop
+    /// is, and what the package's own checks keep finding. <see cref="WarningMessage"/>
+    /// holds them joined, for consumers that expect a single string.
+    /// </summary>
+    [JsonPropertyName("warning_messages")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? WarningMessages { get; set; }
+
     #region Status Reason Tracking
 
     /// <summary>
@@ -710,7 +720,8 @@ public record ItemOutcome(
     bool Success,
     string? ErrorMessage,
     DateTime Timestamp,
-    string? WarningMessage = null);
+    string? WarningMessage = null,
+    string? WarningDetail = null);
 
 /// <summary>
 /// Reports a single loop-suppressed package for reports/loop_suppressed.json.

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -282,17 +282,28 @@ public class LoopGuard
     /// pkgsinfo by hand; the warning now carries the path, product code or script output
     /// that never converges.
     /// </summary>
-    private string BuildSuppressionMessage(string packageName, string version, PackageLoopState pkgState, TimeSpan remaining)
+    private static string BuildSuppressionMessage(string packageName, string version, PackageLoopState pkgState, TimeSpan remaining)
     {
         var shown = string.IsNullOrEmpty(version) ? pkgState.LastVersion : version;
         var name = string.IsNullOrEmpty(shown) ? packageName : $"{packageName} v{shown}";
+        var rule = pkgState.SuppressionReason ?? "repeated installs";
+        return $"Looping install detected: {name} — {rule}; paused for {FormatDuration(remaining)}";
+    }
 
-        var sb = new StringBuilder();
-        sb.Append($"LOOP SUPPRESSED: {name} — suppressed for {FormatDuration(remaining)}.");
-        sb.Append($" Loop rule: {pkgState.SuppressionReason ?? "unknown"}.");
-        sb.Append($" Needs install because: {DescribeTrigger(pkgState)}.");
-        sb.Append($" Fix that criterion in the pkgsinfo — any catalog change clears this fleet-wide — or locally: managedsoftwareupdate --clear-loop {packageName}");
-        return sb.ToString();
+    /// <summary>
+    /// The second half of a loop report: what the package's own checks keep finding, which
+    /// is the part an admin can act on. Kept separate from the suppression message so the
+    /// two can be surfaced as two warnings on the same item rather than one paragraph.
+    /// Null when the package has no loop history at all.
+    /// </summary>
+    public string? GetSuppressionCause(string packageName)
+    {
+        if (string.IsNullOrEmpty(packageName))
+            return null;
+
+        return _state.Packages.TryGetValue(packageName.ToLowerInvariant(), out var pkgState)
+            ? $"Needs install because {DescribeTrigger(pkgState)}"
+            : null;
     }
 
     /// <summary>
@@ -302,23 +313,26 @@ public class LoopGuard
     private static string DescribeTrigger(PackageLoopState pkgState)
     {
         if (pkgState.Trigger == null)
-            return "not recorded — the loop history predates trigger capture; it is recorded on the next evaluation";
+            return "the cause was not recorded yet — it is captured on the next check";
 
         var described = pkgState.Trigger.Describe();
+        var code = pkgState.Trigger.ReasonCode;
         var total = pkgState.TriggerCounts.Values.Sum();
 
+        // Machine-facing tags go at the end, in brackets, so the sentence itself stays
+        // readable: what was checked, what it found, then how consistent it has been.
         if (pkgState.TriggerCounts.Count == 1 && total >= 2)
-            return $"{described} (same on all {total} attempts — the detection criteria never match what the installer lays down)";
+            return $"{described} [{code}, unchanged over all {total} attempts]";
 
         if (pkgState.TriggerCounts.Count > 1)
         {
             var codes = pkgState.TriggerCounts
                 .OrderByDescending(kv => kv.Value)
                 .Select(kv => $"{kv.Key.Split('|')[0]} x{kv.Value}");
-            return $"{described} (most recent of {total} attempts: {string.Join(", ", codes)})";
+            return $"{described} [most recent of {total} attempts: {string.Join(", ", codes)}]";
         }
 
-        return described;
+        return string.IsNullOrEmpty(code) ? described : $"{described} [{code}]";
     }
 
     /// <summary>
@@ -480,14 +494,10 @@ public class LoopGuard
         while (pkgState.RecentTimestamps.Count > 20)
             pkgState.RecentTimestamps.RemoveAt(0);
 
-        // Check if this attempt triggers suppression
-        var (suppress, reason) = EvaluateSuppressionThresholds(key, pkgState, version);
-        if (suppress)
-        {
-            // Suppression will take effect on the NEXT run, not this one
-            // (current run already committed to installing)
-            pkgState.SuppressionReason = reason;
-        }
+        // Check if this attempt triggers suppression. Suppress() records the window and
+        // the rule that opened it; the operator-facing message is composed at report time
+        // from that rule plus the observed cause, so nothing is stored pre-formatted.
+        EvaluateSuppressionThresholds(key, pkgState, version);
 
         SaveState();
     }
@@ -609,7 +619,7 @@ public class LoopGuard
             return (false, "");
         }
 
-        return (true, $"PENDING RESTART: {packageName} v{pkgState.LastVersion} installed successfully but is finalized by a reboot — deferring reinstall until the machine restarts");
+        return (true, $"Pending restart: {packageName} v{pkgState.LastVersion} installed successfully and is finalized by a reboot — reinstall deferred until the machine restarts");
     }
 
     /// <summary>
@@ -627,8 +637,7 @@ public class LoopGuard
     {
         var hours = reprobeHours > 0 ? reprobeHours : 24;
         hours = Math.Min(hours, _maxSuppressionDays * 24);
-        var cause = trigger == null ? "" : $" [{trigger.Describe()}]";
-        var reason = $"installcheck did not converge: {packageName} v{version} still reports action needed immediately after a successful install{cause} — fix the pkgsinfo installcheck/installs criteria (re-probes in {hours}h; clears immediately on pkgsinfo change)";
+        var reason = "installcheck still reported action needed immediately after a successful install";
 
         if (_disabled || string.IsNullOrEmpty(packageName))
             return reason;
@@ -736,7 +745,7 @@ public class LoopGuard
         if (recentCount >= 3)
         {
             return Suppress(pkgState, TimeSpan.FromHours(12),
-                $"Rapid-fire loop: {recentCount} installs within 2 hours");
+                $"{recentCount} installs within 2 hours");
         }
 
         // Threshold 2: Same version reinstalled 3+ times across 3+ sessions
@@ -752,17 +761,17 @@ public class LoopGuard
             {
                 // Top tier — capped at 7 days (finite), then retries automatically
                 window = TimeSpan.FromDays(_maxSuppressionDays);
-                reason = $"Persistent loop: version {version} installed {versionCount} times across {pkgState.SessionCount} sessions ({_maxSuppressionDays}-day suppression)";
+                reason = $"installed {versionCount} times across {pkgState.SessionCount} sessions";
             }
             else if (versionCount >= 5)
             {
                 window = TimeSpan.FromHours(24);
-                reason = $"Escalated loop: version {version} installed {versionCount} times across {pkgState.SessionCount} sessions (24h suppression)";
+                reason = $"installed {versionCount} times across {pkgState.SessionCount} sessions";
             }
             else
             {
                 window = TimeSpan.FromHours(6);
-                reason = $"Install loop: version {version} installed {versionCount} times across {pkgState.SessionCount} sessions (6h suppression)";
+                reason = $"installed {versionCount} times across {pkgState.SessionCount} sessions";
             }
 
             return Suppress(pkgState, window, reason);
@@ -782,13 +791,13 @@ public class LoopGuard
         {
             // Top tier — capped at 7 days (finite), then retries automatically
             return Suppress(pkgState, TimeSpan.FromDays(_maxSuppressionDays),
-                $"Persistent loop: {pkgState.AttemptCount} total installs across {pkgState.SessionCount} sessions ({_maxSuppressionDays}-day suppression)");
+                $"{pkgState.AttemptCount} installs across {pkgState.SessionCount} sessions");
         }
 
         if (loopAttempts >= 5 && pkgState.SessionCount >= 4)
         {
             return Suppress(pkgState, TimeSpan.FromHours(24),
-                $"Escalated loop: {pkgState.AttemptCount} total installs across {pkgState.SessionCount} sessions (24h suppression)");
+                $"{pkgState.AttemptCount} installs across {pkgState.SessionCount} sessions");
         }
 
         return (false, "");
@@ -824,7 +833,11 @@ public class LoopGuard
         pkgState.SuppressedUntil = DateTime.UtcNow + window;
         pkgState.SuppressionReason = reason;
         SaveState();
-        return (true, reason);
+
+        // The run that trips a loop reports it the same way as every run after it —
+        // otherwise the first (and most useful) warning is the only one that arrives
+        // without the package name or how long it is paused for.
+        return (true, BuildSuppressionMessage(pkgState.PackageName, pkgState.LastVersion ?? "", pkgState, window));
     }
 
     #endregion
@@ -1139,7 +1152,7 @@ public class LoopGuard
             lines.Add($"  Versions attempted: {string.Join(", ", pkgState.VersionAttempts.Select(v => $"{v.Key} ({v.Value}x)"))}");
         }
 
-        lines.Add($"  Needs install because: {DescribeTrigger(pkgState)}");
+        lines.Add($"  Needs install because {DescribeTrigger(pkgState)}");
         if (pkgState.TriggerLastSeen.HasValue)
             lines.Add($"  Trigger last seen: {pkgState.TriggerLastSeen.Value.ToString("g")}");
 

--- a/tests/ItemsJsonFinalizationTests.cs
+++ b/tests/ItemsJsonFinalizationTests.cs
@@ -256,10 +256,9 @@ public class ItemsJsonFinalizationTests
             var entry = Assert.Single(report);
             Assert.Equal("WinAdminsAccount", entry.Name);
             Assert.Equal("1.0", entry.Version);
-            // Stored reason is the policy-level cause (LoopGuard composes the
-            // operator-facing "LOOP SUPPRESSED: <name> ..." string at ShouldSuppress
-            // time, not at storage time).
-            Assert.Contains("Rapid-fire", entry.Reason);
+            // Stored reason is the bare rule that opened the window; the operator-facing
+            // "Looping install detected: ..." message is composed at report time.
+            Assert.Contains("3 installs within 2 hours", entry.Reason);
             Assert.Equal("managedsoftwareupdate --clear-loop WinAdminsAccount", entry.ClearCommand);
         }
         finally

--- a/tests/LoopGuardTests.cs
+++ b/tests/LoopGuardTests.cs
@@ -202,7 +202,7 @@ public class LoopGuardTests : IDisposable
         guard.RecordAttempt("MixedPkg", "1.0.0", success: true);
         var (suppress2, reason) = guard.ShouldSuppress("MixedPkg", "1.0.0");
         suppress2.Should().BeTrue("loop guard must still catch real install loops");
-        reason.Should().Contain("LOOP SUPPRESSED");
+        reason.Should().Contain("Looping install detected");
     }
 
     [Fact]
@@ -236,8 +236,10 @@ public class LoopGuardTests : IDisposable
         // Should now be suppressed
         var (suppress, reason) = guard.ShouldSuppress("RapidPkg", "2.0.0");
         suppress.Should().BeTrue();
-        reason.Should().Contain("LOOP SUPPRESSED");
-        reason.Should().Contain("--clear-loop");
+        reason.Should().Contain("Looping install detected");
+        reason.Should().Contain("3 installs within 2 hours");
+        // The fix advice is not repeated on every warning any more.
+        reason.Should().NotContain("--clear-loop");
     }
 
     #endregion
@@ -256,7 +258,8 @@ public class LoopGuardTests : IDisposable
 
         var (suppress, reason) = guard.ShouldSuppress("EscPkg", "3.0.0");
         suppress.Should().BeTrue();
-        reason.Should().Contain("6h");
+        reason.Should().Contain("paused for 6h");
+        guard.GetPackageState("EscPkg")!.SuppressedUntil.Should().BeCloseTo(DateTime.UtcNow.AddHours(6), TimeSpan.FromMinutes(2));
     }
 
     [Fact]
@@ -269,7 +272,8 @@ public class LoopGuardTests : IDisposable
 
         var (suppress, reason) = guard.ShouldSuppress("EscPkg5", "3.0.0");
         suppress.Should().BeTrue();
-        reason.Should().Contain("24h");
+        reason.Should().Contain("paused for 1d");
+        guard.GetPackageState("EscPkg5")!.SuppressedUntil.Should().BeCloseTo(DateTime.UtcNow.AddHours(24), TimeSpan.FromMinutes(2));
     }
 
     [Fact]
@@ -284,8 +288,9 @@ public class LoopGuardTests : IDisposable
         // stranded by a transient failure retries automatically instead of being blacklisted.
         var (suppress, reason) = guard.ShouldSuppress("EscPkg8", "3.0.0");
         suppress.Should().BeTrue();
-        reason.Should().Contain("7-day");
+        reason.Should().Contain("paused for 7d");
         reason.Should().NotContain("indefinite");
+        guard.GetPackageState("EscPkg8")!.SuppressedUntil.Should().BeCloseTo(DateTime.UtcNow.AddDays(7), TimeSpan.FromMinutes(2));
     }
 
     #endregion
@@ -707,7 +712,7 @@ public class LoopGuardTests : IDisposable
         state.SuppressedUntil.Should().NotBeNull();
         // Rapid-fire alone is 12h; the served cycle floors it at 24h.
         state.SuppressedUntil!.Value.Should().BeAfter(DateTime.UtcNow.AddHours(23));
-        state.SuppressionReason.Should().Contain("escalated");
+        state.SuppressionReason.Should().Contain("installs");
 
         state.SuppressedUntil = DateTime.UtcNow.AddMinutes(-1);
         guard.ShouldSuppress("EscalatePkg", "1.0.0");
@@ -903,11 +908,11 @@ public class LoopGuardTests : IDisposable
     {
         var guard = CreateGuard();
         var reason = guard.MarkNonConverged("BadCheck", "1.0.0", "fp1", reprobeHours: 24);
-        reason.Should().Contain("did not converge");
+        reason.Should().Contain("installcheck still reported action needed");
 
         var (suppress, msg) = guard.ShouldSuppress("BadCheck", "1.0.0", "fp1");
         suppress.Should().BeTrue();
-        msg.Should().Contain("did not converge");
+        msg.Should().Contain("installcheck still reported action needed");
     }
 
     [Fact]
@@ -947,7 +952,7 @@ public class LoopGuardTests : IDisposable
 
         var (defer, reason) = guard.ShouldDeferForRestart("FirmwarePkg", "fp1");
         defer.Should().BeTrue();
-        reason.Should().Contain("PENDING RESTART");
+        reason.Should().Contain("Pending restart");
     }
 
     [Fact]
@@ -1031,14 +1036,19 @@ public class LoopGuardTests : IDisposable
         guard.RecordAttempt("LoopPkg", "1.0.0", true, trigger: trigger);
 
         var (suppress, reason) = guard.ShouldSuppress("LoopPkg", "1.0.0", null, trigger);
+        var cause = guard.GetSuppressionCause("LoopPkg");
 
         suppress.Should().BeTrue();
-        reason.Should().Contain("Needs install because");
-        reason.Should().Contain(StatusReasonCode.FileMissing);
-        reason.Should().Contain("installs[0] file");
-        reason.Should().Contain("thing.exe");
-        reason.Should().Contain("same on all 3 attempts");
-        reason.Should().Contain("--clear-loop LoopPkg");
+
+        // Two messages: the loop, then the cause. Neither repeats the other.
+        reason.Should().Contain("Looping install detected: LoopPkg v1.0.0");
+        reason.Should().NotContain("Needs install because");
+
+        cause.Should().StartWith("Needs install because");
+        cause.Should().Contain(StatusReasonCode.FileMissing);
+        cause.Should().Contain("installs[0] file");
+        cause.Should().Contain("thing.exe");
+        cause.Should().Contain("unchanged over all 3 attempts");
     }
 
     [Fact]
@@ -1052,8 +1062,11 @@ public class LoopGuardTests : IDisposable
         var (_, reason) = guard.ShouldSuppress("LoopPkg", "2.5.0", null, trigger);
 
         reason.Should().Contain("LoopPkg v2.5.0");
-        reason.Should().Contain("Loop rule:");
-        reason.Should().MatchRegex("Rapid-fire|Install loop|Escalated|Persistent");
+        reason.Should().Contain("3 installs within 2 hours");
+        reason.Should().Contain("paused for");
+        // The rule speaks for itself — no "Loop rule:" label, no advice tail.
+        reason.Should().NotContain("Loop rule");
+        reason.Should().NotContain("managedsoftwareupdate");
     }
 
     [Fact]
@@ -1068,12 +1081,13 @@ public class LoopGuardTests : IDisposable
         guard.RecordAttempt("MixedPkg", "1.0.0", true, trigger: outdated);
         guard.RecordAttempt("MixedPkg", "1.0.0", true, trigger: outdated);
 
-        var (suppress, reason) = guard.ShouldSuppress("MixedPkg", "1.0.0", null, outdated);
+        var (suppress, _) = guard.ShouldSuppress("MixedPkg", "1.0.0", null, outdated);
+        var cause = guard.GetSuppressionCause("MixedPkg")!;
 
         suppress.Should().BeTrue();
-        reason.Should().Contain("most recent of 3 attempts");
-        reason.Should().Contain($"{StatusReasonCode.VersionOutdated} x2");
-        reason.Should().Contain($"{StatusReasonCode.FileMissing} x1");
+        cause.Should().Contain("most recent of 3 attempts");
+        cause.Should().Contain($"{StatusReasonCode.VersionOutdated} x2");
+        cause.Should().Contain($"{StatusReasonCode.FileMissing} x1");
     }
 
     [Fact]
@@ -1085,10 +1099,10 @@ public class LoopGuardTests : IDisposable
         for (var i = 0; i < 3; i++)
             guard.RecordAttempt("OldPkg", "1.0.0", true);
 
-        var (suppress, reason) = guard.ShouldSuppress("OldPkg", "1.0.0");
+        var (suppress, _) = guard.ShouldSuppress("OldPkg", "1.0.0");
 
         suppress.Should().BeTrue();
-        reason.Should().Contain("not recorded");
+        guard.GetSuppressionCause("OldPkg").Should().Contain("not recorded yet");
     }
 
     [Fact]
@@ -1101,10 +1115,10 @@ public class LoopGuardTests : IDisposable
 
         var nowOutdated = InstallTrigger.From(StatusReasonCode.VersionOutdated, DetectionMethod.File,
             "installs[0] file C:/Program Files/Thing/thing.exe: file version 1.0 is older than the catalog's 2.0")!;
-        var (suppress, reason) = guard.ShouldSuppress("LoopPkg", "1.0.0", null, nowOutdated);
+        var (suppress, _) = guard.ShouldSuppress("LoopPkg", "1.0.0", null, nowOutdated);
 
         suppress.Should().BeTrue();
-        reason.Should().Contain(StatusReasonCode.VersionOutdated);
+        guard.GetSuppressionCause("LoopPkg").Should().Contain(StatusReasonCode.VersionOutdated);
 
         // The refresh must not inflate the attempt evidence — it was never installed.
         var state = guard.GetPackageState("LoopPkg")!;
@@ -1136,12 +1150,12 @@ public class LoopGuardTests : IDisposable
 
         var reason = guard.MarkNonConverged("StuckPkg", "1.0.0", "fp", 24, trigger);
 
-        reason.Should().Contain("installcheck_script exited 0");
-        reason.Should().Contain("legacy key still present");
+        reason.Should().Contain("installcheck still reported action needed");
 
         var (suppress, message) = guard.ShouldSuppress("StuckPkg", "1.0.0", "fp");
         suppress.Should().BeTrue();
-        message.Should().Contain("legacy key still present");
+        message.Should().Contain("installcheck still reported action needed");
+        guard.GetSuppressionCause("StuckPkg").Should().Contain("legacy key still present");
     }
 
     [Fact]
@@ -1163,10 +1177,10 @@ public class LoopGuardTests : IDisposable
             guard.RecordAttempt("LoopPkg", "1.0.0", true, trigger: trigger);
 
         var reloaded = CreateGuard();
-        var (suppress, reason) = reloaded.ShouldSuppress("LoopPkg", "1.0.0");
+        var (suppress, _) = reloaded.ShouldSuppress("LoopPkg", "1.0.0");
 
         suppress.Should().BeTrue();
-        reason.Should().Contain("thing.exe");
+        reloaded.GetSuppressionCause("LoopPkg").Should().Contain("thing.exe");
     }
 
     [Fact]

--- a/wiki/install-loop-prevention.md
+++ b/wiki/install-loop-prevention.md
@@ -46,30 +46,36 @@ LoopGuard runs inside `UpdateEngine.IdentifyActions()` and actively blocks packa
 | 5+ total installs across 4+ sessions (any version) | 24 hours |
 | 8+ total installs across 5+ sessions (any version) | 7 days (the `LoopMaxTime` cap) |
 
-#### What the suppression warning tells you
+#### What a loop reports
 
-Every suppression warning reports the cause, not just the count. The counting rule
-("3 installs within 2 hours") establishes that a loop exists; the trigger says which
-detection criterion keeps deciding the package must run, which is the thing an admin
-actually has to fix:
+A loop is reported as two messages on the same item, so neither has to be read as a
+paragraph. The first says what the loop is; the second says what the package's own
+checks keep finding, which is the part an admin can act on:
 
 ```
-LOOP SUPPRESSED: FortiClient v7.4.3.4799 — suppressed for 15h 1m. Loop rule: Rapid-fire loop: 3 installs within 2 hours. Needs install because: version_outdated via installs_array — installs[0] file C:\Program Files\Fortinet\FortiClient\FortiClient.exe: file version 7.4.3.1790 is older than the catalog's 7.4.3.4799 (same on all 3 attempts — the detection criteria never match what the installer lays down). Fix that criterion in the pkgsinfo — any catalog change clears this fleet-wide — or locally: managedsoftwareupdate --clear-loop FortiClient
+Looping install detected: FortiClient v7.4.3.4799 — 3 installs within 2 hours; paused for 12h 59m
+Needs install because installs[0] file C:\Program Files\Fortinet\FortiClient\FortiClient.exe: file version 7.4.3.1790 is older than the catalog's 7.4.3.4799 [version_outdated, unchanged over all 3 attempts]
 ```
 
-The trigger is the `StatusService` result that scheduled the install: its reason code,
-the check that produced it (`installs_array`, `script`, `msi`, `registry`, …) and the
-detail, which names the specific `installs` entry by index and identity field, the
-`installcheck_script` output, or the product code that missed. "Same on all N attempts"
-means the criterion is stuck — the pkgsinfo is describing something the installer does
-not produce. Several different triggers across attempts means the machine is changing
-underneath the item instead.
+They arrive as two WARN lines in the session log, as `warning_messages` in items.json
+(with `warning_message` holding them joined, for consumers that expect one string), and
+as two lines in `--loop-status`.
 
-It is refreshed on every run, including runs where the package stayed suppressed and was
-never installed, so the warning reports what the item wants **now** rather than what it
-wanted when the window opened. The same trigger is written to
-`reports/loop_suppressed.json` and printed by `--loop-status`. State written by a client
-older than this reports `not recorded` until the next evaluation.
+The cause comes from the `StatusService` result that scheduled the install. Its detail
+names the specific `installs` entry by index and identity field, the `installcheck_script`
+output, or the product code that missed; the bracketed tags carry the machine-readable
+reason code and how consistent the answer has been. `unchanged over all N attempts` means
+the criterion is stuck — the pkgsinfo describes something the installer does not produce.
+Several different reasons across attempts means the machine is changing underneath the
+item instead.
+
+The cause is refreshed on every run, including runs where the package stayed suppressed
+and was never installed, so it reports what the item wants **now** rather than what it
+wanted when the window opened. State written by a client older than this reports the cause
+as not recorded until the next check.
+
+Neither message repeats the fix advice. Any catalog change clears suppression fleet-wide
+(see below); `managedsoftwareupdate --clear-loop <name>` clears one machine.
 
 #### Auto-Clear on Catalog Change
 
@@ -207,12 +213,12 @@ NvidiaGeforce:
   Last attempt: 2/25/2026 4:00 AM
   Last success: True
   Versions attempted: 572.61 (8x)
-  Needs install because: hash_mismatch via installs_array — installs[0] file C:\Windows\System32\nvapi64.dll: hash mismatch — expected 4f2a…, found 9c81… (same on all 8 attempts — the detection criteria never match what the installer lays down)
+  Needs install because installs[0] file C:\Windows\System32\nvapi64.dll: hash mismatch — expected 4f2a…, found 9c81… [hash_mismatch, unchanged over all 8 attempts]
   Trigger last seen: 2/25/2026 4:00 AM
   Cache: HIT — C:\ProgramData\ManagedInstalls\Cache\NvidiaGeforce\dbInstaller.exe
   Diagnosis: Loop is install/status-check issue, not download (cached installer exists)
   Suppressed until: indefinite
-  Reason: Persistent loop: version 572.61 installed 8 times across 6 sessions (indefinite)
+  Reason: installed 8 times across 6 sessions
 ```
 
 ### Check items.json for warnings


### PR DESCRIPTION
Follow-up to #120. The warning it produced was correct but a wall of text.

A loop is now two messages on the same item — what the loop is, and what the package's own checks keep finding:

```
Looping install detected: FortiClient v7.4.3.4799 — 3 installs within 2 hours; paused for 12h 59m
Needs install because installs[0] file C:\Program Files\...\FortiClient.exe: file version 7.4.3.1790 is older than the catalog's 7.4.3.4799 [version_outdated, unchanged over all 3 attempts]
```

- `warning_messages` (list) on the item carries the parts; `warning_message` keeps them joined for consumers that read one string. Same split for the non-convergence warning, and two WARN lines in the session log.
- The fix advice — "fix the pkgsinfo … or clear with `managedsoftwareupdate --clear-loop <name>`" — is gone from every message. It was repeated per item per session and is documented once in the wiki.
- No shouting: `LOOP SUPPRESSED` → `Looping install detected`, `PENDING RESTART` → `Pending restart`.
- The rule states itself: `Loop rule: Rapid-fire loop: 3 installs within 2 hours` → `3 installs within 2 hours`, with the duplicated `(6h suppression)` tail dropped since the message already says how long it is paused.
- Machine-readable tags moved to the end in brackets so the sentence reads as prose.

Also fixed along the way: the run that **first** trips a loop reported the bare rule with no package name, version or duration — only later runs got the full message. Both paths now compose the same message, and stored state keeps the rule alone rather than a pre-formatted string.

Suite: 1007 passed, the same 5 pre-existing failures as main.