### PR TITLE
Apply a staged self-update as soon as the client is idle

### DIFF
--- a/cli/cimiwatcher/Services/FileWatcherService.cs
+++ b/cli/cimiwatcher/Services/FileWatcherService.cs
@@ -55,6 +55,7 @@ public class FileWatcherService : BackgroundService
                 if (!_isPaused)
                 {
                     CheckBootstrapFiles(stoppingToken);
+                    ApplyStagedSelfUpdateIfIdle();
                 }
                 
                 await Task.Delay(PollInterval, stoppingToken);
@@ -72,6 +73,73 @@ public class FileWatcherService : BackgroundService
         }
 
         _logger.LogInformation("CimianWatcher file monitoring service stopped");
+    }
+
+    /// <summary>
+    /// Applies a self-update that an earlier run staged, without waiting for a
+    /// service restart or for a flag-file-triggered run.
+    ///
+    /// The routine hourly run is a scheduled task that invokes
+    /// managedsoftwareupdate.exe directly, so it never passes through
+    /// RunBootstrapUpdateAsync and the post-run check that lives there. A staged
+    /// update therefore sat on disk until the machine rebooted or the nightly
+    /// bootstrap fired, which put up to a day between publishing a client and
+    /// the fleet running it.
+    ///
+    /// The installer stops this service and replaces managedsoftwareupdate.exe,
+    /// so it must never start while a run is in flight - that truncates the
+    /// session mid-install. Hence both guards: the flag we set for our own
+    /// triggered runs, and a process check that also covers runs launched by the
+    /// scheduled task or by hand.
+    /// </summary>
+    private void ApplyStagedSelfUpdateIfIdle()
+    {
+        if (!SelfUpdateService.IsSelfUpdatePending())
+            return;
+
+        if (Interlocked.CompareExchange(ref _updateRunning, 1, 0) != 0)
+        {
+            _logger.LogDebug("Self-update staged, but a triggered update is running - deferring");
+            return;
+        }
+
+        try
+        {
+            if (IsManagedSoftwareUpdateRunning())
+            {
+                _logger.LogDebug(
+                    "Self-update staged, but managedsoftwareupdate is running - deferring");
+                return;
+            }
+
+            _logger.LogInformation("Self-update staged by an earlier run - applying now");
+            CheckAndPerformSelfUpdate();
+        }
+        finally
+        {
+            // Not reached on the success path: CheckAndPerformSelfUpdate exits
+            // the process once the detached installer is running.
+            Interlocked.Exchange(ref _updateRunning, 0);
+        }
+    }
+
+    /// <summary>
+    /// True when any managedsoftwareupdate process is running, including one this
+    /// service did not launch.
+    /// </summary>
+    private bool IsManagedSoftwareUpdateRunning()
+    {
+        try
+        {
+            return Process.GetProcessesByName("managedsoftwareupdate").Length > 0;
+        }
+        catch (Exception ex)
+        {
+            // An unreadable process list counts as busy: deferring costs one poll
+            // interval, guessing wrong truncates an install session.
+            _logger.LogDebug(ex, "Could not enumerate processes - assuming a run is active");
+            return true;
+        }
     }
 
     private void CheckBootstrapFiles(CancellationToken cancellationToken)


### PR DESCRIPTION
Closes #122.

`managedsoftwareupdate` stages a client self-update rather than installing it inline, because the installer replaces the binaries that are running. Consuming that staged flag only happened at watcher service start and at the end of a run the watcher itself launched from a bootstrap flag file. The hourly scheduled task calls `managedsoftwareupdate.exe --auto` directly and reaches neither, so it could only ever stage.

`FileWatcherService` now checks for the staged flag on its regular 10-second poll and applies it when the client is idle, reusing the existing `CheckAndPerformSelfUpdate` path — launch the detached installer, exit, let the SCM restart the service on the new binary.

Two guards, because the installer stops the service and replaces `managedsoftwareupdate.exe`, and starting it mid-session truncates an install:

- `_updateRunning`, which covers runs the watcher triggered
- a `managedsoftwareupdate` process check, which covers the scheduled task and manual runs

An unreadable process list counts as busy: deferring costs one poll interval, guessing wrong truncates a session.

Test suite: 1008 passing, 4 failing — the `ConfigurationServiceTests`/`PredicateEngineTests` fixture failures that already fail on `main`. `cimiwatcher` has no test project; the change is in a `BackgroundService` loop that binds to machine-wide paths and a live process table.