### PR TITLE
Bound installcheck script execution

### DIFF
--- a/cli/managedsoftwareupdate/Services/ScriptService.cs
+++ b/cli/managedsoftwareupdate/Services/ScriptService.cs
@@ -19,6 +19,8 @@ public record ScriptResult(bool Success, int ExitCode, string Output, string? Wa
 /// </summary>
 public class ScriptService
 {
+    public const int TimeoutExitCode = -2;
+
     // Postinstall scripts may emit a line of the form:
     //   CIMIAN-WARNING: <message>
     // on stdout or stderr. The runner extracts the message into ScriptResult.WarningMessage,
@@ -208,7 +210,37 @@ public class ScriptService
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            await process.WaitForExitAsync(cancellationToken);
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                        await process.WaitForExitAsync(CancellationToken.None);
+                    }
+                }
+                catch (Exception killException)
+                {
+                    errors.AppendLine($"Failed to terminate timed-out script process: {killException.Message}");
+                }
+
+                var timedOutOutput = output.ToString();
+                if (errors.Length > 0)
+                {
+                    timedOutOutput += Environment.NewLine + errors;
+                }
+
+                return new ScriptResult(
+                    Success: false,
+                    ExitCode: TimeoutExitCode,
+                    Output: $"Script execution timed out.{Environment.NewLine}{timedOutOutput}".Trim(),
+                    WarningMessage: null);
+            }
 
             var combinedOutput = output.ToString();
             if (errors.Length > 0)

--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -20,6 +20,13 @@ namespace Cimian.CLI.managedsoftwareupdate.Services;
 public class StatusService
 {
     private static readonly string BootstrapFlagFile = CimianPaths.BootstrapFlagFile;
+    private static readonly TimeSpan DefaultInstallcheckTimeout = TimeSpan.FromMinutes(2);
+    private readonly TimeSpan _installcheckTimeout;
+
+    public StatusService(TimeSpan? installcheckTimeout = null)
+    {
+        _installcheckTimeout = installcheckTimeout ?? DefaultInstallcheckTimeout;
+    }
 
     /// <summary>
     /// Checks if the item is the Cimian/CimianTools self-update package
@@ -311,9 +318,28 @@ public class StatusService
         try
         {
             var scriptService = new ScriptService();
-            var (success, output) = scriptService.ExecuteScriptAsync(item.InstallcheckScript!).Result;
+            using var timeout = new CancellationTokenSource(_installcheckTimeout);
+            var scriptResult = scriptService
+                .ExecuteScriptWithDetailsAsync(item.InstallcheckScript!, timeout.Token)
+                .GetAwaiter()
+                .GetResult();
+            var success = scriptResult.Success;
+            var output = scriptResult.Output;
 
             ConsoleLogger.Debug($"InstallCheckScript output stdout: {output?.Trim()} stderr:  error: <nil>");
+
+            if (scriptResult.ExitCode == ScriptService.TimeoutExitCode)
+            {
+                var timeoutSeconds = Math.Ceiling(_installcheckTimeout.TotalSeconds);
+                var reason = $"installcheck_script timed out after {timeoutSeconds:0} seconds for {item.Name}";
+                ConsoleLogger.Error(reason);
+                result.Status = "error";
+                result.NeedsAction = false;
+                result.Reason = reason;
+                result.ReasonCode = StatusReasonCode.ScriptError;
+                result.Error = new TimeoutException(reason);
+                return result;
+            }
 
             // Go behavior: exit code 0 = needs install, exit code 1 = does not need install
             if (success) // exit 0

--- a/tests/Managedsoftwareupdate/ScriptServiceTests.cs
+++ b/tests/Managedsoftwareupdate/ScriptServiceTests.cs
@@ -219,6 +219,23 @@ if ($value -gt 5) {
         Assert.Contains("Quick script", output);
     }
 
+    [Fact]
+    public async Task ExecuteScriptWithDetailsAsync_CancellationTerminatesHungScript()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        var result = await _service.ExecuteScriptWithDetailsAsync(
+            "while ($true) { Start-Sleep -Milliseconds 100 }",
+            cts.Token);
+
+        stopwatch.Stop();
+        Assert.False(result.Success);
+        Assert.Equal(ScriptService.TimeoutExitCode, result.ExitCode);
+        Assert.Contains("timed out", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5));
+    }
+
     #endregion
 
     #region ExecuteScriptWithDetailsAsync - CIMIAN-WARNING marker tests

--- a/tests/Managedsoftwareupdate/StatusServiceTests.cs
+++ b/tests/Managedsoftwareupdate/StatusServiceTests.cs
@@ -58,6 +58,26 @@ public class StatusServiceTests
 
     #endregion
 
+    [Fact]
+    public void CheckStatus_TimedOutInstallcheck_ReturnsDetectionErrorWithoutInstall()
+    {
+        var service = new StatusService(TimeSpan.FromMilliseconds(250));
+        var item = new CatalogItem
+        {
+            Name = "HungDetection",
+            Version = "1.0.0",
+            InstallcheckScript = "while ($true) { Start-Sleep -Milliseconds 100 }"
+        };
+
+        var result = service.CheckStatus(item, "install", _testDir);
+
+        Assert.Equal("error", result.Status);
+        Assert.False(result.NeedsAction);
+        Assert.Equal(Cimian.Core.Models.StatusReasonCode.ScriptError, result.ReasonCode);
+        Assert.Contains("timed out", result.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(item.Name, result.Reason);
+    }
+
     #region Static Method Tests
 
     [Fact]


### PR DESCRIPTION
## Summary

- bound installcheck scripts to two minutes by default
- terminate the full process tree when the bound expires
- report detection as an error without attempting a blind install
- cover process termination and status classification with tests

## Verification

- 58 ScriptService and StatusService tests pass

Closes #127