### PR TITLE
Surface direct-msiexec failure diagnostics

### DIFF
--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -986,6 +986,13 @@ public class InstallerService
                 {
                     output += $"\nMSI_EXIT={finalCode}";
                 }
+                var diagnostics = ExtractMsiFailureDiagnostics(logPath);
+                if (diagnostics.Count > 0)
+                {
+                    output += "\n--- failure diagnostics from MSI log ---\n";
+                    output += string.Join(Environment.NewLine, diagnostics);
+                }
+                output += $"\nFull MSI log: {logPath}";
                 return (false, output);
             }
             // The retry loop above always either returns or continues — the
@@ -999,6 +1006,64 @@ public class InstallerService
         {
             _msiexecMutex.Release();
         }
+    }
+
+    /// <summary>
+    /// Pulls a bounded, actionable excerpt from a verbose Windows Installer log.
+    /// The full log remains on disk; this excerpt is returned with the item failure
+    /// so telemetry consumers do not have to reduce every MSI failure to exit 1603.
+    /// </summary>
+    internal static IReadOnlyList<string> ExtractMsiFailureDiagnostics(string logPath)
+    {
+        var diagnostics = new List<string>();
+        const int maxLines = 40;
+
+        try
+        {
+            if (!File.Exists(logPath))
+            {
+                return diagnostics;
+            }
+
+            using var stream = new FileStream(
+                logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream, detectEncodingFromByteOrderMarks: true);
+
+            string? lastActionStart = null;
+            string? line;
+            while ((line = reader.ReadLine()) != null && diagnostics.Count < maxLines)
+            {
+                if (line.Contains("Action start", StringComparison.OrdinalIgnoreCase))
+                {
+                    lastActionStart = line;
+                    continue;
+                }
+
+                if (line.Contains("CimianPreinstall", StringComparison.OrdinalIgnoreCase) ||
+                    line.Contains("CimianPostinstall", StringComparison.OrdinalIgnoreCase) ||
+                    line.Contains("CimianUninstall", StringComparison.OrdinalIgnoreCase) ||
+                    line.Contains("pending Windows reboot", StringComparison.OrdinalIgnoreCase))
+                {
+                    diagnostics.Add(line.Trim());
+                    continue;
+                }
+
+                if (line.Contains("Return value 3", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (lastActionStart != null)
+                    {
+                        diagnostics.Add(lastActionStart.Trim());
+                    }
+                    diagnostics.Add(line.Trim());
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            ConsoleLogger.Debug($"Could not extract MSI failure diagnostics: {ex.Message}");
+        }
+
+        return diagnostics;
     }
 
     /// <summary>

--- a/tests/Managedsoftwareupdate/InstallerServiceTests.cs
+++ b/tests/Managedsoftwareupdate/InstallerServiceTests.cs
@@ -79,6 +79,29 @@ public class InstallerServiceTests
     #region Install Method Tests
 
     [Fact]
+    public void ExtractMsiFailureDiagnostics_ReturnsActionableBoundedExcerpt()
+    {
+        var logPath = Path.Combine(_testDir, "failed-msi.log");
+        File.WriteAllLines(logPath,
+        [
+            "Action start 10:00:00: InstallFinalize.",
+            "CimianPostinstall | configuring package",
+            "Product: Test -- Error 1720. CimianPostinstall script exited 1",
+            "Action ended 10:00:01: InstallFinalize. Return value 3.",
+            "unrelated verbose line"
+        ]);
+
+        var diagnostics = InstallerService.ExtractMsiFailureDiagnostics(logPath);
+
+        Assert.Contains("CimianPostinstall | configuring package", diagnostics);
+        Assert.Contains(diagnostics, line => line.Contains("Error 1720", StringComparison.Ordinal));
+        Assert.Contains("Action start 10:00:00: InstallFinalize.", diagnostics);
+        Assert.Contains(diagnostics, line => line.Contains("Return value 3", StringComparison.Ordinal));
+        Assert.DoesNotContain("unrelated verbose line", diagnostics);
+        Assert.True(diagnostics.Count <= 40);
+    }
+
+    [Fact]
     public async Task InstallAsync_ScriptOnlyItem_Succeeds()
     {
         var item = new CatalogItem


### PR DESCRIPTION
## Summary

- append a bounded diagnostic excerpt from direct msiexec verbose logs to failed item output
- include custom-action output, launch-condition failures, and the action associated with Return value 3
- retain the full rotated log path in the result
- cover filtering and bounds with an InstallerService test

## Verification

- 26 InstallerService tests pass

Closes #129