### PR TITLE
Use calendar release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9].[0-9][0-9][0-9][0-9]'
 
 permissions:
   contents: write
@@ -31,7 +31,7 @@ jobs:
       # No NuGet caching — see ci.yml for rationale.
       - name: Build (unsigned)
         shell: pwsh
-        run: .\build.ps1 -NoSign
+        run: .\build.ps1 -NoSign -ReleaseVersion '${{ github.ref_name }}'
 
       - name: Capture build info
         id: version
@@ -43,6 +43,10 @@ jobs:
             $datestamp = $Matches[1]
           } else {
             throw "Could not parse datestamp version from $($msi.Name)"
+          }
+          $tag = '${{ github.ref_name }}'
+          if ($datestamp -ne $tag) {
+            throw "Release tag $tag does not match produced build version $datestamp"
           }
           $dotnetVersion = (dotnet --version).Trim()
           $osCaption = (Get-CimInstance Win32_OperatingSystem).Caption.Trim()

--- a/build.ps1
+++ b/build.ps1
@@ -66,6 +66,10 @@
 .PARAMETER Architecture
     Target architecture (x64, arm64, or both). Default: both
 
+.PARAMETER ReleaseVersion
+    Pin the build to a YYYY.MM.DD.HHMM release identity. Release automation uses
+    this so the Git tag, GitHub release, artifacts, and client version all agree.
+
 .EXAMPLE
     .\build.ps1
     # Full build with auto-signing (binaries + MSI + NUPKG)
@@ -138,7 +142,9 @@ param(
     [ValidateSet('Debug', 'Release')]
     [string]$Configuration = 'Release',
     [ValidateSet('x64', 'arm64', 'both')]
-    [string]$Architecture = 'both'
+    [string]$Architecture = 'both',
+    [ValidatePattern('^\d{4}\.\d{2}\.\d{2}\.\d{4}$')]
+    [string]$ReleaseVersion = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -543,7 +549,29 @@ function Invoke-SignNuget {
 #region Version Functions
 
 function Get-BuildVersion {
-    $currentTime = Get-Date
+    param([string]$PinnedVersion = '')
+
+    if ($PinnedVersion) {
+        if ($PinnedVersion -notmatch '^(?<year>\d{4})\.(?<month>\d{2})\.(?<day>\d{2})\.(?<hour>\d{2})(?<minute>\d{2})$') {
+            throw "ReleaseVersion must use YYYY.MM.DD.HHMM: $PinnedVersion"
+        }
+        try {
+            $currentTime = [datetime]::new(
+                [int]$Matches.year,
+                [int]$Matches.month,
+                [int]$Matches.day,
+                [int]$Matches.hour,
+                [int]$Matches.minute,
+                0)
+        }
+        catch {
+            throw "ReleaseVersion is not a valid calendar timestamp: $PinnedVersion"
+        }
+    }
+    else {
+        $currentTime = Get-Date
+    }
+
     $fullVersion = $currentTime.ToString("yyyy.MM.dd.HHmm")
     $semanticVersion = "{0}.{1}.{2}.{3}" -f ($currentTime.Year - 2000), $currentTime.Month, $currentTime.Day, $currentTime.ToString("HHmm")
     
@@ -1587,7 +1615,7 @@ function Show-BuildSummary {
 
 try {
     $startTime = Get-Date
-    $version = Get-BuildVersion
+    $version = Get-BuildVersion -PinnedVersion $ReleaseVersion
     
     Write-Host ""
     Write-Host "╔═══════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan


### PR DESCRIPTION
Release tags now use the same YYYY.MM.DD.HHMM identity already carried by build artifacts and client versions.

The release workflow accepts only calendar tags, pins that value into the build, and fails if the produced artifact identity differs from the tag.

Validation:
- Parsed valid and invalid calendar identities through the build version function
- Completed an unsigned x64 build pinned to 2026.09.01.1900

Closes #131