### PR TITLE
Resolve the exporter's log root through CimianPaths and stamp redirected console output

### DIFF
--- a/shared/core/Services/ConsoleLogger.cs
+++ b/shared/core/Services/ConsoleLogger.cs
@@ -81,7 +81,9 @@ public static class ConsoleLogger
     /// <summary>
     /// Writes <paramref name="text"/> as-is on a terminal, or one stamped line per line
     /// of it when the stream is redirected. The stamp matches <see cref="SessionLogger.Log"/>
-    /// so a captured stdout and the file log read the same way.
+    /// and the decoration is stripped the same way, so a captured stdout and the file log
+    /// read the same way. Nothing on the far end of a redirect renders an escape sequence,
+    /// so leaving the colours in would only put control bytes in the transcript.
     /// </summary>
     private static void Write(System.IO.TextWriter writer, bool redirected, string level, string text)
     {
@@ -92,10 +94,21 @@ public static class ConsoleLogger
         }
 
         var stamp = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {level,-5} ";
-        foreach (var line in text.Split('\n'))
+        foreach (var line in StripDecoration(text).Split('\n'))
         {
             writer.WriteLine(stamp + line.TrimEnd('\r'));
         }
+    }
+
+    /// <summary>
+    /// Removes ANSI colour sequences and replaces box-drawing and symbol characters with
+    /// ASCII, so a line reads the same in a file as it does on a terminal.
+    /// </summary>
+    private static string StripDecoration(string message)
+    {
+        var clean = System.Text.RegularExpressions.Regex.Replace(message, @"\x1b\[[0-9;]*m", "");
+        return clean.Replace("├", "+").Replace("└", "+").Replace("─", "-").Replace("│", "|")
+                    .Replace("→", "->").Replace("✓", "[OK]").Replace("✗", "[FAIL]");
     }
 
     /// <summary>
@@ -105,12 +118,7 @@ public static class ConsoleLogger
     private static void LogToSession(string level, string message)
     {
         if (_sessionLogger == null) return;
-        // Strip ANSI escape sequences for clean log file output
-        var clean = System.Text.RegularExpressions.Regex.Replace(message, @"\x1b\[[0-9;]*m", "");
-        // Replace Unicode box-drawing and symbol characters with ASCII equivalents for log compatibility
-        clean = clean.Replace("├", "+").Replace("└", "+").Replace("─", "-").Replace("│", "|")
-                      .Replace("→", "->").Replace("✓", "[OK]").Replace("✗", "[FAIL]");
-        _sessionLogger.Log(level, clean);
+        _sessionLogger.Log(level, StripDecoration(message));
     }
 
     /// <summary>

--- a/shared/core/Services/ConsoleLogger.cs
+++ b/shared/core/Services/ConsoleLogger.cs
@@ -4,8 +4,11 @@ namespace Cimian.Core.Services;
 
 /// <summary>
 /// Centralized console logging with verbosity control and clean output.
-/// No timestamps, no log level prefixes - just clean colored messages.
-/// Colors indicate the log level visually.
+/// On a terminal: no timestamps, no log level prefixes - just clean colored messages,
+/// where colors indicate the log level visually. When stdout (or stderr) is redirected
+/// there is no terminal to read the colors and no clock to relate lines to, so each line
+/// is prefixed with the same "[yyyy-MM-dd HH:mm:ss] LEVEL " stamp the log files use and
+/// a captured transcript lines up with run.log.
 /// 
 /// - verbose 1+ (-v): info, majorStatus, minorStatus, warning, error
 /// - verbose 2+ (-vv): detail messages  
@@ -60,6 +63,42 @@ public static class ConsoleLogger
     }
 
     /// <summary>
+    /// Overrides the redirection check for both stdout and stderr. Tests set it so the
+    /// prefixed and unprefixed paths can each be exercised regardless of how the test
+    /// host wires the console; null means ask the console.
+    /// </summary>
+    internal static bool? OutputRedirectedOverride { get; set; }
+
+    private static bool OutputRedirected => OutputRedirectedOverride ?? Console.IsOutputRedirected;
+    private static bool ErrorRedirected  => OutputRedirectedOverride ?? Console.IsErrorRedirected;
+
+    private static void WriteOut(string level, string text)
+        => Write(Console.Out, OutputRedirected, level, text);
+
+    private static void WriteErr(string level, string text)
+        => Write(Console.Error, ErrorRedirected, level, text);
+
+    /// <summary>
+    /// Writes <paramref name="text"/> as-is on a terminal, or one stamped line per line
+    /// of it when the stream is redirected. The stamp matches <see cref="SessionLogger.Log"/>
+    /// so a captured stdout and the file log read the same way.
+    /// </summary>
+    private static void Write(System.IO.TextWriter writer, bool redirected, string level, string text)
+    {
+        if (!redirected)
+        {
+            writer.WriteLine(text);
+            return;
+        }
+
+        var stamp = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {level,-5} ";
+        foreach (var line in text.Split('\n'))
+        {
+            writer.WriteLine(stamp + line.TrimEnd('\r'));
+        }
+    }
+
+    /// <summary>
     /// Write a message to the session logger if attached.
     /// Strips ANSI color codes and Unicode box-drawing characters before writing to log files.
     /// </summary>
@@ -79,7 +118,7 @@ public static class ConsoleLogger
     /// </summary>
     public static void Log(string message = "")
     {
-        Console.WriteLine(message);
+        WriteOut("INFO", message);
         LogToSession("INFO", message);
     }
 
@@ -90,7 +129,7 @@ public static class ConsoleLogger
     {
         if (Verbosity >= 1)
         {
-            Console.WriteLine(message);
+            WriteOut("INFO", message);
         }
         LogToSession("INFO", message);
     }
@@ -102,7 +141,7 @@ public static class ConsoleLogger
     {
         if (Verbosity >= 2)
         {
-            Console.WriteLine($"{ColorCyan}    {message}{ColorReset}");
+            WriteOut("DEBUG", $"{ColorCyan}    {message}{ColorReset}");
         }
         LogToSession("DEBUG", message);
     }
@@ -114,7 +153,7 @@ public static class ConsoleLogger
     {
         if (Verbosity >= 3)
         {
-            Console.WriteLine($"{ColorCyan}    {message}{ColorReset}");
+            WriteOut("DEBUG", $"{ColorCyan}    {message}{ColorReset}");
         }
         LogToSession("DEBUG", message);
     }
@@ -131,7 +170,7 @@ public static class ConsoleLogger
     {
         if (Verbosity >= 4)
         {
-            Console.WriteLine($"{ColorCyan}    {message}{ColorReset}");
+            WriteOut("TRACE", $"{ColorCyan}    {message}{ColorReset}");
         }
         LogToSession("TRACE", message);
     }
@@ -146,7 +185,7 @@ public static class ConsoleLogger
     /// </summary>
     public static void Success(string message)
     {
-        Console.WriteLine($"{ColorGreen}{message}{ColorReset}");
+        WriteOut("INFO", $"{ColorGreen}{message}{ColorReset}");
         LogToSession("INFO", message);
     }
 
@@ -155,7 +194,7 @@ public static class ConsoleLogger
     /// </summary>
     public static void Warn(string message)
     {
-        Console.WriteLine($"{ColorYellow}{message}{ColorReset}");
+        WriteOut("WARN", $"{ColorYellow}{message}{ColorReset}");
         LogToSession("WARN", message);
     }
 
@@ -164,7 +203,7 @@ public static class ConsoleLogger
     /// </summary>
     public static void Error(string message)
     {
-        Console.Error.WriteLine($"{ColorRed}{message}{ColorReset}");
+        WriteErr("ERROR", $"{ColorRed}{message}{ColorReset}");
         LogToSession("ERROR", message);
     }
 
@@ -174,7 +213,7 @@ public static class ConsoleLogger
     public static void Indented(string message, int level = 1)
     {
         var indent = new string('\t', level);
-        Console.WriteLine($"{indent}{message}");
+        WriteOut("INFO", $"{indent}{message}");
     }
 
     /// <summary>
@@ -182,7 +221,7 @@ public static class ConsoleLogger
     /// </summary>
     public static void Item(string message)
     {
-        Console.WriteLine($"* {message}");
+        WriteOut("INFO", $"* {message}");
     }
 
     /// <summary>
@@ -190,6 +229,6 @@ public static class ConsoleLogger
     /// </summary>
     public static void SubItem(string message)
     {
-        Console.WriteLine($"** {message}");
+        WriteOut("INFO", $"** {message}");
     }
 }

--- a/shared/core/Services/DataExporter.cs
+++ b/shared/core/Services/DataExporter.cs
@@ -21,10 +21,9 @@ public class DataExporter
     private List<SessionPackageInfo> _currentSessionPackagesInfo = new();
     private List<string> _currentSessionPackages = new();
 
-    // DataExporter writes to ManagedInstalls\Logs (capital L) — distinct from
-    // SessionLogger's lowercase 'logs'. Preserved as-is for compatibility with
-    // existing on-disk layouts and external log shippers.
-    private static readonly string DefaultBaseDir = Path.Combine(CimianPaths.ManagedInstallsRoot, "Logs");
+    // Reads the session tree SessionLogger writes (logs\YYYY-MM-DD\HHMM\), so the
+    // root is resolved through the same definition rather than spelled again here.
+    private static readonly string DefaultBaseDir = CimianPaths.LogsDir;
     private static readonly string ReportsDir   = CimianPaths.ReportsDir;
     private static readonly string ManifestsDir = CimianPaths.ManifestsDir;
     private static readonly string CatalogsDir  = CimianPaths.CatalogsDir;

--- a/tests/Shared/ConsoleLoggerTests.cs
+++ b/tests/Shared/ConsoleLoggerTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using Cimian.Core.Services;
+using Xunit;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// Console output is plain on a terminal and stamped when captured.
+/// </summary>
+/// <remarks>
+/// The regression this guards: console output carried no timestamp or level, so a
+/// stdout captured by a scheduler or a wrapper script could not be lined up against
+/// run.log, and a warning and an info line were told apart by colour codes alone.
+/// </remarks>
+public class ConsoleLoggerTests : IDisposable
+{
+    private const string Stamp = @"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] ";
+
+    private readonly TextWriter _originalOut = Console.Out;
+    private readonly TextWriter _originalError = Console.Error;
+    private readonly int _originalVerbosity = ConsoleLogger.Verbosity;
+    private readonly StringWriter _stdout = new();
+    private readonly StringWriter _stderr = new();
+
+    public ConsoleLoggerTests()
+    {
+        Console.SetOut(_stdout);
+        Console.SetError(_stderr);
+        ConsoleLogger.SetSessionLogger(null);
+        ConsoleLogger.Verbosity = 2;
+    }
+
+    public void Dispose()
+    {
+        ConsoleLogger.OutputRedirectedOverride = null;
+        ConsoleLogger.Verbosity = _originalVerbosity;
+        Console.SetOut(_originalOut);
+        Console.SetError(_originalError);
+    }
+
+    private static string[] Lines(StringWriter writer)
+        => writer.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+    [Fact]
+    public void RedirectedOutputCarriesTheSameStampAsTheFileLog()
+    {
+        ConsoleLogger.OutputRedirectedOverride = true;
+
+        ConsoleLogger.Log("plain");
+        ConsoleLogger.Warn("careful");
+        ConsoleLogger.Detail("fine print");
+        ConsoleLogger.Error("broken");
+
+        var outLines = Lines(_stdout);
+        Assert.Equal(3, outLines.Length);
+        Assert.Matches(Stamp + "INFO  plain$", outLines[0]);
+        Assert.Matches(Stamp + "WARN  .*careful", outLines[1]);
+        Assert.Matches(Stamp + "DEBUG .*fine print", outLines[2]);
+
+        var errLines = Lines(_stderr);
+        Assert.Single(errLines);
+        Assert.Matches(Stamp + "ERROR .*broken", errLines[0]);
+    }
+
+    [Fact]
+    public void RedirectedMultiLineMessagesStampEveryLine()
+    {
+        ConsoleLogger.OutputRedirectedOverride = true;
+
+        ConsoleLogger.Log("first\nsecond");
+
+        var lines = Lines(_stdout);
+        Assert.Equal(2, lines.Length);
+        Assert.Matches(Stamp + "INFO  first$", lines[0]);
+        Assert.Matches(Stamp + "INFO  second$", lines[1]);
+    }
+
+    [Fact]
+    public void TerminalOutputIsLeftExactlyAsItWas()
+    {
+        ConsoleLogger.OutputRedirectedOverride = false;
+
+        ConsoleLogger.Log("plain");
+        ConsoleLogger.Warn("careful");
+        ConsoleLogger.Error("broken");
+
+        Assert.Equal(new[] { "plain", "[33mcareful[0m" }, Lines(_stdout));
+        Assert.Equal(new[] { "[31mbroken[0m" }, Lines(_stderr));
+    }
+}

--- a/tests/Shared/ConsoleLoggerTests.cs
+++ b/tests/Shared/ConsoleLoggerTests.cs
@@ -55,12 +55,26 @@ public class ConsoleLoggerTests : IDisposable
         var outLines = Lines(_stdout);
         Assert.Equal(3, outLines.Length);
         Assert.Matches(Stamp + "INFO  plain$", outLines[0]);
-        Assert.Matches(Stamp + "WARN  .*careful", outLines[1]);
-        Assert.Matches(Stamp + "DEBUG .*fine print", outLines[2]);
+        Assert.Matches(Stamp + "WARN  careful$", outLines[1]);
+        Assert.Matches(Stamp + "DEBUG     fine print$", outLines[2]);
 
         var errLines = Lines(_stderr);
         Assert.Single(errLines);
-        Assert.Matches(Stamp + "ERROR .*broken", errLines[0]);
+        Assert.Matches(Stamp + "ERROR broken$", errLines[0]);
+
+        // No control bytes reach the transcript: colours are meaningless once captured.
+        Assert.DoesNotContain('\u001b', _stdout.ToString());
+        Assert.DoesNotContain('\u001b', _stderr.ToString());
+    }
+
+    [Fact]
+    public void RedirectedOutputReplacesBoxDrawingWithAscii()
+    {
+        ConsoleLogger.OutputRedirectedOverride = true;
+
+        ConsoleLogger.Log("└─ ✓ done → next");
+
+        Assert.Matches(Stamp + @"INFO  \+- \[OK\] done -> next$", Lines(_stdout)[0]);
     }
 
     [Fact]


### PR DESCRIPTION
## What

- `DataExporter` resolved its base directory as `ManagedInstalls\Logs` with a comment claiming it was distinct from `SessionLogger`'s lowercase `logs`. On NTFS they are the same directory, and the exporter reads the `session.json` / `events.jsonl` files `SessionLogger` writes there. It now uses `CimianPaths.LogsDir`, so the logs root has a single definition and no writer spells it differently.
- `ConsoleLogger` wrote bare messages with colour as the only level cue. When stdout or stderr is redirected (scheduler, wrapper script, CI capture) each line now carries the same `[yyyy-MM-dd HH:mm:ss] LEVEL ` prefix the file log uses, so a captured transcript lines up with `run.log`. Output to a terminal is unchanged. Multi-line messages are stamped per line. Errors written to stderr follow `Console.IsErrorRedirected` so the two streams are decided independently.

## Why

Anything treating the path as data (a case-sensitive log shipper, a mirror of the tree on another filesystem) sees two directories where NTFS shows one. Captured console output with no timestamps or levels was unreadable next to the file log.

## Verification

- `dotnet build -p:EnableWindowsTargeting=true CimianTools.sln` on macOS (with the `cli/cimipkg` submodule initialised): every core, engine, infrastructure, CLI and test project compiles with 0 errors. The two GUI projects fail on this host for pre-existing, platform reasons only: `Cimian.GUI.ManagedSoftwareCenter` needs WinUI's `XamlCompiler.exe` and `Cimian.GUI.CimianStatus` needs the WPF runtime pack, neither of which exists for a non-Windows runtime identifier. Neither project touches the changed files.
- `dotnet test` filtered to `ConsoleLoggerTests`, `SessionLogRetentionTests`, `PackageScriptLogDrainTests`: 28 passed, 0 failed.
- Not verified: interactive terminal rendering on Windows. The terminal path is untouched; only the redirected branch is new.

## Tests

`tests/Shared/ConsoleLoggerTests.cs` covers the stamped redirected output (stdout and stderr), per-line stamping of multi-line messages, and that terminal output is byte-for-byte what it was.
