### PR TITLE
Report deferred items as pending, not installed

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -625,6 +625,9 @@ public class UpdateEngine : IDisposable
                             $"Outside install window {item.InstallWindow}",
                             Cimian.Core.Models.StatusReasonCode.DeferredInstallWindow,
                             Cimian.Core.Models.DetectionMethod.None, null, false);
+                        RecordDeferral(item, list, toInstall, toUpdate,
+                            $"Outside install window {item.InstallWindow}",
+                            Cimian.Core.Models.StatusReasonCode.DeferredInstallWindow);
                         deferredItems.Add(item);
                         list.RemoveAt(i);
                     }
@@ -658,6 +661,9 @@ public class UpdateEngine : IDisposable
                             $"Blocking applications running: {runningList}",
                             Cimian.Core.Models.StatusReasonCode.BlockingApps,
                             Cimian.Core.Models.DetectionMethod.None, null, true);
+                        RecordDeferral(item, list, toInstall, toUpdate,
+                            $"Blocking applications running: {runningList}",
+                            Cimian.Core.Models.StatusReasonCode.BlockingApps);
                         blockedItems.Add(item);
                         list.RemoveAt(i);
                     }
@@ -704,6 +710,9 @@ public class UpdateEngine : IDisposable
                                 deferReason,
                                 Cimian.Core.Models.StatusReasonCode.DeferredUserActive,
                                 Cimian.Core.Models.DetectionMethod.None, null, true);
+                            RecordDeferral(item, list, toInstall, toUpdate,
+                                deferReason,
+                                Cimian.Core.Models.StatusReasonCode.DeferredUserActive);
                             deferredForUser.Add(item);
                             list.RemoveAt(i);
                         }
@@ -732,6 +741,8 @@ public class UpdateEngine : IDisposable
                             deferReason,
                             Cimian.Core.Models.StatusReasonCode.DeferredUserActive,
                             Cimian.Core.Models.DetectionMethod.None, null, true);
+                        _deferredByName[item.Name] = ("uninstall", deferReason,
+                            Cimian.Core.Models.StatusReasonCode.DeferredUserActive);
                         deferredForUser.Add(item);
                         toUninstall.RemoveAt(i);
                     }
@@ -2898,6 +2909,40 @@ public class UpdateEngine : IDisposable
     /// Go parity: main.go lines 3308-3430 where SessionPackageInfo is collected for each manifest item.
     /// Excludes MDM profiles/apps (managed externally) - those are filtered by SessionLogger.
     /// </summary>
+    /// <summary>
+    /// Items pulled out of the action lists this run because they were deferred:
+    /// name -> the kind of action that was deferred, and why.
+    /// </summary>
+    /// <remarks>
+    /// Deferral removes the item from toInstall/toUpdate/toUninstall, which used to
+    /// erase every trace of it from the reported status. CollectSessionItems then saw
+    /// no outcome and no pending flag and fell through to the resolver's "Installed"
+    /// default, so a package the status check had just declared missing was reported
+    /// to the fleet as installed. Every install_window package on a machine that
+    /// checks in during the day was affected. Keep the deferral so the reported
+    /// status can stay truthful.
+    /// </remarks>
+    private readonly Dictionary<string, (string Kind, string Reason, string ReasonCode)> _deferredByName = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Remembers that <paramref name="item"/> was deferred out of <paramref name="list"/>,
+    /// so the reported status can say "Pending" with a reason instead of defaulting to
+    /// "Installed".
+    /// </summary>
+    private void RecordDeferral(
+        CatalogItem item,
+        List<CatalogItem> list,
+        List<CatalogItem> toInstall,
+        List<CatalogItem> toUpdate,
+        string reason,
+        string reasonCode)
+    {
+        var kind = ReferenceEquals(list, toInstall) ? "install"
+                 : ReferenceEquals(list, toUpdate) ? "update"
+                 : "uninstall";
+        _deferredByName[item.Name] = (kind, reason, reasonCode);
+    }
+
     private void CollectSessionItems(
         List<ManifestItem> manifestItems,
         List<CatalogItem> toInstall,
@@ -2970,6 +3015,29 @@ public class UpdateEngine : IDisposable
                     // Mark as touched this run so DataExporter stamps last_seen_in_session.
                     // Distinct from install/update/remove so consumers can filter on it.
                     ActionPerformed = suppression.PendingRestart ? "restart_deferred" : "loop_suppressed",
+                    OutcomeTimestamp = DateTime.UtcNow
+                });
+                continue;
+            }
+
+            // An item deferred this run was removed from the action lists, so without
+            // this it would reach the resolver with no outcome and no pending flag and
+            // be reported as "Installed" - the exact opposite of the truth for an
+            // install_window package that is not on the machine yet.
+            if (_deferredByName.TryGetValue(mi.Name, out var deferral)
+                && !outcomesByName.ContainsKey(key))
+            {
+                items.Add(new SessionPackageInfo
+                {
+                    Name = mi.Name,
+                    Version = version,
+                    Status = SessionItemStatusResolver.ResolveDeferred(deferral.Kind),
+                    ItemType = itemType,
+                    DisplayName = displayName,
+                    StatusReason = deferral.Reason,
+                    StatusReasonCode = deferral.ReasonCode,
+                    DetectionMethod = Cimian.Core.Models.DetectionMethod.None,
+                    ActionPerformed = "deferred",
                     OutcomeTimestamp = DateTime.UtcNow
                 });
                 continue;

--- a/shared/core/Models/Reporting.cs
+++ b/shared/core/Models/Reporting.cs
@@ -792,6 +792,23 @@ public static class SessionItemStatusResolver
             return "Removed";
         return "Installed";
     }
+
+    /// <summary>
+    /// The status for an item that was deferred this run rather than acted on.
+    /// </summary>
+    /// <remarks>
+    /// Deferral removes the item from the action lists, so it reaches Resolve with no
+    /// outcome and no pending flag and falls through to the "Installed" default. That
+    /// reported a package the status check had just found missing as installed - the
+    /// failure was silent and it applied to every install_window item on a machine that
+    /// checked in outside its window. A deferred item is pending, by definition.
+    /// </remarks>
+    public static string ResolveDeferred(string kind) => kind switch
+    {
+        "update"    => "Pending Update",
+        "uninstall" => "Pending Removal",
+        _           => "Pending Install"
+    };
 }
 
 /// <summary>

--- a/tests/Shared/DeferredItemStatusTests.cs
+++ b/tests/Shared/DeferredItemStatusTests.cs
@@ -1,0 +1,59 @@
+using Cimian.Core.Models;
+using Xunit;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// A deferred item is pending, never installed.
+/// </summary>
+/// <remarks>
+/// The regression this guards: deferring an item - outside its install_window, a
+/// blocking application running, an active user in auto mode - removes it from the
+/// action lists. It then reached the resolver with no outcome and no pending flag
+/// and fell through to the "Installed" default, so a package the status check had
+/// just reported missing was published to the fleet as installed. Every
+/// install_window package on a machine checking in outside its window was affected,
+/// which made the fleet view assert the opposite of what was on disk.
+/// </remarks>
+public class DeferredItemStatusTests
+{
+    [Theory]
+    [InlineData("install", "Pending Install")]
+    [InlineData("update", "Pending Update")]
+    [InlineData("uninstall", "Pending Removal")]
+    public void DeferredItem_ReportsPending(string kind, string expected)
+    {
+        Assert.Equal(expected, SessionItemStatusResolver.ResolveDeferred(kind));
+    }
+
+    [Fact]
+    public void DeferredItem_NeverReportsInstalled()
+    {
+        foreach (var kind in new[] { "install", "update", "uninstall", "", "something-else" })
+        {
+            Assert.NotEqual("Installed", SessionItemStatusResolver.ResolveDeferred(kind));
+        }
+    }
+
+    [Fact]
+    public void UnknownDeferralKind_FallsBackToPendingInstall()
+    {
+        // A new deferral path that forgets to name its kind must still be honest.
+        Assert.Equal("Pending Install", SessionItemStatusResolver.ResolveDeferred("whatever"));
+    }
+
+    [Fact]
+    public void ResolverStillDefaultsToInstalled_WhenNothingIsPending()
+    {
+        // The default itself is correct for an item the status check found present;
+        // the bug was reaching it with a deferred item. Pin the contract so the two
+        // paths cannot be conflated again.
+        Assert.Equal("Installed", SessionItemStatusResolver.Resolve(
+            outcome: null, isPendingInstall: false, isPendingUpdate: false,
+            isPendingUninstall: false, manifestAction: "install"));
+
+        Assert.Equal("Pending Install", SessionItemStatusResolver.Resolve(
+            outcome: null, isPendingInstall: true, isPendingUpdate: false,
+            isPendingUninstall: false, manifestAction: "install"));
+    }
+}


### PR DESCRIPTION
Deferring an item removes it from the action lists, and nothing remembered the deferral, so `CollectSessionItems` reached the status resolver with no outcome and no pending flag and fell through to its `"Installed"` default. A package the status check had just declared missing was published as installed.

The `install_window` path makes this systematic: any machine checking in outside a package's window reports that package as installed, which is most check-ins for most of the day. The blocking-application and active-user deferrals had the same result.

Each deferral now records the item and its reason, and `CollectSessionItems` emits `Pending Install` / `Pending Update` / `Pending Removal` with that reason and reason code. An item deferred but later acted on in the same run still reports its real outcome.

Four tests in `tests/Shared/DeferredItemStatusTests.cs` pin the mapping, that no deferral kind can ever resolve to `Installed`, the fallback for an unnamed kind, and the resolver's own default so the two paths cannot be conflated again. Build clean, 11 tests pass alongside the abandoned-session set.

Closes #136