### PR TITLE
Run postflight after the session's reports are written

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -867,15 +867,11 @@ public class UpdateEngine : IDisposable
                 await CleanUpSelfServeUninstallsAsync(uninstallOutcomes);
             }
 
-            // Combine install + uninstall outcomes keyed by lower-invariant name so
-            // CollectSessionItems can stamp each manifest item with its real result.
-            var outcomesByName = new Dictionary<string, ItemOutcome>(StringComparer.OrdinalIgnoreCase);
-            foreach (var o in installOutcomes) outcomesByName[o.Name.ToLowerInvariant()] = o;
-            foreach (var o in uninstallOutcomes) outcomesByName[o.Name.ToLowerInvariant()] = o;
-
-            // Run postflight unless skipped
-            if (!skipPostflight && !_config.NoPostflight)
+            // Runs the postflight script once the session's reports are on disk, so
+            // whatever it hands to the reporting client is this session's state.
+            async Task RunPostflightAfterReportsAsync()
             {
+                if (skipPostflight || _config.NoPostflight) return;
                 LogInfo("----------------------------------------------------------------------");
                 LogInfo("POSTFLIGHT EXECUTION");
                 LogInfo("----------------------------------------------------------------------");
@@ -887,6 +883,25 @@ public class UpdateEngine : IDisposable
                     _sessionLogger?.Log("WARN", $"Postflight script failed: {postflightOutput}");
                 }
             }
+
+            // Combine install + uninstall outcomes keyed by lower-invariant name so
+            // CollectSessionItems can stamp each manifest item with its real result.
+            var outcomesByName = new Dictionary<string, ItemOutcome>(StringComparer.OrdinalIgnoreCase);
+            foreach (var o in installOutcomes) outcomesByName[o.Name.ToLowerInvariant()] = o;
+            foreach (var o in uninstallOutcomes) outcomesByName[o.Name.ToLowerInvariant()] = o;
+
+            // Postflight deliberately does NOT run here. It used to, and postflight's
+            // whole job is to hand this session's results to the reporting client -
+            // but the results do not exist yet at this point. CollectSessionItems and
+            // EndSessionWithSummary below are what write items.json, sessions.json and
+            // events.json, so a postflight fired here collected the PREVIOUS session
+            // every time. Measured on a render node: postflight ran at 07:45:29 and
+            // items.json was not rewritten until 07:46:16, 47 seconds later, every
+            // hour, for as long as the two have been scheduled together. The fleet
+            // report was permanently one session behind the machine while last_seen
+            // looked current, which is why devices showed failures they had already
+            // recovered from. It now runs after the reports are on disk - see
+            // RunPostflightAsync calls below.
 
             // Clear bootstrap mode if successful
             if (_isBootstrap && installSuccess && uninstallSuccess)
@@ -915,7 +930,11 @@ public class UpdateEngine : IDisposable
 
                 EndSessionWithSummary("completed", toInstall.Count, toUpdate.Count, toUninstall.Count,
                     toInstall.Count + toUpdate.Count + toUninstall.Count, 0, manifestItems);
-                
+
+                // Reports are written; now hand them over. Before any restart, which
+                // would otherwise kill the handover.
+                await RunPostflightAfterReportsAsync();
+
                 // Handle restart_action: restart takes precedence over logout (Munki parity)
                 if (_restartNeeded)
                 {
@@ -942,6 +961,9 @@ public class UpdateEngine : IDisposable
 
                 EndSessionWithSummary("partial_failure", toInstall.Count, toUpdate.Count, toUninstall.Count,
                     successCount, failCount, manifestItems);
+
+                // A partial failure is exactly the session a fleet report most needs.
+                await RunPostflightAfterReportsAsync();
 
                 // Even on partial failure, honor restart/logout if any successful item required it
                 if (_restartNeeded)


### PR DESCRIPTION
Postflight ran before the branch that finishes the session, and the reports it exists to hand over are written in that branch:

```
876   postflight runs            -> invokes the reporting client
926   CollectSessionItems(...)   <- builds this session's item states
931   EndSessionWithSummary(...) -> writes items.json/sessions.json/events.json
```

So it always handed over the previous session. Measured on a render node, one ordinary hourly run: postflight at 07:45:29, items.json not rewritten until 07:46:16 — 47 seconds early, every hour, on every machine where the two are scheduled together.

The consequence is worse than the delay: a fleet report sits permanently one session behind the endpoint while the device's last check-in looks current, so a stale record is indistinguishable from a live one. Machines display failures they have already recovered from and a shipped fix looks like it did not work. The node above had the agent installed and its item locally read `Installed` with no error while the fleet still showed the previous session's failure — and that gap could never close, because the next hour repeated it.

Postflight now runs after `EndSessionWithSummary` in both branches, and before any restart or logout, which would otherwise kill the handover.

The check-only path still returns without postflight; separate decision, not changed here, and the scheduled task runs `--auto`.

Build clean. The 5 test failures in this repo on my machine are environment-dependent (hostname-based predicate cases, console box-drawing, config round-trip) and fail identically with this change stashed.

Closes #139