### PR TITLE
Run postflight before the session log closes

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -872,6 +872,10 @@ public class UpdateEngine : IDisposable
             async Task RunPostflightAfterReportsAsync()
             {
                 if (skipPostflight || _config.NoPostflight) return;
+                // Must be called BEFORE EndSessionWithSummary. EndSession closes the
+                // session log files, and a postflight run after that is invisible -
+                // which is exactly how the first attempt at this fix shipped a client
+                // where postflight silently never ran at all.
                 LogInfo("----------------------------------------------------------------------");
                 LogInfo("POSTFLIGHT EXECUTION");
                 LogInfo("----------------------------------------------------------------------");
@@ -928,12 +932,15 @@ public class UpdateEngine : IDisposable
                 // Write InstallInfo.yaml for MSC GUI (post-install: actions completed)
                 WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName.Values);
 
+                // Put the reports on disk first, then hand them over, then end the
+                // session. Postflight's whole purpose is to give the reporting client
+                // this session's results, so it has to run after the reports exist -
+                // and before EndSession, which closes the log files.
+                _sessionLogger?.GenerateReportsNow();
+                await RunPostflightAfterReportsAsync();
+
                 EndSessionWithSummary("completed", toInstall.Count, toUpdate.Count, toUninstall.Count,
                     toInstall.Count + toUpdate.Count + toUninstall.Count, 0, manifestItems);
-
-                // Reports are written; now hand them over. Before any restart, which
-                // would otherwise kill the handover.
-                await RunPostflightAfterReportsAsync();
 
                 // Handle restart_action: restart takes precedence over logout (Munki parity)
                 if (_restartNeeded)
@@ -959,11 +966,12 @@ public class UpdateEngine : IDisposable
                 // Write InstallInfo.yaml for MSC GUI (post-install: reflects final state)
                 WriteInstallInfo(manifestItems, toInstall, toUpdate, toUninstall, catalogMap, outcomesByName.Values);
 
+                // A partial failure is exactly the session a fleet report most needs.
+                _sessionLogger?.GenerateReportsNow();
+                await RunPostflightAfterReportsAsync();
+
                 EndSessionWithSummary("partial_failure", toInstall.Count, toUpdate.Count, toUninstall.Count,
                     successCount, failCount, manifestItems);
-
-                // A partial failure is exactly the session a fleet report most needs.
-                await RunPostflightAfterReportsAsync();
 
                 // Even on partial failure, honor restart/logout if any successful item required it
                 if (_restartNeeded)

--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -1031,6 +1031,29 @@ public class SessionLogger : IDisposable
     /// <summary>
     /// Generates report files for external tools
     /// </summary>
+    /// <summary>
+    /// Writes the report files (items.json, sessions.json, events.json) without ending
+    /// the session.
+    /// </summary>
+    /// <remarks>
+    /// EndSession generates the reports and then closes the log files. Anything that
+    /// needs the reports on disk AND needs the session log still open - postflight,
+    /// which hands the reports to the reporting client and whose success or failure is
+    /// worth recording - cannot use EndSession for that. Callers generate here, do the
+    /// work, then end the session.
+    /// </remarks>
+    public void GenerateReportsNow()
+    {
+        try
+        {
+            GenerateReports();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[ERROR] Failed to generate reports: {ex.Message}");
+        }
+    }
+
     private void GenerateReports()
     {
         try


### PR DESCRIPTION
Regression fix for #140. Moving postflight after `EndSessionWithSummary` put it past `CloseLogFiles()`, and on the shipped client 2026.09.02.1553 it does not run at all — verified on a lab machine including a deliberately triggered run: three consecutive completed sessions with no POSTFLIGHT entry, `reports/state.json` frozen at the last run of the old client, and no reporting-client invocation afterwards.

That is worse than what it replaced: previously the handover was one session stale, now updated machines have no handover and no record of why, because the log is closed by then.

Reports are now generated explicitly before the handover via a new `SessionLogger.GenerateReportsNow()`, and postflight runs while the session log is still open, before `EndSessionWithSummary`. The ordering #140 was about is preserved — postflight sees this session's reports rather than the previous session's.

Build clean.

Closes #142