### PR TITLE
Rename a wrong-cased convention directory at session start

### DIFF
--- a/cli/managedsoftwareupdate/Services/ConfigurationService.cs
+++ b/cli/managedsoftwareupdate/Services/ConfigurationService.cs
@@ -224,6 +224,15 @@ public class ConfigurationService
     /// </summary>
     public void EnsureDirectoriesExist(CimianConfig config)
     {
+        // Before creating anything: a device provisioned before the lowercase convention
+        // still has ManagedInstalls\Logs, and every path built from CimianPaths resolves
+        // onto it because NTFS is case-insensitive. Renaming it here means the reported
+        // path matches the convention from the next session on. Best effort by design.
+        foreach (var conventionDir in CimianPaths.ConventionDirs)
+        {
+            CimianPaths.NormalizeDirectoryCasing(conventionDir);
+        }
+
         var directories = new[]
         {
             config.CachePath,

--- a/shared/core/CimianPaths.cs
+++ b/shared/core/CimianPaths.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Cimian.Core;
 
 /// <summary>
@@ -89,4 +91,63 @@ public static class CimianPaths
     public static readonly string CimiStatusExe            = Path.Combine(CimianInstallDir, "cimistatus.exe");
     public static readonly string PreflightScriptInstall   = Path.Combine(CimianInstallDir, "preflight.ps1");
     public static readonly string PostflightScriptInstall  = Path.Combine(CimianInstallDir, "postflight.ps1");
+
+    /// <summary>
+    /// Directories under <see cref="ManagedInstallsRoot"/> whose names are part of the
+    /// cross-platform convention and must be exactly lowercase on disk.
+    /// </summary>
+    public static readonly string[] ConventionDirs =
+    {
+        LogsDir, ReportsDir, CatalogsDir, IconsDir, ManifestsDir, ConditionsDir, FactsDir
+    };
+
+    /// <summary>
+    /// Renames a directory that exists with the wrong casing to the name this class
+    /// defines, and returns true when it moved one.
+    /// </summary>
+    /// <remarks>
+    /// Changing the path string in this class did not rename anything already on disk:
+    /// NTFS is case-insensitive, so a machine that had <c>ManagedInstalls\Logs</c> before the
+    /// convention landed keeps that name for ever and reports it upward, while every path
+    /// built here happily resolves onto it. Nothing is broken on the endpoint — both spellings
+    /// are the same directory — but the reported path is wrong, and a case-sensitive reader
+    /// (a log shipper, a mirror on another filesystem) sees two names for one thing.
+    ///
+    /// The rename goes via a temporary name because a direct case-only Move is a no-op on a
+    /// case-insensitive volume. Everything is best effort: this runs at the start of every
+    /// session, and a directory that cannot be renamed — held open by another process, denied,
+    /// or already correct — must never stop a run.
+    /// </remarks>
+    public static bool NormalizeDirectoryCasing(string desiredPath)
+    {
+        try
+        {
+            var parent = Path.GetDirectoryName(desiredPath);
+            var wanted = Path.GetFileName(desiredPath);
+            if (string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(wanted) || !Directory.Exists(parent))
+                return false;
+
+            var matches = Directory.GetDirectories(parent)
+                .Where(d => string.Equals(Path.GetFileName(d), wanted, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            // Exactly one entry is the normal case. Zero means nothing to do; more than one
+            // means a case-sensitive volume holds both spellings as separate directories, and
+            // merging them is a data decision this must not take on its own.
+            if (matches.Count != 1) return false;
+
+            var actual = Path.GetFileName(matches[0]);
+            if (string.Equals(actual, wanted, StringComparison.Ordinal)) return false;
+
+            var staging = Path.Combine(parent, $"{wanted}.casing-{Guid.NewGuid():N}");
+            Directory.Move(matches[0], staging);
+            Directory.Move(staging, desiredPath);
+            return true;
+        }
+        catch
+        {
+            // Cosmetic correction; never worth failing a run over.
+            return false;
+        }
+    }
 }

--- a/tests/Shared/DirectoryCasingTests.cs
+++ b/tests/Shared/DirectoryCasingTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using Cimian.Core;
+using Xunit;
+
+namespace Cimian.Tests.Shared;
+
+/// <summary>
+/// The logs directory must be spelled exactly "logs" on disk.
+/// </summary>
+/// <remarks>
+/// The regression this guards: the convention was applied by changing the path string in
+/// CimianPaths, which renamed nothing. NTFS is case-insensitive, so every device that already
+/// had ManagedInstalls\Logs kept that name and went on reporting it upward, on the newest
+/// client, indefinitely.
+/// </remarks>
+public class DirectoryCasingTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "cimian-casing-" + Guid.NewGuid().ToString("N"));
+
+    public DirectoryCasingTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static string LeafOnDisk(string parent, string name)
+        => Path.GetFileName(Directory.GetDirectories(parent, name)[0]);
+
+    [Fact]
+    public void AWrongCasedDirectoryIsRenamedAndItsContentsSurvive()
+    {
+        var upper = Path.Combine(_root, "Logs");
+        Directory.CreateDirectory(upper);
+        File.WriteAllText(Path.Combine(upper, "run.log"), "history worth keeping");
+
+        var moved = CimianPaths.NormalizeDirectoryCasing(Path.Combine(_root, "logs"));
+
+        Assert.True(moved);
+        Assert.Equal("logs", LeafOnDisk(_root, "logs"));
+        Assert.Equal("history worth keeping", File.ReadAllText(Path.Combine(_root, "logs", "run.log")));
+    }
+
+    [Fact]
+    public void AnAlreadyCorrectDirectoryIsLeftAlone()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "logs"));
+
+        Assert.False(CimianPaths.NormalizeDirectoryCasing(Path.Combine(_root, "logs")));
+        Assert.Equal("logs", LeafOnDisk(_root, "logs"));
+    }
+
+    [Fact]
+    public void AMissingDirectoryIsNotCreated()
+    {
+        Assert.False(CimianPaths.NormalizeDirectoryCasing(Path.Combine(_root, "logs")));
+        Assert.False(Directory.Exists(Path.Combine(_root, "logs")));
+    }
+
+    [Fact]
+    public void RunningTwiceIsHarmless()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "Logs"));
+
+        Assert.True(CimianPaths.NormalizeDirectoryCasing(Path.Combine(_root, "logs")));
+        Assert.False(CimianPaths.NormalizeDirectoryCasing(Path.Combine(_root, "logs")));
+        Assert.Single(Directory.GetDirectories(_root));
+    }
+
+    [Fact]
+    public void NoStagingDirectoryIsLeftBehindWhenTheRenameSucceeds()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "Logs"));
+
+        CimianPaths.NormalizeDirectoryCasing(Path.Combine(_root, "logs"));
+
+        Assert.DoesNotContain(Directory.GetDirectories(_root), d => Path.GetFileName(d).Contains(".casing-"));
+    }
+
+    [Fact]
+    public void TheConventionDirsAllSpellTheirLeafInLowercase()
+    {
+        foreach (var dir in CimianPaths.ConventionDirs)
+        {
+            var leaf = Path.GetFileName(dir);
+            Assert.Equal(leaf.ToLowerInvariant(), leaf);
+        }
+    }
+}


### PR DESCRIPTION
Applying the lowercase `logs` convention changed the path strings in `CimianPaths` but renamed nothing on disk. NTFS is case-insensitive, so a device provisioned before the convention keeps `ManagedInstalls\Logs` indefinitely and reports that spelling upward, while every path built here resolves onto it.

This does not age out on its own. Sampling the 40 most recently seen Windows devices: 11 still report the capital-L spelling, and **every one of them is running the newest client**. The split is not version-related — it is purely whether the directory predated the convention.

`EnsureDirectoriesExist` already owns directory creation at session start, so the rename goes there, ahead of the create loop, and covers every convention directory rather than just `logs`.

Two details worth knowing:
- The move goes via a staging name, because a case-only `Directory.Move` is a no-op on a case-insensitive volume.
- It is best effort and non-fatal. A directory held open by another process, denied, or present in **both** spellings on a case-sensitive volume is left alone. Merging two real directories is a data decision this must not take by itself, and a cosmetic correction must never fail a run.

To be clear about the stakes: nothing is broken on the endpoint today — both spellings are the same directory. This only makes the reported path match the convention, which matters to a case-sensitive reader such as a log shipper or a mirror on another filesystem.

Verified against a real capital-L tree with a nested session directory: renamed to `logs`, all files and the nested session intact, no staging directory left behind, and a second call a no-op. Six new unit tests cover the rename, the already-correct case, the missing case, idempotency, staging cleanup, and that every convention directory is spelled lowercase.