### PR TITLE
Retire loop state when a package converges

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1121,7 +1121,17 @@ public class UpdateEngine : IDisposable
                         status.DetectionMethod,
                         status.InstalledVersion,
                         status.NeedsAction);
-                    
+
+                    if (!status.NeedsAction)
+                    {
+                        // The item's own checks are satisfied: whatever a previous run was
+                        // looping on is resolved. Retire the loop history now rather than
+                        // waiting out the window — a converged package is a fixed package,
+                        // and a window left open keeps it reported as broken (and floors
+                        // its next window) for up to LoopMaxTime after the fact.
+                        _loopGuard?.NoteConverged(catalogItem.Name, ComputeCatalogFingerprint(catalogItem));
+                    }
+
                     if (status.NeedsAction)
                     {
                         // Remember WHY this item needs to run. LoopGuard replays it in the
@@ -2083,7 +2093,8 @@ public class UpdateEngine : IDisposable
                 success: true,
                 ComputeCatalogFingerprint(item),
                 selfReportedWarning: warningMessage != null,
-                trigger: TakeInstallTrigger(item.Name));
+                trigger: TakeInstallTrigger(item.Name),
+                loopExempt: item.OnDemand || item.Recurring);
 
             // Act on the convergence verdict from above.
             if (convergencePendingRestart)
@@ -2128,7 +2139,8 @@ public class UpdateEngine : IDisposable
 
             // Record failed install for loop guard tracking
             _loopGuard?.RecordAttempt(item.Name, item.Version, success: false, ComputeCatalogFingerprint(item),
-                trigger: TakeInstallTrigger(item.Name));
+                trigger: TakeInstallTrigger(item.Name),
+                loopExempt: item.OnDemand || item.Recurring);
             return false;
         }
 
@@ -3103,6 +3115,36 @@ public class UpdateEngine : IDisposable
                 WarningMessages = hasWarning ? WarningList(outcome!.WarningMessage!, outcome.WarningDetail) : null,
                 ActionPerformed = hadOutcome ? outcome!.Action : null,
                 OutcomeTimestamp = hadOutcome ? outcome!.Timestamp : null
+            });
+        }
+
+        // Dependencies are resolved into the install plan but are not manifest entries, so
+        // the loop above never reaches them. A suppressed dependency was therefore absent
+        // from items.json entirely — not merely unflagged — which is why several packages
+        // sitting in an open suppression window showed up nowhere in the item report.
+        foreach (var (key, suppression) in loopSuppressedByName)
+        {
+            if (!seen.Add(key))
+                continue;
+
+            catalogMap.TryGetValue(key, out var suppressedCat);
+            items.Add(new SessionPackageInfo
+            {
+                Name = suppressedCat?.Name ?? key,
+                Version = suppressedCat?.Version ?? "",
+                Status = suppression.PendingRestart ? "Pending" : "Warning",
+                ItemType = "managed_installs",
+                DisplayName = string.IsNullOrEmpty(suppressedCat?.DisplayName) ? (suppressedCat?.Name ?? key) : suppressedCat!.DisplayName,
+                InstalledVersion = suppression.InstalledVersion,
+                WarningMessage = suppression.PendingRestart ? null : JoinWarnings(suppression.Reason, suppression.Cause),
+                WarningMessages = suppression.PendingRestart ? null : WarningList(suppression.Reason, suppression.Cause),
+                StatusReason = JoinWarnings(suppression.Reason, suppression.Cause),
+                StatusReasonCode = suppression.PendingRestart
+                    ? Cimian.Core.Models.StatusReasonCode.PendingReboot
+                    : Cimian.Core.Models.StatusReasonCode.LoopSuppressed,
+                DetectionMethod = Cimian.Core.Models.DetectionMethod.None,
+                ActionPerformed = suppression.PendingRestart ? "restart_deferred" : "loop_suppressed",
+                OutcomeTimestamp = DateTime.UtcNow
             });
         }
 

--- a/shared/core/Models/Reporting.cs
+++ b/shared/core/Models/Reporting.cs
@@ -441,6 +441,16 @@ public class ItemRecord
     [JsonPropertyName("total_sessions")]
     public int TotalSessions { get; set; }
 
+    /// <summary>
+    /// The warning split into its parts, mirroring
+    /// <see cref="SessionPackageInfo.WarningMessages"/>. A looping install produces two:
+    /// what the loop is, and what the package's own checks keep finding.
+    /// <see cref="LastWarning"/> holds them joined, for consumers expecting one string.
+    /// </summary>
+    [JsonPropertyName("warning_messages")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? WarningMessages { get; set; }
+
     // Enhanced install loop detection
     [JsonPropertyName("install_loop_detected")]
     public bool InstallLoopDetected { get; set; }

--- a/shared/core/Services/DataExporter.cs
+++ b/shared/core/Services/DataExporter.cs
@@ -560,6 +560,7 @@ public class DataExporter
             if (!string.IsNullOrEmpty(pkg.WarningMessage))
             {
                 record.LastWarning = pkg.WarningMessage;
+                record.WarningMessages = pkg.WarningMessages;
                 record.WarningCount = 1;
             }
 
@@ -568,6 +569,17 @@ public class DataExporter
                 var (loopDetected, loopDetails) = DetectInstallLoopEnhanced(record.RecentAttempts, pkg.Name);
                 record.InstallLoopDetected = loopDetected;
                 record.LoopDetails = loopDetails;
+            }
+
+            // A suppressed item is the one case where the loop is certain and the event
+            // history cannot show it: LoopGuard's whole job is to stop the reinstall, so
+            // the item records no attempt, RecentAttempts stays empty, and the derivation
+            // above never runs. install_loop_detected was therefore false for every
+            // genuinely-looping package on the fleet while being true only for packages
+            // the guard had not caught yet — exactly backwards. Trust the guard's verdict.
+            if (pkg.StatusReasonCode == Models.StatusReasonCode.LoopSuppressed)
+            {
+                record.InstallLoopDetected = true;
             }
 
             records.Add(record);

--- a/shared/core/Services/LoopGuard.cs
+++ b/shared/core/Services/LoopGuard.cs
@@ -245,6 +245,52 @@ public class LoopGuard
     }
 
     /// <summary>
+    /// Records that a package's own checks now report nothing to do. Convergence is the
+    /// definition of a fixed package, so any loop history and any open suppression window
+    /// are retired here.
+    /// <para>
+    /// Without this, LoopGuard only ever hears about a package while it still needs
+    /// action: <see cref="ShouldSuppress"/> is reached from the engine only when the
+    /// status check says NeedsAction. The moment a looping package starts converging —
+    /// the pkgsinfo was fixed, the installer finally took, the machine changed — the
+    /// guard is never consulted for it again, so its window, its (possibly absent)
+    /// trigger and its counters freeze exactly as they were and keep being reported as a
+    /// live loop for as long as the window runs. Measured on a lab fleet: healthy
+    /// packages whose installcheck reported "no action needed" on the same run were still
+    /// listed in loop_suppressed.json, and legacy indefinite entries for packages that
+    /// had converged months earlier never reached the MaxValue migration below at all.
+    /// </para>
+    /// <para>
+    /// This is deliberately stronger than letting the window expire: an expiry costs the
+    /// package a full LoopMaxTime of being reported broken and, via
+    /// <see cref="PackageLoopState.SuppressionCycles"/>, floors its next window. A package
+    /// that converged is not owed either.
+    /// </para>
+    /// </summary>
+    public void NoteConverged(string packageName, string? catalogFingerprint = null)
+    {
+        if (_disabled || string.IsNullOrEmpty(packageName))
+            return;
+
+        var key = packageName.ToLowerInvariant();
+        if (!_state.Packages.TryGetValue(key, out var pkgState))
+            return;
+
+        // Nothing accumulated: leave the entry untouched rather than rewriting state
+        // (and the state file) on every converged item of every run.
+        if (pkgState.SuppressedUntil == null
+            && pkgState.AttemptCount == 0
+            && pkgState.SuppressionCycles == 0
+            && pkgState.PendingRestartSince == null)
+        {
+            return;
+        }
+
+        ResetLoopHistory(pkgState, version: "", catalogFingerprint: catalogFingerprint ?? pkgState.CatalogFingerprint);
+        SaveState();
+    }
+
+    /// <summary>
     /// Records the check that decided this package needs to run. Called on every
     /// evaluation (so the reported cause stays current while suppressed) and on every
     /// real attempt with <paramref name="countIt"/> set, which is what builds the
@@ -438,9 +484,18 @@ public class LoopGuard
     /// marker) still accumulate and trip suppression as before.
     /// </para>
     /// </summary>
-    public void RecordAttempt(string packageName, string version, bool success, string? catalogFingerprint = null, bool selfReportedWarning = false, InstallTrigger? trigger = null)
+    public void RecordAttempt(string packageName, string version, bool success, string? catalogFingerprint = null, bool selfReportedWarning = false, InstallTrigger? trigger = null, bool loopExempt = false)
     {
         if (string.IsNullOrEmpty(packageName))
+            return;
+
+        // OnDemand and recurring items re-install every run by design, so the engine
+        // never asks ShouldSuppress about them. Counting their attempts anyway wrote a
+        // suppression window that nothing would ever enforce — invisible in behaviour,
+        // but reported in loop_suppressed.json as a live loop. On a lab fleet this was
+        // 11 of 76 active "loops", every one of them a provisioning helper doing exactly
+        // what OnDemand means.
+        if (loopExempt)
             return;
 
         // Globally disabled by config (LoopGuardEnabled: false): don't accumulate any
@@ -1010,6 +1065,31 @@ public class LoopGuard
 
     #region State Persistence
 
+    /// <summary>
+    /// Replaces any legacy permanent suppression (DateTime.MaxValue, written before the
+    /// finite cap existed) with a concrete window anchored on the package's last real
+    /// attempt.
+    /// <para>
+    /// <see cref="ShouldSuppress"/> performs the same migration, but only for packages it
+    /// is actually asked about — and a package is only asked about while its status check
+    /// still reports NeedsAction. An item that converged, or that was dropped from the
+    /// manifest, is never evaluated again, so its MaxValue entry was unreachable by that
+    /// path and stayed permanent forever. Doing it at load covers every entry in the file
+    /// exactly once per run, whatever the manifest happens to contain today.
+    /// </para>
+    /// </summary>
+    private LoopGuardState CapIndefiniteWindows(LoopGuardState state)
+    {
+        foreach (var (_, pkgState) in state.Packages)
+        {
+            if (pkgState.SuppressedUntil == DateTime.MaxValue)
+            {
+                pkgState.SuppressedUntil = pkgState.LastAttempt.GetValueOrDefault().AddDays(_maxSuppressionDays);
+            }
+        }
+        return state;
+    }
+
     private LoopGuardState LoadState()
     {
         var path = EffectiveStatePath;
@@ -1022,12 +1102,12 @@ public class LoopGuard
                 // Try reading as the new CimianState wrapper first
                 var wrapper = JsonSerializer.Deserialize<CimianState>(json, JsonOptions);
                 if (wrapper?.LoopGuard != null)
-                    return wrapper.LoopGuard;
+                    return CapIndefiniteWindows(wrapper.LoopGuard);
 
                 // Fall back to reading as bare LoopGuardState (legacy state.json or test)
                 var state = JsonSerializer.Deserialize<LoopGuardState>(json, JsonOptions);
                 if (state != null && state.Packages.Count > 0)
-                    return state;
+                    return CapIndefiniteWindows(state);
             }
 
             // Migrate from legacy loop_state.json if it exists

--- a/tests/LoopGuardTests.cs
+++ b/tests/LoopGuardTests.cs
@@ -38,6 +38,97 @@ public class LoopGuardTests : IDisposable
         return new LoopGuard(_statePath, _logsDir, isBootstrap, _cacheDir, disabled);
     }
 
+    #region Stale suppression
+
+    [Fact]
+    public void NoteConverged_ClearsSuppressionAndHistory()
+    {
+        var guard = CreateGuard();
+        guard.RecordAttempt("LoopPkg", "1.0.0", true);
+        guard.RecordAttempt("LoopPkg", "1.0.0", true);
+        guard.RecordAttempt("LoopPkg", "1.0.0", true);
+        guard.ShouldSuppress("LoopPkg", "1.0.0").Suppress.Should().BeTrue();
+
+        // The package's own checks now report nothing to do.
+        guard.NoteConverged("LoopPkg");
+
+        guard.ShouldSuppress("LoopPkg", "1.0.0").Suppress.Should().BeFalse();
+        guard.GetSuppressedReport().Should().BeEmpty();
+        guard.GetPackageState("LoopPkg")!.AttemptCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void NoteConverged_DoesNotFloorTheNextWindow()
+    {
+        var guard = CreateGuard();
+        guard.RecordAttempt("LoopPkg", "1.0.0", true);
+        guard.RecordAttempt("LoopPkg", "1.0.0", true);
+        guard.RecordAttempt("LoopPkg", "1.0.0", true);
+        guard.ShouldSuppress("LoopPkg", "1.0.0").Suppress.Should().BeTrue();
+
+        guard.NoteConverged("LoopPkg");
+
+        // Convergence is a fix, not a served sentence: it must not leave an escalation
+        // behind that lengthens the window if the package ever loops again.
+        guard.GetPackageState("LoopPkg")!.SuppressionCycles.Should().Be(0);
+    }
+
+    [Fact]
+    public void NoteConverged_UnknownOrCleanPackage_IsANoOp()
+    {
+        var guard = CreateGuard();
+        guard.NoteConverged("NeverSeen");
+        guard.GetPackageState("NeverSeen").Should().BeNull();
+    }
+
+    [Fact]
+    public void LoadState_MigratesIndefiniteWindowWithoutBeingEvaluated()
+    {
+        // A package suppressed indefinitely by an older client, which has since converged
+        // or left the manifest — so ShouldSuppress is never called for it again and its
+        // own migration path is unreachable.
+        var json = JsonSerializer.Serialize(new
+        {
+            loop_guard = new
+            {
+                packages = new Dictionary<string, object>
+                {
+                    ["stuckpkg"] = new
+                    {
+                        package_name = "StuckPkg",
+                        attempt_count = 400,
+                        session_count = 37,
+                        last_attempt = DateTime.UtcNow.AddDays(-90),
+                        suppressed_until = DateTime.MaxValue,
+                        suppression_reason = "Persistent loop"
+                    }
+                }
+            }
+        });
+        File.WriteAllText(_statePath, json);
+
+        var guard = CreateGuard();
+
+        var state = guard.GetPackageState("StuckPkg");
+        state.Should().NotBeNull();
+        state!.SuppressedUntil.Should().NotBe(DateTime.MaxValue);
+        // Anchored on the last attempt 90 days ago, so the window is already spent.
+        guard.GetSuppressedReport().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RecordAttempt_LoopExempt_AccumulatesNothing()
+    {
+        var guard = CreateGuard();
+        for (var i = 0; i < 5; i++)
+            guard.RecordAttempt("OnDemandPkg", "1.0.0", true, loopExempt: true);
+
+        guard.GetPackageState("OnDemandPkg").Should().BeNull();
+        guard.GetSuppressedReport().Should().BeEmpty();
+    }
+
+    #endregion
+
     #region Basic Behavior
 
     [Fact]


### PR DESCRIPTION
LoopGuard is only consulted about a package while its status check still reports `NeedsAction`. The moment a looping package starts converging, the guard is never asked about it again — so its suppression window, counters and trigger freeze as they were and keep being reported as a live loop until the window runs out.

Found by a field health check across 209 endpoints (76 active suppressions on 38 hosts). One root cause, four visible defects:

| | Observed |
|---|---|
| Stale windows | Items whose installcheck reported *no action needed* on the same run were still listed in `loop_suppressed.json` |
| Permanent entries | 7 legacy `DateTime.MaxValue` suppressions on 5 hosts, last attempts 3–4 months earlier, never migrated to the finite cap |
| Missing cause | 21 of 76 suppressions carried no trigger and could never acquire one |
| OnDemand noise | 11 of 76 were OnDemand items accumulating windows `ShouldSuppress` deliberately never enforces |

## Changes

- **`LoopGuard.NoteConverged`** retires loop history and any open window when an item's own checks come back clean; the engine calls it on the `!status.NeedsAction` branch. Deliberately stronger than letting the window expire — an expiry costs the package a full `LoopMaxTime` of being reported broken and floors its next window via `SuppressionCycles`, and a converged package is owed neither.
- **Indefinite windows are capped at load** (`CapIndefiniteWindows`), so every entry in the file is covered once per run whatever the manifest contains today. The existing migration in `ShouldSuppress` was unreachable for exactly the entries that needed it.
- **`RecordAttempt` takes `loopExempt`**, set for OnDemand and recurring items, so items that bypass the guard stop accumulating state nothing acts on.
- **`items.json` reflects the guard's verdict.** `install_loop_detected` was derived from event history, which a suppressed item cannot have — the guard's job is to stop the reinstall — so the flag was `false` for every genuinely looping package and `true` only for ones the guard had not caught yet. It now follows the suppression, carries `warning_messages` alongside the joined string, and includes suppressed **dependencies**, which were absent from the item report entirely because only manifest entries were walked.

## Tests

5 new tests in `LoopGuardTests`. Full suite: 1031 passed / 4 failed; the same 4 fail on unmodified `origin/main` (hostname- and environment-dependent).