### PR TITLE
Validate payload size on every run, not only under --hash_check

### DIFF
--- a/cli/makecatalogs/Services/CatalogBuilder.cs
+++ b/cli/makecatalogs/Services/CatalogBuilder.cs
@@ -99,9 +99,16 @@ public class CatalogBuilder
                 {
                     warnings.Add($"{pkg.FilePath} has missing installer => {relativePath}");
                 }
-                else if (hashCheck)
+                else
                 {
-                    // Hash and size validation when --hash_check is enabled
+                    // Size is checked on every run; hashing only under --hash_check.
+                    // They used to share the flag, which meant neither ran in practice:
+                    // the publishing pipeline does not pass it, because hashing every
+                    // payload means re-reading multi-gigabyte packages on each publish.
+                    // Reading a file's length costs a stat call, so there is no reason
+                    // for it to sit behind the expensive check -- and a wrong size is
+                    // exactly what went unnoticed for months, because the one detector
+                    // for it never ran.
                     var fullPath = Path.Combine(repoPath, relativePath.Replace('/', '\\'));
                     if (File.Exists(fullPath))
                     {
@@ -110,7 +117,7 @@ public class CatalogBuilder
                         {
                             warnings.Add($"{pkg.FilePath} installer size mismatch: expected {pkg.Installer.Size}, actual {fileInfo.Length}");
                         }
-                        if (!string.IsNullOrEmpty(pkg.Installer.Hash))
+                        if (hashCheck && !string.IsNullOrEmpty(pkg.Installer.Hash))
                         {
                             var actualHash = ComputeMd5Hash(fullPath);
                             if (!string.Equals(actualHash, pkg.Installer.Hash, StringComparison.OrdinalIgnoreCase))
@@ -139,8 +146,6 @@ public class CatalogBuilder
                         continue;
                     }
 
-                    if (!hashCheck) continue;
-
                     var fullPath = Path.Combine(repoPath, relativePath.Replace('/', '\\'));
                     if (!File.Exists(fullPath)) continue;
 
@@ -149,7 +154,7 @@ public class CatalogBuilder
                     {
                         warnings.Add($"{pkg.FilePath} uninstaller size mismatch: expected {uninst.Size}, actual {fileInfo.Length}");
                     }
-                    if (!string.IsNullOrEmpty(uninst.Hash))
+                    if (hashCheck && !string.IsNullOrEmpty(uninst.Hash))
                     {
                         var actualHash = ComputeMd5Hash(fullPath);
                         if (!string.Equals(actualHash, uninst.Hash, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Closes #146

`VerifyPayloads` checked size and hash together behind `--hash_check`. The publishing pipeline does not pass that flag, for a defensible reason — hashing every payload re-reads the whole repository on each publish, and individual packages run to 12–14 GB. So in practice **neither check has ever run**.

The costs are not comparable:

| check | cost |
|---|---|
| size | one `FileInfo.Length` |
| hash | full MD5 read of the payload |

Sharing a flag made the cheap check inherit the expensive one's reason for being off.

The result was a package recording `size: 11909782` for a payload of 12,193,948,000 bytes — kilobytes written into a field that is compared against `FileInfo.Length` — which nothing surfaced, because the only detector for it was disabled by default and never enabled. It also blocks any consumer that wants to reason about free disk space before installing, since the recorded size cannot be trusted.

Size is now checked whenever payload verification runs; hashing still requires `--hash_check`. Warnings are already non-fatal, so this reports drift without failing a publish.

Verified against a throwaway repo containing a payload of 19 bytes with a deliberately wrong size and hash:

```
without --hash_check:
  WARNING: ... installer size mismatch: expected 999999, actual 19

with --hash_check:
  WARNING: ... installer size mismatch: expected 999999, actual 19
  WARNING: ... installer hash mismatch: expected 000...0, actual 2b178c16...
```

Builds clean.