### PR TITLE
Include the current session's own events in events.json

### DIFF
--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -515,6 +515,27 @@ public class SessionLogger : IDisposable
     /// <see cref="FileShare.ReadWrite"/> reads the file as it stands; AutoFlush on the
     /// writer means every completed line is already on disk.
     /// </remarks>
+    /// <summary>
+    /// Parses JSON Lines events, dropping any line that does not parse.
+    /// </summary>
+    /// <remarks>
+    /// The current session's events.jsonl is read while it is still being written, so
+    /// its final line can be torn. One bad line must cost that line, not the session.
+    /// </remarks>
+    internal static IEnumerable<LogEvent> ParseEventLines(IEnumerable<string> lines)
+    {
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            LogEvent? evt;
+            try { evt = JsonSerializer.Deserialize<LogEvent>(line, JsonLinesOptions); }
+            catch { continue; }
+            if (evt != null)
+                yield return evt;
+        }
+    }
+
     internal static IEnumerable<string> ReadLinesShared(string path)
     {
         using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -531,17 +552,13 @@ public class SessionLogger : IDisposable
 
         try
         {
-            string? lastLine = null;
-            foreach (var line in ReadLinesShared(eventsPath))
-            {
-                if (!string.IsNullOrWhiteSpace(line))
-                    lastLine = line;
-            }
+            // The last line that parses, not the last line: a session killed mid-write
+            // can end on a torn line, and the reaper's reason is better with the item
+            // before it than with nothing.
+            LogEvent? evt = null;
+            foreach (var parsed in ParseEventLines(ReadLinesShared(eventsPath)))
+                evt = parsed;
 
-            if (lastLine == null)
-                return (null, null);
-
-            var evt = JsonSerializer.Deserialize<LogEvent>(lastLine, JsonLinesOptions);
             if (evt == null)
                 return (null, null);
 
@@ -1191,19 +1208,19 @@ public class SessionLogger : IDisposable
             var eventsPath = Path.Combine(dir, "events.jsonl");
             if (File.Exists(eventsPath))
             {
-                try
+                // One bad line drops that line, not the session. The current session's
+                // file is read while it is still being written, so its final line can
+                // be torn; a catch around the whole loop would throw away every event
+                // of the run that matters most because of the one that is incomplete.
+                IEnumerable<string> lines;
+                try { lines = ReadLinesShared(eventsPath).ToList(); }
+                catch { continue; }
+
+                foreach (var evt in ParseEventLines(lines))
                 {
-                    foreach (var line in ReadLinesShared(eventsPath))
-                    {
-                        if (!string.IsNullOrWhiteSpace(line))
-                        {
-                            var evt = JsonSerializer.Deserialize<LogEvent>(line, JsonLinesOptions);
-                            if (evt != null && evt.Timestamp >= cutoff)
-                                allEvents.Add(evt);
-                        }
-                    }
+                    if (evt.Timestamp >= cutoff)
+                        allEvents.Add(evt);
                 }
-                catch { /* Skip invalid event files */ }
             }
         }
 

--- a/shared/core/Services/SessionLogger.cs
+++ b/shared/core/Services/SessionLogger.cs
@@ -501,6 +501,29 @@ public class SessionLogger : IDisposable
     /// <summary>
     /// Returns the timestamp and package name of the last event a session wrote.
     /// </summary>
+    /// <summary>
+    /// Reads a JSON Lines file that another writer may still hold open.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="File.ReadLines(string)"/> opens with <see cref="FileShare.Read"/>, which
+    /// the OS refuses while any other handle has the file open for writing. The current
+    /// session's events.jsonl is exactly that file: <c>_eventsFile</c> keeps it open until
+    /// EndSession, and the reports are generated before then. The open threw a sharing
+    /// violation, the per-file catch swallowed it, and events.json was written without
+    /// the session that was writing it - so a run's own install events never appeared in
+    /// the report it handed to postflight, only in the next run's. Opening with
+    /// <see cref="FileShare.ReadWrite"/> reads the file as it stands; AutoFlush on the
+    /// writer means every completed line is already on disk.
+    /// </remarks>
+    internal static IEnumerable<string> ReadLinesShared(string path)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+            yield return line;
+    }
+
     private static (DateTime? Timestamp, string? Item) ReadLastEvent(string eventsPath)
     {
         if (!File.Exists(eventsPath))
@@ -509,7 +532,7 @@ public class SessionLogger : IDisposable
         try
         {
             string? lastLine = null;
-            foreach (var line in File.ReadLines(eventsPath))
+            foreach (var line in ReadLinesShared(eventsPath))
             {
                 if (!string.IsNullOrWhiteSpace(line))
                     lastLine = line;
@@ -1170,7 +1193,7 @@ public class SessionLogger : IDisposable
             {
                 try
                 {
-                    foreach (var line in File.ReadLines(eventsPath))
+                    foreach (var line in ReadLinesShared(eventsPath))
                     {
                         if (!string.IsNullOrWhiteSpace(line))
                         {

--- a/tests/Shared/LiveSessionEventsTests.cs
+++ b/tests/Shared/LiveSessionEventsTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Linq;
+using Cimian.Core.Services;
+using Xunit;
+
+/// <summary>
+/// A run's own install events must reach events.json while the run is still writing them.
+/// </summary>
+/// <remarks>
+/// The report is generated before EndSession disposes the events.jsonl writer, so the
+/// current session's file is open for writing when the report reads it. File.ReadLines
+/// opens with FileShare.Read, which the OS refuses against an open writer; the sharing
+/// violation was swallowed per file, and events.json was written without the session that
+/// was writing it. Every installing run therefore handed postflight a report with none of
+/// its own installs, and the fleet showed nothing for a package that had just installed.
+/// </remarks>
+public class LiveSessionEventsTests : IDisposable
+{
+    private readonly string _root;
+
+    public LiveSessionEventsTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cimian-live-events-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private string OpenLiveEventsFile(out StreamWriter writer)
+    {
+        var path = Path.Combine(_root, "events.jsonl");
+        // Exactly how SessionLogger opens it: append, AutoFlush, default share mode.
+        writer = new StreamWriter(path, append: true) { AutoFlush = true };
+        writer.WriteLine("{\"event_type\":\"install\",\"package_name\":\"Rhino\",\"status\":\"started\"}");
+        writer.WriteLine("{\"event_type\":\"install\",\"package_name\":\"Rhino\",\"status\":\"completed\"}");
+        return path;
+    }
+
+    [Fact]
+    public void ReadLinesShared_ReadsAFileAnotherWriterStillHoldsOpen()
+    {
+        var path = OpenLiveEventsFile(out var writer);
+        using (writer)
+        {
+            var lines = SessionLogger.ReadLinesShared(path).ToList();
+            Assert.Equal(2, lines.Count);
+            Assert.Contains("\"status\":\"completed\"", lines[1]);
+        }
+    }
+
+    [Fact]
+    public void ReadLinesShared_SeesLinesWrittenAfterAnEarlierRead()
+    {
+        // AutoFlush puts each completed line on disk; a later read must see it.
+        var path = OpenLiveEventsFile(out var writer);
+        using (writer)
+        {
+            Assert.Equal(2, SessionLogger.ReadLinesShared(path).Count());
+            writer.WriteLine("{\"event_type\":\"install\",\"package_name\":\"Rhino\",\"status\":\"completed\",\"message\":\"v8\"}");
+            Assert.Equal(3, SessionLogger.ReadLinesShared(path).Count());
+        }
+    }
+
+    [Fact]
+    public void TheDefaultReadIsRefusedAgainstAnOpenWriter_OnWindows()
+    {
+        // The premise. Share modes are enforced by the OS only on Windows, which is the
+        // only platform this client runs on; elsewhere .NET emulates nothing and the old
+        // read succeeds, so this fact is meaningful only there.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var path = OpenLiveEventsFile(out var writer);
+        using (writer)
+        {
+            Assert.Throws<IOException>(() => File.ReadLines(path).ToList());
+        }
+    }
+
+    [Fact]
+    public void ReadLinesShared_StillReadsAClosedFile()
+    {
+        var path = OpenLiveEventsFile(out var writer);
+        writer.Dispose();
+        Assert.Equal(2, SessionLogger.ReadLinesShared(path).Count());
+    }
+}

--- a/tests/Shared/LiveSessionEventsTests.cs
+++ b/tests/Shared/LiveSessionEventsTests.cs
@@ -81,6 +81,21 @@ public class LiveSessionEventsTests : IDisposable
     }
 
     [Fact]
+    public void ATornFinalLine_CostsThatLineNotTheSession()
+    {
+        // The file is read while it is still being written, so the last line can be
+        // incomplete. The two good events must survive it.
+        var path = OpenLiveEventsFile(out var writer);
+        using (writer)
+        {
+            writer.Write("{\"event_type\":\"install\",\"package_name\":\"Rhi");
+            var events = SessionLogger.ParseEventLines(SessionLogger.ReadLinesShared(path)).ToList();
+            Assert.Equal(2, events.Count);
+            Assert.All(events, e => Assert.Equal("Rhino", e.PackageName));
+        }
+    }
+
+    [Fact]
     public void ReadLinesShared_StillReadsAClosedFile()
     {
         var path = OpenLiveEventsFile(out var writer);


### PR DESCRIPTION
The events report was always one session behind, so a run's own install events never appeared in the report it handed to postflight - only in the next run's. A package that had just installed showed nothing in fleet reporting.

## Cause

`GenerateEventsReport` reads each session's `events.jsonl` with `File.ReadLines`, which opens with `FileShare.Read`. The current session's file is still held open for writing by `_eventsFile` until `EndSession`, and since #143 the reports are generated before that. The OS refuses that open with a sharing violation, the per-file `catch { }` swallows it, and `events.json` is written without the session that is writing it. Every older session reads fine because its writer is gone - which is exactly why the events surfaced one session late.

Observed on a device: the run's `events.jsonl` held 165 lines including 8 `install` events; the `events.json` that run wrote listed every earlier session and not itself; the next run's `events.json` contained all 165.

Before #143 postflight ran ahead of the reports, so the reporting client saw the previous session as latest and matched it against an `events.json` that already contained it. One session late, but every install surfaced. Moving the reports first made `sessions.json` name a session that `events.json` could never contain.

## Fix

Read with `FileShare.ReadWrite`. `AutoFlush` on the writer means every completed line is already on disk, so the file reads as it stands. `ReadLastEvent` reads the same files the same way and gets the same change.

## Tests

`LiveSessionEventsTests`: the shared read returns a file another writer holds open, sees lines appended after an earlier read, and still reads a closed file. A Windows-only fact pins the premise - `File.ReadLines` throws `IOException` against the open writer - because share modes are not enforced on other platforms, where the old read would have succeeded and the test would say nothing.

Suite on macOS: 995 passed, 50 failed. The same 50 fail on `origin/main` (991 passed) - they exercise PowerShell, the registry, Windows services and MSI readers, and are not runnable off Windows. The +4 are this change's tests.