### PR TITLE
Report the installed version, not just the catalog target

### DIFF
--- a/cli/managedsoftwareupdate/Services/UpdateEngine.cs
+++ b/cli/managedsoftwareupdate/Services/UpdateEngine.cs
@@ -1122,6 +1122,10 @@ public class UpdateEngine : IDisposable
                         status.InstalledVersion,
                         status.NeedsAction);
 
+                    // Keep what detection found. This is the only point in the run that
+                    // holds it, and the session report is built long after the check.
+                    RememberInstalledVersion(catalogItem.Name, status);
+
                     if (!status.NeedsAction)
                     {
                         // The item's own checks are satisfied: whatever a previous run was
@@ -1274,6 +1278,8 @@ public class UpdateEngine : IDisposable
                             catalogItem.Name, catalogItem.Version, optStatus.Status,
                             optStatus.Reason, optStatus.ReasonCode, optStatus.DetectionMethod,
                             optStatus.InstalledVersion, optStatus.NeedsAction);
+
+                        RememberInstalledVersion(catalogItem.Name, optStatus);
 
                         if (optStatus.NeedsAction)
                         {
@@ -1599,6 +1605,9 @@ public class UpdateEngine : IDisposable
             var status = _statusService.CheckStatus(depItem, "install", _config.CachePath);
 
             LogInfo($"Dependency {depItem.Name} v{depItem.Version}: needsAction={status.NeedsAction} ({status.Reason})");
+
+            // Dependencies reach items.json too, so their detection result matters here.
+            RememberInstalledVersion(depItem.Name, status);
 
             if (!existingNames.Contains(depKey))
             {
@@ -3046,7 +3055,7 @@ public class UpdateEngine : IDisposable
                     Status = suppression.PendingRestart ? "Pending" : "Warning",
                     ItemType = itemType,
                     DisplayName = displayName,
-                    InstalledVersion = suppression.InstalledVersion,
+                    InstalledVersion = suppression.InstalledVersion ?? ResolveInstalledVersion(mi.Name, null, version),
                     WarningMessage = suppression.PendingRestart ? null : JoinWarnings(suppression.Reason, suppression.Cause),
                     WarningMessages = suppression.PendingRestart ? null : WarningList(suppression.Reason, suppression.Cause),
                     StatusReason = JoinWarnings(suppression.Reason, suppression.Cause),
@@ -3076,6 +3085,7 @@ public class UpdateEngine : IDisposable
                     Status = SessionItemStatusResolver.ResolveDeferred(deferral.Kind),
                     ItemType = itemType,
                     DisplayName = displayName,
+                    InstalledVersion = ResolveInstalledVersion(mi.Name, null, version),
                     StatusReason = deferral.Reason,
                     StatusReasonCode = deferral.ReasonCode,
                     DetectionMethod = Cimian.Core.Models.DetectionMethod.None,
@@ -3110,6 +3120,7 @@ public class UpdateEngine : IDisposable
                 Status = effectiveStatus,
                 ItemType = itemType,
                 DisplayName = displayName,
+                InstalledVersion = ResolveInstalledVersion(mi.Name, hadOutcome ? outcome : null, version),
                 ErrorMessage = hadOutcome && !outcome!.Success ? outcome.ErrorMessage : null,
                 WarningMessage = hasWarning ? JoinWarnings(outcome!.WarningMessage!, outcome.WarningDetail) : null,
                 WarningMessages = hasWarning ? WarningList(outcome!.WarningMessage!, outcome.WarningDetail) : null,
@@ -3135,7 +3146,7 @@ public class UpdateEngine : IDisposable
                 Status = suppression.PendingRestart ? "Pending" : "Warning",
                 ItemType = "managed_installs",
                 DisplayName = string.IsNullOrEmpty(suppressedCat?.DisplayName) ? (suppressedCat?.Name ?? key) : suppressedCat!.DisplayName,
-                InstalledVersion = suppression.InstalledVersion,
+                InstalledVersion = suppression.InstalledVersion ?? ResolveInstalledVersion(suppressedCat?.Name ?? key, null, suppressedCat?.Version ?? ""),
                 WarningMessage = suppression.PendingRestart ? null : JoinWarnings(suppression.Reason, suppression.Cause),
                 WarningMessages = suppression.PendingRestart ? null : WarningList(suppression.Reason, suppression.Cause),
                 StatusReason = JoinWarnings(suppression.Reason, suppression.Cause),
@@ -3519,6 +3530,45 @@ public class UpdateEngine : IDisposable
     /// three times and still not say what kept asking for it.
     /// </summary>
     private readonly Dictionary<string, Cimian.Core.Models.InstallTrigger> _installTriggers = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// What each item's own detection actually found on disk, keyed by item name, so the
+    /// session report can state the installed version rather than only the catalog target.
+    /// StatusService resolves this during every status check and it was being discarded
+    /// the moment the check returned, which left installed_version absent from items.json
+    /// for every item and made "is this version really on the machine" unanswerable
+    /// downstream.
+    /// </summary>
+    private readonly Dictionary<string, string> _installedVersions = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Records what a status check found installed. Empty results are not recorded, so a
+    /// later check that resolves a version cannot be overwritten by an earlier blank one.
+    /// </summary>
+    private void RememberInstalledVersion(string name, StatusCheckResult status)
+    {
+        if (!string.IsNullOrWhiteSpace(status.InstalledVersion))
+            _installedVersions[name] = status.InstalledVersion!.Trim();
+    }
+
+    /// <summary>
+    /// The installed version to report for an item. A run that successfully installed or
+    /// updated the item supersedes whatever the pre-install check saw, because that check
+    /// ran before the install; anything else falls back to what detection found.
+    /// </summary>
+    private string? ResolveInstalledVersion(string name, ItemOutcome? outcome, string catalogVersion)
+    {
+        if (outcome is { Success: true }
+            && !string.IsNullOrEmpty(outcome.Action)
+            && outcome.Action.ToLowerInvariant() is "install" or "update")
+        {
+            var installed = !string.IsNullOrEmpty(outcome.Version) ? outcome.Version : catalogVersion;
+            if (!string.IsNullOrWhiteSpace(installed))
+                return installed.Trim();
+        }
+
+        return _installedVersions.TryGetValue(name, out var known) ? known : null;
+    }
 
     /// <summary>
     /// A warning that has a cause is two messages, not one paragraph. Consumers that read

--- a/shared/core/Models/Reporting.cs
+++ b/shared/core/Models/Reporting.cs
@@ -402,8 +402,18 @@ public class ItemRecord
     [JsonPropertyName("latest_version")]
     public string LatestVersion { get; set; } = string.Empty;
 
+    /// <summary>
+    /// What detection actually found on the machine, as opposed to
+    /// <see cref="LatestVersion"/>, which is only the catalog target.
+    ///
+    /// <para>
+    /// Always serialized, including when null. Omitting it made an item whose version
+    /// could not be determined indistinguishable from a client too old to report one,
+    /// and that ambiguity is what let the field sit empty everywhere without surfacing.
+    /// A null here is a claim — "this run could not determine a version" — not silence.
+    /// </para>
+    /// </summary>
     [JsonPropertyName("installed_version")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? InstalledVersion { get; set; }
 
     // Status and timing

--- a/shared/core/Services/DataExporter.cs
+++ b/shared/core/Services/DataExporter.cs
@@ -1193,6 +1193,17 @@ public class DataExporter
                     (eventData.TryGetValue("version",         out var v)  ? v.GetString()  : "");
                 var error = eventData.TryGetValue("error", out var e) ? e.GetString() : "";
 
+                // Status-check and install events both carry what detection found. Keep the
+                // most recent non-empty one so the historical report can state the installed
+                // version, not just the catalog target.
+                if (eventData.TryGetValue("installed_version", out var iv)
+                    && iv.ValueKind == JsonValueKind.String)
+                {
+                    var detected = iv.GetString();
+                    if (!string.IsNullOrWhiteSpace(detected))
+                        stats.InstalledVersion = detected.Trim();
+                }
+
                 // Update statistics
                 switch (action?.ToLowerInvariant())
                 {

--- a/tests/ItemsJsonFinalizationTests.cs
+++ b/tests/ItemsJsonFinalizationTests.cs
@@ -269,11 +269,102 @@ public class ItemsJsonFinalizationTests
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
+    // ── installed_version: what is on the machine, not what the catalog targets ──
+
+    /// <summary>
+    /// The regression this pins: items.json carried only latest_version (the catalog
+    /// target), so nothing downstream could say what a machine actually had. The field
+    /// existed on the model end to end and was simply never populated, which read as
+    /// "empty" rather than "broken" everywhere it surfaced.
+    /// </summary>
+    [Fact]
+    public void GenerateCurrentItems_CarriesTheInstalledVersionThroughToTheRecord()
+    {
+        using var fixture = new SessionsFixture();
+
+        var exporter = new DataExporter(fixture.BaseDir);
+        var items = exporter.GenerateCurrentItemsFromPackagesInfo(
+            new List<SessionPackageInfo>
+            {
+                new()
+                {
+                    Name = "Foo",
+                    Version = "2.0",              // catalog target
+                    InstalledVersion = "1.4",     // what detection found
+                    Status = "Installed",
+                    ItemType = "managed_installs",
+                    DisplayName = "Foo"
+                }
+            },
+            currentSessionId: "2026-04-27-1000");
+
+        var foo = items.Single();
+        Assert.Equal("2.0", foo.LatestVersion);
+        Assert.Equal("1.4", foo.InstalledVersion);
+    }
+
+    /// <summary>
+    /// The historical/stats producer reads events rather than the live session, so it
+    /// needs its own path to the same fact.
+    /// </summary>
+    [Fact]
+    public void GenerateItemsTable_TakesTheInstalledVersionFromEventHistory()
+    {
+        using var fixture = new SessionsFixture();
+        fixture.WriteSession("2026-04-27-1000",
+            StatusCheckEventLine("Foo", packageVersion: "2.0", installedVersion: "1.4"));
+
+        var exporter = new DataExporter(fixture.BaseDir);
+
+        var foo = exporter.GenerateItemsTable(30).Single(i => i.ItemName == "Foo");
+        Assert.Equal("1.4", foo.InstalledVersion);
+    }
+
+    /// <summary>
+    /// A later blank must not erase a version an earlier check resolved — otherwise a
+    /// single unreadable check in a session wipes the answer for the whole run.
+    /// </summary>
+    [Fact]
+    public void GenerateItemsTable_ABlankLaterEventDoesNotEraseAKnownVersion()
+    {
+        using var fixture = new SessionsFixture();
+        fixture.WriteSession("2026-04-27-1000",
+            StatusCheckEventLine("Foo", packageVersion: "2.0", installedVersion: "1.4"),
+            StatusCheckEventLine("Foo", packageVersion: "2.0", installedVersion: ""));
+
+        var exporter = new DataExporter(fixture.BaseDir);
+
+        Assert.Equal("1.4", exporter.GenerateItemsTable(30).Single(i => i.ItemName == "Foo").InstalledVersion);
+    }
+
+    /// <summary>
+    /// An absent key and an undetermined version are different facts. Omitting the
+    /// property made a client that could not read a version look identical to one too
+    /// old to report the field at all, which is what kept this invisible.
+    /// </summary>
+    [Fact]
+    public void ItemRecord_AlwaysSerializesInstalledVersionEvenWhenUnknown()
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            new ItemRecord { ItemName = "Foo", LatestVersion = "2.0", InstalledVersion = null });
+
+        Assert.Contains("\"installed_version\"", json);
+    }
+
     private static string EventLine(string action, string status, string packageName, string packageVersion) =>
         "{\"action\":\"" + action + "\"," +
         "\"status\":\"" + status + "\"," +
         "\"package_name\":\"" + packageName + "\"," +
         "\"package_version\":\"" + packageVersion + "\"," +
+        "\"timestamp\":\"" + DateTime.UtcNow.ToString("o") + "\"}";
+
+    /// <summary>A status_check event, which is what carries installed_version in a real run.</summary>
+    private static string StatusCheckEventLine(string packageName, string packageVersion, string installedVersion) =>
+        "{\"action\":\"status_check\"," +
+        "\"status\":\"installed\"," +
+        "\"package_name\":\"" + packageName + "\"," +
+        "\"package_version\":\"" + packageVersion + "\"," +
+        "\"installed_version\":\"" + installedVersion + "\"," +
         "\"timestamp\":\"" + DateTime.UtcNow.ToString("o") + "\"}";
 
     private sealed class SessionsFixture : IDisposable


### PR DESCRIPTION
`items.json` carried `latest_version` for every item and `installed_version` for almost none, so a consumer could see what an item was *supposed* to be but never what the machine actually had. The field is defined end to end on every model and was simply never populated on the paths that matter.

### Why it was invisible

`StatusService` resolves the installed version on every status check — running binary, registry, MSI/ARP, disk — and that result was discarded the moment the check returned. The session report is assembled much later, by which point nothing remembered it. Only the two LoopGuard-suppression branches set the field, and those are rare, so in practice it was absent everywhere.

The property was serialized with `WhenWritingNull`, so an undetermined version was *omitted* rather than written. That made it indistinguishable from a client too old to report the field at all, which is why an empty column read as "nothing to see" rather than as a defect.

### Change

- Remember what each status check found, keyed by item, for the life of the run.
- Resolve the reported value at report time: a successful install or update supersedes the pre-install check, since that check ran *before* the install.
- Populate the main, deferred and dependency paths; suppression keeps its own value and falls back to the memo.
- Give the historical exporter the same fact from event history, keeping the most recent non-empty reading so one unreadable check cannot erase a known version.
- `installed_version` is now always serialized. A null is a claim — "this run could not determine a version" — not silence.

### Tests

Four added to `ItemsJsonFinalizationTests`, covering the live producer, the history-based producer, the blank-does-not-erase rule, and the serialization contract. Three of them fail on `main` and pass here; verified by reverting the source with the tests in place.

Full suite: 1046 passed. The 4 remaining failures are pre-existing on `main` (hostname-dependent predicate cases and a config round-trip) and unchanged by this PR — baselined before and after.

https://claude.ai/code/session_015MM4e9AWa9K9gJoj4TqTMd