### PR TITLE
Keep the version the installs check already resolved

### DIFF
--- a/cli/managedsoftwareupdate/Services/StatusService.cs
+++ b/cli/managedsoftwareupdate/Services/StatusService.cs
@@ -162,6 +162,13 @@ public class StatusService
                 result.Reason = "Installs array verification passed";
                 result.ReasonCode = StatusReasonCode.FileMatch;
                 result.DetectionMethod = DetectionMethod.InstallsArray;
+
+                // Carry over what the walk actually found on disk. Only the failure path
+                // returned installsResult, so on success every version it had resolved —
+                // including the MSI/ARP one — was discarded with the object. That is why
+                // packages verified through their installs array reported no version at
+                // all while the check that proved they were installed had just read one.
+                NoteInstalledVersion(result, installsResult.InstalledVersion);
                 ConsoleLogger.Debug($"CheckStatus explicitly indicates NO update required item: {item.Name}");
                 return result;
             }
@@ -517,9 +524,16 @@ public class StatusService
                         // Check version - use item.Version as fallback when install.Version is not specified (reduces pkgsinfo redundancy)
                         // Go parity: When hash verification passed, version mismatches are informational only (hash is authoritative)
                         var expectedVersion = !string.IsNullOrEmpty(installItem.Version) ? installItem.Version : item.Version;
+
+                        // Read the version whether or not the catalog gives us something to
+                        // compare against. It was previously resolved only as an input to the
+                        // comparison and then dropped, so a file-detected package reported no
+                        // version at all — which is most of the catalog.
+                        var fileVersion = GetFileVersion(installItem.Path);
+                        NoteInstalledVersion(result, fileVersion);
+
                         if (!string.IsNullOrEmpty(expectedVersion))
                         {
-                            var fileVersion = GetFileVersion(installItem.Path);
                             if (!string.IsNullOrEmpty(fileVersion))
                             {
                                 var comparison = CatalogService.CompareVersions(expectedVersion, fileVersion);
@@ -772,6 +786,7 @@ public class StatusService
                         }
                     }
 
+                    NoteInstalledVersion(result, msixVersion);
                     ConsoleLogger.Info($"MSIX verification passed item: {item.Name} installedVersion: {msixVersion} catalogVersion: {msixCatalogVersion}");
                     result.InstalledVersion = msixVersion;
                     break;
@@ -1645,6 +1660,23 @@ if ($results.Count -gt 0) {{
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Records what a check found installed, first non-empty reading wins.
+    ///
+    /// <para>
+    /// Purely an observation: it never influences <see cref="StatusCheckResult.NeedsAction"/>
+    /// or any version comparison. A pkgsinfo with several installs entries is describing one
+    /// package, so the first entry that yields a version is the one that names it; letting a
+    /// later versionless entry (a marker file, a directory) overwrite it would report the
+    /// package as versionless despite having just resolved one.
+    /// </para>
+    /// </summary>
+    private static void NoteInstalledVersion(StatusCheckResult result, string? found)
+    {
+        if (!string.IsNullOrWhiteSpace(found) && string.IsNullOrWhiteSpace(result.InstalledVersion))
+            result.InstalledVersion = found!.Trim();
     }
 
     private static string? GetFileVersion(string path)

--- a/tests/Managedsoftwareupdate/StatusServiceTests.cs
+++ b/tests/Managedsoftwareupdate/StatusServiceTests.cs
@@ -58,6 +58,116 @@ public class StatusServiceTests
 
     #endregion
 
+    #region installed_version resolution
+
+    /// <summary>
+    /// A real Windows binary with genuine version metadata. Using a system file keeps the
+    /// test honest — FileVersionInfo against a hand-made temp file returns nothing, which
+    /// would pass a broken implementation.
+    /// </summary>
+    private static string VersionedSystemFile =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "kernel32.dll");
+
+    /// <summary>
+    /// The regression: the installs-array walk resolved a version, and CheckStatus threw
+    /// it away on the success path by returning a fresh result rather than the walk's.
+    /// Only the failure path carried it, so a package that verified cleanly reported no
+    /// version at all — while the very check that proved it was installed had just read one.
+    /// </summary>
+    [Fact]
+    public void CheckStatus_InstallsArrayPasses_StillReportsTheInstalledVersion()
+    {
+        var item = new CatalogItem
+        {
+            Name = "VersionedFilePackage",
+            Version = "1.0.0",
+            Installs = new List<InstallCheckItem>
+            {
+                new() { Type = "file", Path = VersionedSystemFile }
+            }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.False(result.NeedsAction);
+        Assert.False(string.IsNullOrWhiteSpace(result.InstalledVersion));
+    }
+
+    /// <summary>
+    /// Reading the version must stay an observation. A file that exists satisfies the check
+    /// regardless of what its metadata says, so recording the version cannot flip the
+    /// install decision — that would change what the fleet installs.
+    /// </summary>
+    [Fact]
+    public void CheckStatus_ReadingTheVersionDoesNotChangeTheInstallDecision()
+    {
+        var item = new CatalogItem
+        {
+            Name = "NoExpectedVersionPackage",
+            Version = "",
+            Installs = new List<InstallCheckItem>
+            {
+                new() { Type = "file", Path = VersionedSystemFile }
+            }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.False(result.NeedsAction);
+        Assert.Equal("installed", result.Status);
+    }
+
+    /// <summary>
+    /// A missing file is still pending. The version work must not mask a real failure.
+    /// </summary>
+    [Fact]
+    public void CheckStatus_MissingFile_IsStillPendingAndReportsNoVersion()
+    {
+        var item = new CatalogItem
+        {
+            Name = "AbsentPackage",
+            Version = "1.0.0",
+            Installs = new List<InstallCheckItem>
+            {
+                new() { Type = "file", Path = Path.Combine(_testDir, "does-not-exist.exe") }
+            }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.True(result.NeedsAction);
+        Assert.True(string.IsNullOrWhiteSpace(result.InstalledVersion));
+    }
+
+    /// <summary>
+    /// One package, several installs entries. The entry that yields a version names the
+    /// package; a later versionless marker file must not erase it.
+    /// </summary>
+    [Fact]
+    public void CheckStatus_AVersionlessLaterEntryDoesNotEraseTheVersion()
+    {
+        var marker = Path.Combine(_testDir, "marker.txt");
+        File.WriteAllText(marker, "installed");
+
+        var item = new CatalogItem
+        {
+            Name = "MultiEntryPackage",
+            Version = "",
+            Installs = new List<InstallCheckItem>
+            {
+                new() { Type = "file", Path = VersionedSystemFile },
+                new() { Type = "file", Path = marker }
+            }
+        };
+
+        var result = _service.CheckStatus(item, "install", _testDir);
+
+        Assert.False(result.NeedsAction);
+        Assert.False(string.IsNullOrWhiteSpace(result.InstalledVersion));
+    }
+
+    #endregion
+
     [Fact]
     public void CheckStatus_TimedOutInstallcheck_ReturnsDetectionErrorWithoutInstall()
     {


### PR DESCRIPTION
Most managed items reported no installed version even though the check that proved they were installed had just read one.

### The main cause

`CheckStatus` calls `CheckInstallsArray`, returns the walk's result **only when it demands action**, and on success builds a *fresh* result and returns that instead — discarding the version along with the object:

```
var installsResult = CheckInstallsArray(item);
if (installsResult.NeedsAction) return installsResult;   // carries InstalledVersion
result.Status = "installed";
return result;                                            // does not
```

So every package that verified cleanly through its installs array reported nothing, including MSI-detected ones whose version had been resolved from ARP moments earlier. That is most of the catalog.

### Two smaller gaps

- The **file** branch resolved a version solely as an input to the comparison and then dropped it — and only ran at all when the catalog gave it something to compare against.
- The **MSIX** branch recorded a version when the package was outdated but not when it was current.

### Safety

Recording is strictly an observation. It never touches `NeedsAction` and no version comparison changes, so what the fleet installs is unaffected — a file that exists still satisfies its check whatever its metadata says. This matters because `StatusCheckResult` drives install decisions, not just reporting.

Where several installs entries describe one package, the first entry to yield a version wins, so a trailing marker file or directory cannot erase it.

Directory and hash-only checks still resolve nothing, because there is nothing to read. Those stay null — now a meaningful answer rather than an omission.

### Tests

Four added to `StatusServiceTests`, using a real system binary because `FileVersionInfo` against a hand-made temp file returns nothing and would pass a broken implementation. They cover the success path carrying the version, the decision staying unchanged, a missing file still going pending with no version, and the multi-entry precedence rule. Two fail on `main` and pass here, verified by reverting the source with the tests in place.

Full suite: 1050 passed. The 4 remaining failures are pre-existing on `main` (hostname-dependent predicate cases and a config round-trip), baselined before and after.

https://claude.ai/code/session_015MM4e9AWa9K9gJoj4TqTMd