### PR TITLE
Bound preflight and postflight so a hung script cannot retire a machine

### DIFF
--- a/cli/managedsoftwareupdate/Services/ScriptService.cs
+++ b/cli/managedsoftwareupdate/Services/ScriptService.cs
@@ -21,6 +21,32 @@ public class ScriptService
 {
     public const int TimeoutExitCode = -2;
 
+    /// <summary>
+    /// How long preflight and postflight are each allowed to run before the run is
+    /// abandoned and their process tree killed.
+    /// </summary>
+    /// <remarks>
+    /// These exist because the timeout machinery below was unreachable. Every caller
+    /// passed either CancellationToken.None or a token that is only ever cancelled by
+    /// a user stop, so nothing set a deadline and TimeoutExitCode could not occur.
+    ///
+    /// The consequence is not a slow run, it is a machine that stops updating for
+    /// good. postflight runs the reports collector, which shells out to
+    /// schtasks.exe; on a host whose Task Scheduler has partly wedged that call never
+    /// returns. The session then never ends, so the single-instance mutex is never
+    /// released, so every scheduled run afterwards exits immediately with "Another
+    /// instance is running". Measured on two lab workstations: 101 and 88 minutes
+    /// hung, no new packages installed for hours, and nothing reported as failed
+    /// because from the outside the machine simply looked idle.
+    ///
+    /// Postflight gets the longer budget of the two because it does the reporting
+    /// work. Both are generous on purpose: this is a safeguard against a script that
+    /// will never finish, not a performance limit on one that is merely slow.
+    /// </remarks>
+    public static readonly TimeSpan PreflightTimeout = TimeSpan.FromMinutes(10);
+
+    public static readonly TimeSpan PostflightTimeout = TimeSpan.FromMinutes(15);
+
     // Postinstall scripts may emit a line of the form:
     //   CIMIAN-WARNING: <message>
     // on stdout or stderr. The runner extracts the message into ScriptResult.WarningMessage,
@@ -384,7 +410,42 @@ public class ScriptService
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            await process.WaitForExitAsync(cancellationToken);
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Kill the whole tree, not just the shell we started.
+                //
+                // The outer catch would already turn this into a returned failure, so
+                // the caller unblocks either way -- but the processes underneath would
+                // be left running. That matters here because the thing that hangs is
+                // never the PowerShell host itself: it is something it shelled out to,
+                // schtasks.exe against a wedged Task Scheduler being the case actually
+                // observed. Abandoning the wait without killing the tree leaves that
+                // process alive to be joined by another one on the next run.
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                        await process.WaitForExitAsync(CancellationToken.None);
+                    }
+                }
+                catch (Exception killException)
+                {
+                    errors.AppendLine($"Failed to terminate timed-out script process: {killException.Message}");
+                }
+
+                var timedOut = output.ToString();
+                if (errors.Length > 0)
+                {
+                    timedOut += Environment.NewLine + errors;
+                }
+
+                return (false, $"Script execution timed out: {scriptPath}{Environment.NewLine}{timedOut}".Trim());
+            }
 
             var combinedOutput = output.ToString();
             if (errors.Length > 0)
@@ -441,6 +502,23 @@ public class ScriptService
     }
 
     /// <summary>
+    /// A token that is cancelled either by the caller or by <paramref name="timeout"/>,
+    /// whichever comes first.
+    /// </summary>
+    /// <remarks>
+    /// Applied here rather than at the call sites so that it cannot be forgotten by
+    /// one of them. That is exactly how the original bug survived: the execution path
+    /// honoured cancellation correctly, and every caller handed it a token that was
+    /// never going to be cancelled.
+    /// </remarks>
+    private static CancellationTokenSource CreateDeadline(CancellationToken caller, TimeSpan timeout)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(caller);
+        cts.CancelAfter(timeout);
+        return cts;
+    }
+
+    /// <summary>
     /// Runs the preflight script if it exists
     /// </summary>
     public async Task<(bool Success, string Output)> RunPreflightAsync(
@@ -469,7 +547,9 @@ public class ScriptService
         }
 
         ConsoleLogger.Info($"Executing preflight script: {preflightPath}");
-        return await ExecuteScriptFileAsync(preflightPath, cancellationToken);
+
+        using var deadline = CreateDeadline(cancellationToken, PreflightTimeout);
+        return await ExecuteScriptFileAsync(preflightPath, deadline.Token);
     }
 
     /// <summary>
@@ -501,6 +581,8 @@ public class ScriptService
         }
 
         ConsoleLogger.Info($"Executing postflight script: {postflightPath}");
-        return await ExecuteScriptFileAsync(postflightPath, cancellationToken);
+
+        using var deadline = CreateDeadline(cancellationToken, PostflightTimeout);
+        return await ExecuteScriptFileAsync(postflightPath, deadline.Token);
     }
 }

--- a/tests/Managedsoftwareupdate/FlightScriptTimeoutTests.cs
+++ b/tests/Managedsoftwareupdate/FlightScriptTimeoutTests.cs
@@ -1,0 +1,93 @@
+using System.Diagnostics;
+using Xunit;
+using Cimian.CLI.managedsoftwareupdate.Services;
+
+namespace Cimian.Tests.Managedsoftwareupdate;
+
+/// <summary>
+/// Preflight and postflight must be bounded.
+/// </summary>
+/// <remarks>
+/// The regression these exist for is not a slow script, it is a machine that stops
+/// updating permanently. ScriptService always had the timeout machinery - it kills the
+/// process tree and returns TimeoutExitCode - but no caller ever supplied a deadline,
+/// so it could not fire. postflight runs the reports collector, which shells out to
+/// schtasks.exe; on a host whose Task Scheduler has partly wedged that never returns.
+/// The session then never ends, the single-instance mutex is never released, and every
+/// scheduled run afterwards exits immediately with "Another instance is running".
+///
+/// Measured on two lab workstations: 101 and 88 minutes hung, no packages installed for
+/// hours, and nothing reported as failed - from the outside the machine looked idle.
+/// </remarks>
+public class FlightScriptTimeoutTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly ScriptService _service = new();
+
+    public FlightScriptTimeoutTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "CimianTests", "FlightTimeout", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void BothFlightScriptsHaveADeadline()
+    {
+        // A deadline that is zero or absent is the bug: the machinery below it is
+        // correct and simply never runs.
+        Assert.True(ScriptService.PreflightTimeout > TimeSpan.Zero);
+        Assert.True(ScriptService.PostflightTimeout > TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void DeadlinesAreGenerousEnoughNotToCutOffRealWork()
+    {
+        // These are safeguards against a script that will never finish, not limits on
+        // one that is merely slow. postflight does the reporting work, so it gets the
+        // longer budget of the two.
+        Assert.True(ScriptService.PreflightTimeout >= TimeSpan.FromMinutes(5));
+        Assert.True(ScriptService.PostflightTimeout >= ScriptService.PreflightTimeout);
+
+        // But still bounded well under the hours that were actually observed.
+        Assert.True(ScriptService.PostflightTimeout <= TimeSpan.FromMinutes(30));
+    }
+
+    [Fact]
+    public async Task AScriptThatNeverFinishesIsAbandonedAndItsTreeKilled()
+    {
+        // Stands in for the real case: a child that never returns. The point is that
+        // the call returns at all, and that nothing is left running behind it.
+        var script = Path.Combine(_dir, "hang.ps1");
+        await File.WriteAllTextAsync(script, "Start-Sleep -Seconds 600");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var sw = Stopwatch.StartNew();
+
+        var (success, output) = await _service.ExecuteScriptFileAsync(script, cts.Token);
+
+        sw.Stop();
+
+        Assert.False(success);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(60),
+            $"the run should be abandoned at its deadline, took {sw.Elapsed}");
+        Assert.Contains("timed out", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AScriptThatFinishesNormallyIsUnaffected()
+    {
+        // The guard must not change the ordinary path.
+        var script = Path.Combine(_dir, "ok.ps1");
+        await File.WriteAllTextAsync(script, "Write-Output 'done'; exit 0");
+
+        var (success, output) = await _service.ExecuteScriptFileAsync(script, CancellationToken.None);
+
+        Assert.True(success, output);
+        Assert.Contains("done", output);
+    }
+}


### PR DESCRIPTION
`ScriptService` already had the timeout machinery — it kills the process tree and returns `TimeoutExitCode`. **Nothing could reach it.** `RunPostflightOnlyAsync` passed `CancellationToken.None`, the engine passed a token cancelled only by a user stop, and there is no `CancelAfter` anywhere in the codebase. The deadline did not exist.

## Why this matters

The cost is not a slow run, it is a machine that stops updating permanently.

`postflight` runs the reports collector, which shells out to `schtasks.exe`. On a host whose Task Scheduler has partly wedged, that call never returns. The session then never ends, so the single-instance mutex is never released, so every scheduled run afterwards exits immediately with `Another instance of managedsoftwareupdate is running`.

Observed on two lab workstations:

```
managedsoftwareupdate
 └─ powershell postflight.ps1
    └─ managedreportsrunner.exe --run-modules inventory,installs
       └─ schtasks.exe /query /tn "Cimian Managed Software Update Hourly"   <-- hung
```

Alive 101 and 88 minutes. No packages installed for hours. Nothing recorded as failed — from the outside the machine looked idle and healthy, which is what made it expensive to find.

Worth knowing for diagnosis: Task Scheduler can be only *partly* wedged. `Get-ScheduledTask` answered in under a second on both hosts (806 and 929 tasks) while `schtasks.exe` hung on the same machine — different RPC paths. A health check on the CIM provider reports healthy on an affected host.

## The change

The deadline is applied inside `RunPreflightAsync` / `RunPostflightAsync` rather than at the call sites, so it cannot be omitted by one of them — which is precisely how this survived.

`ExecuteScriptFileAsync` also handles cancellation explicitly now. Its outer `catch (Exception)` already turned the abandoned wait into a returned failure, so the caller unblocked either way, but the tree underneath was left running — and the thing that hangs is never the PowerShell host itself, it is whatever the script shelled out to.

Budgets are deliberately generous: 10 minutes preflight, 15 postflight (it does the reporting work). A safeguard against a script that will never finish, not a limit on one that is merely slow.

## Verification

28 tests pass across `ScriptService` and the new suite, 4 new — including a behavioural one that runs a script which never finishes and asserts the call returns at its deadline with the tree killed. The 5 unrelated failures in `PredicateEngine` / `ConfigurationService` / `ConsoleLogger` reproduce identically on clean `main`.