### PR TITLE
Keep the install directory on PATH exactly once

### DIFF
--- a/build/nupkg/scripts/chocolateyInstall.ps1
+++ b/build/nupkg/scripts/chocolateyInstall.ps1
@@ -172,12 +172,33 @@ try {
 
     # Add to PATH
     Write-Host "Adding Cimian to system PATH..."
+    # Kept exactly once, however many times this has run before.
+    #
+    # The old test was "-split ';' -notcontains $InstallDir", an exact string
+    # compare. It does not match the same directory written with a trailing
+    # backslash, so a build that once wrote one left an entry that no later
+    # install could see and no uninstall could remove -- a permanent duplicate
+    # that a further append could only add to. The machine PATH has a hard
+    # length limit, so this has to converge rather than grow.
     $currentPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
-    if ($currentPath -split ';' -notcontains $InstallDir) {
-        $newPath = "$InstallDir;$currentPath"
+    if ($null -eq $currentPath) { $currentPath = "" }
+    $target = $InstallDir.TrimEnd([char]92)
+    $kept = @()
+    foreach ($entry in ($currentPath -split ';')) {
+        $trimmed = $entry.Trim()
+        if ($trimmed.Length -eq 0) { continue }
+        if ($trimmed.TrimEnd([char]92) -ieq $target) { continue }
+        $kept += $trimmed
+    }
+    # Ours goes first, as it always has, and only ours is touched: other
+    # duplicates on this PATH belong to other installers.
+    $newPath = (@($target) + $kept) -join ';'
+    if ($newPath -ne $currentPath) {
         [Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
-        $env:PATH = "$InstallDir;$env:PATH"
-        Write-Host "Added to system PATH"
+        Write-Host "System PATH updated: '$target' now listed once"
+    }
+    if (($env:PATH -split ';' | Where-Object { $_.Trim().TrimEnd([char]92) -ieq $target }).Count -eq 0) {
+        $env:PATH = "$target;$env:PATH"
     }
 
     # Install and start CimianWatcher service for responsive bootstrap monitoring

--- a/build/nupkg/scripts/chocolateyUninstall.ps1
+++ b/build/nupkg/scripts/chocolateyUninstall.ps1
@@ -129,7 +129,9 @@ function Remove-FromPath {
         $currentPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
         
         if ($currentPath) {
-            $pathEntries = $currentPath -split ';' | Where-Object { $_ -ne $InstallDir -and $_ -ne "" }
+            # Trailing-slash tolerant, or an entry written as "...\Cimian\" survives
+            # the uninstall and is then invisible to every later install.
+            $pathEntries = $currentPath -split ';' | Where-Object { $_.Trim() -and ($_.Trim().TrimEnd([char]92) -ine $InstallDir.TrimEnd([char]92)) }
             $newPath = $pathEntries -join ';'
             
             if ($newPath -ne $currentPath) {

--- a/build/pkg/postinstall.ps1
+++ b/build/pkg/postinstall.ps1
@@ -33,12 +33,33 @@ try {
 
     # Add to system PATH (idempotent)
     Write-Host "Adding Cimian to system PATH..."
+    # Kept exactly once, however many times this has run before.
+    #
+    # The old test was "-split ';' -notcontains $InstallDir", an exact string
+    # compare. It does not match the same directory written with a trailing
+    # backslash, so a build that once wrote one left an entry that no later
+    # install could see and no uninstall could remove -- a permanent duplicate
+    # that a further append could only add to. The machine PATH has a hard
+    # length limit, so this has to converge rather than grow.
     $currentPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
-    if ($currentPath -split ';' -notcontains $InstallDir) {
-        $newPath = "$InstallDir;$currentPath"
+    if ($null -eq $currentPath) { $currentPath = "" }
+    $target = $InstallDir.TrimEnd([char]92)
+    $kept = @()
+    foreach ($entry in ($currentPath -split ';')) {
+        $trimmed = $entry.Trim()
+        if ($trimmed.Length -eq 0) { continue }
+        if ($trimmed.TrimEnd([char]92) -ieq $target) { continue }
+        $kept += $trimmed
+    }
+    # Ours goes first, as it always has, and only ours is touched: other
+    # duplicates on this PATH belong to other installers.
+    $newPath = (@($target) + $kept) -join ';'
+    if ($newPath -ne $currentPath) {
         [Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
-        $env:PATH = "$InstallDir;$env:PATH"
-        Write-Host "Added to system PATH"
+        Write-Host "System PATH updated: '$target' now listed once"
+    }
+    if (($env:PATH -split ';' | Where-Object { $_.Trim().TrimEnd([char]92) -ieq $target }).Count -eq 0) {
+        $env:PATH = "$target;$env:PATH"
     }
 
     # Install or restart CimianWatcher service. Idempotent across all phases:

--- a/build/pkg/uninstall.ps1
+++ b/build/pkg/uninstall.ps1
@@ -74,7 +74,9 @@ try {
 try {
     $currentPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
     if ($currentPath) {
-        $entries = $currentPath -split ';' | Where-Object { $_ -and ($_ -ne $InstallDir) }
+        # Trailing-slash tolerant, or an entry written as "...\Cimian\" survives
+        # the uninstall and is then invisible to every later install.
+        $entries = $currentPath -split ';' | Where-Object { $_.Trim() -and ($_.Trim().TrimEnd([char]92) -ine $InstallDir.TrimEnd([char]92)) }
         $newPath = ($entries -join ';')
         if ($newPath -ne $currentPath) {
             [Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)


### PR DESCRIPTION
Install tested PATH membership with an exact string compare (`-notcontains $InstallDir`) and uninstall removed with `-ne $InstallDir`. Neither matches the same directory written with a trailing backslash, so an entry written that way is invisible to every later install and survives uninstall — and the next install appends beside it. The machine PATH has a hard length limit, so this needs to converge rather than grow.

Install now rebuilds the list, dropping every spelling of the install directory and putting one canonical copy at the front. Uninstall removes every spelling. Both compare case-insensitively and ignore a trailing backslash, and only the install directory is touched.

Applied to all four scripts that write PATH so the pkg and nupkg paths cannot drift: `build/pkg/postinstall.ps1`, `build/pkg/uninstall.ps1`, `build/nupkg/scripts/chocolateyInstall.ps1`, `build/nupkg/scripts/chocolateyUninstall.ps1`.

Verified against a PATH holding the plain, trailing-backslash and differently-cased spellings at once: install collapses all three to one at the front, a second run is a no-op, uninstall removes all three, and no other entry is reordered or lost.

Risk: medium — management-client installer scripts; contained to one repo, revertible by a revert PR, and merging deploys nothing on its own. Delivery to Testing is a separate submodule bump and pipeline run.
