### PR TITLE
Bound the two scheduler calls that could hang indefinitely

### DIFF
--- a/build/msi/install-tasks.ps1
+++ b/build/msi/install-tasks.ps1
@@ -34,14 +34,47 @@ try {
 
 try {
     # First, remove any existing Cimian tasks to prevent duplicates
+    #
+    # Bounded, because this runs inside the MSI. Get-ScheduledTask talks to the
+    # Task Scheduler service, and on a machine whose scheduler has degraded it
+    # never returns. Unbounded here that stalls the install itself rather than
+    # just the cleanup, and an install that never finishes leaves the payload
+    # half replaced.
+    #
+    # Giving up is the right answer: a duplicate task is cosmetic, and
+    # Register-ScheduledTask below replaces one of the same name anyway.
     Write-Host "Removing any existing Cimian tasks..."
-    Get-ScheduledTask | Where-Object {
-        $_.TaskName -like "*Cimian*" -or
-        $_.Description -like "*Cimian*" -or
-        $_.TaskName -like "*Automatic Software Update*"
-    } | ForEach-Object {
-        Write-Host "  Removing existing task: $($_.TaskName)"
-        Unregister-ScheduledTask -TaskName $_.TaskName -Confirm:$false -ErrorAction SilentlyContinue
+
+    $existingJob = Start-Job -ScriptBlock {
+        Get-ScheduledTask -ErrorAction SilentlyContinue | Where-Object {
+            $_.TaskName -like "*Cimian*" -or
+            $_.Description -like "*Cimian*" -or
+            $_.TaskName -like "*Automatic Software Update*"
+        } | Select-Object -ExpandProperty TaskName
+    }
+
+    $existingTasks = @()
+    if (Wait-Job -Job $existingJob -Timeout 20) {
+        $existingTasks = @(Receive-Job -Job $existingJob -ErrorAction SilentlyContinue)
+    }
+    else {
+        Write-Host "  Task Scheduler did not answer within 20s; skipping duplicate cleanup and continuing."
+        Stop-Job -Job $existingJob -ErrorAction SilentlyContinue
+    }
+    Remove-Job -Job $existingJob -Force -ErrorAction SilentlyContinue
+
+    foreach ($taskName in $existingTasks) {
+        if (-not $taskName) { continue }
+
+        Write-Host "  Removing existing task: $taskName"
+        $removeJob = Start-Job -ScriptBlock {
+            Unregister-ScheduledTask -TaskName $using:taskName -Confirm:$false -ErrorAction SilentlyContinue
+        }
+        if (-not (Wait-Job -Job $removeJob -Timeout 20)) {
+            Write-Host "    Task Scheduler did not answer within 20s removing '$taskName'; continuing."
+            Stop-Job -Job $removeJob -ErrorAction SilentlyContinue
+        }
+        Remove-Job -Job $removeJob -Force -ErrorAction SilentlyContinue
     }
 
     $managedSoftwareUpdateExe = Join-Path $InstallPath "managedsoftwareupdate.exe"

--- a/gui/CimianStatus/Services/UpdateService.cs
+++ b/gui/CimianStatus/Services/UpdateService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Cimian.Status.Models;
@@ -615,6 +616,10 @@ namespace Cimian.Status.Services
         /// <summary>
         /// Helper method to run command-line tools asynchronously
         /// </summary>
+        // Nothing this class shells out to is long-running; a schtasks call that has
+        // not answered in 30s is not going to.
+        private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(30);
+
         private async Task<(int ExitCode, string Output)> RunCommandAsync(string fileName, string arguments)
         {
             using var process = new Process
@@ -631,12 +636,34 @@ namespace Cimian.Status.Services
             };
 
             process.Start();
-            
-            var output = await process.StandardOutput.ReadToEndAsync();
-            var error = await process.StandardError.ReadToEndAsync();
-            
-            await process.WaitForExitAsync();
-            
+
+            // Start both reads before waiting, and never await them first.
+            //
+            // ReadToEndAsync completes when the pipe closes, and the pipe closes
+            // when the child exits, so awaiting it up front leaves everything below
+            // unreachable for a child that does not exit. Every caller of this method
+            // runs schtasks.exe, which talks to the Task Scheduler service; on a
+            // machine whose scheduler has degraded that never returns, and neither
+            // did this. There was no timeout here at all to save it.
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+
+            using var cts = new CancellationTokenSource(CommandTimeout);
+
+            try
+            {
+                await process.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                _logger.LogWarning("{FileName} did not return within {Seconds:N0}s; abandoning it", fileName, CommandTimeout.TotalSeconds);
+                return (-1, string.Empty);
+            }
+
+            var output = await stdout;
+            var error = await stderr;
+
             var fullOutput = string.IsNullOrEmpty(error) ? output : $"{output}\n{error}";
             return (process.ExitCode, fullOutput);
         }


### PR DESCRIPTION
Two places called into the Task Scheduler service with no way out. That service degrades once a machine accumulates enough tasks, and when it does these calls never return.

**`CimianStatus` `RunCommandAsync`** had no timeout at all, and the shape below it made one impossible anyway:

```csharp
var output = await process.StandardOutput.ReadToEndAsync();
await process.WaitForExitAsync();
```

`ReadToEndAsync` completes when the pipe closes, and the pipe closes when the child exits — so awaiting it up front parks there forever for a child that does not exit. All three callers pass `schtasks.exe`. Both reads now start before the wait, the wait carries a 30s deadline, the process tree is killed on timeout, and the caller gets `-1`.

**`build/msi/install-tasks.ps1`** enumerated every task on the machine to find duplicates to remove. Unbounded inside an MSI, that stalls the install itself rather than just the cleanup — and an install that does not finish leaves the payload half replaced. The enumeration and each removal now run in a job with a 20s deadline, and the script continues past an abandoned one. Giving up is safe: a duplicate task is cosmetic, and `Register-ScheduledTask` further down replaces one of the same name regardless.

Found while sweeping the management tools for this defect class. The signature to watch for is a timeout placed *after* an awaited stream read — it reads as present while being unreachable.

`install-tasks.ps1` parses clean; `CimianStatus` builds with 0 errors.