### PR TITLE
Only warn about a nopkg item with no scripts at all

### DIFF
--- a/cli/managedsoftwareupdate/Services/InstallerService.cs
+++ b/cli/managedsoftwareupdate/Services/InstallerService.cs
@@ -1489,7 +1489,13 @@ try {{
     {
         if (string.IsNullOrWhiteSpace(item.InstallScript))
         {
-            ConsoleLogger.Warn($"nopkg item '{item.Name}' has no install_script defined");
+            // A nopkg item is allowed to do all of its work in preinstall_script or
+            // postinstall_script, which run around this call, so a missing
+            // install_script is only worth a warning when the item has no script
+            // at all. Warning otherwise put a false WARN in every session that
+            // installed such an item, burying the warnings that matter.
+            if (string.IsNullOrWhiteSpace(item.PreinstallScript) && string.IsNullOrWhiteSpace(item.PostinstallScript))
+                ConsoleLogger.Warn($"nopkg item '{item.Name}' has no install_script, preinstall_script or postinstall_script defined");
             return (true, "No install_script defined; nothing to run");
         }
 


### PR DESCRIPTION
A `nopkg` item may do all of its work in `preinstall_script` or `postinstall_script`, which the installer runs around the `install_script` call. `InstallScriptOnlyAsync` warned whenever `install_script` was empty, so every session that installed such an item logged

```
WARN  nopkg item '<name>' has no install_script defined
```

immediately followed by that item's postinstall script running successfully. The false warnings bury the ones that matter.

The warning now fires only when the item has no `install_script`, `preinstall_script` or `postinstall_script` — the case where a nopkg item genuinely does nothing.

## Verified
Tests: 1053 pass. Of the 5 failures, 4 (`ConfigurationServiceTests.SaveConfig_RoundTrip_PreservesValues` and three `PredicateEngineTests` hostname cases) fail identically on a clean `main`; the fifth, `ConsoleLoggerTests.RedirectedOutputReplacesBoxDrawingWithAscii`, passes when run on its own, so it is order-dependent rather than affected by this change.